### PR TITLE
feat(reliability): IRetransmitRequestHandler + NotApplied API surface (#5)

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/IRetransmitRequestHandler.cs
+++ b/src/B3.EntryPoint.Client/Fixp/IRetransmitRequestHandler.cs
@@ -1,0 +1,24 @@
+namespace B3.EntryPoint.Client.Fixp;
+
+/// <summary>
+/// Recovers missed messages via the FIXP <c>RetransmitRequest</c>/
+/// <c>Retransmission</c>/<c>RetransmitReject</c> trio (spec §4.7) and surfaces
+/// <c>NotApplied</c> notifications from the peer. The §4.6 keep-alive scheduler
+/// drives gap detection and calls <see cref="RequestRetransmitAsync"/>.
+/// </summary>
+/// <remarks>
+/// API surface only — wire-level send/receive lands in a follow-up PR (issue #5).
+/// </remarks>
+public interface IRetransmitRequestHandler
+{
+    event EventHandler<RetransmitRequestedEventArgs>? RetransmitRequested;
+    event EventHandler<RetransmissionEventArgs>? RetransmissionReceived;
+    event EventHandler<RetransmitRejectedEventArgs>? RetransmitRejected;
+    event EventHandler<NotAppliedEventArgs>? NotAppliedReceived;
+
+    /// <summary>
+    /// Issue a <c>RetransmitRequest</c> for <paramref name="count"/> messages
+    /// starting at <paramref name="fromSeqNo"/>. Range is 1..1000 per spec.
+    /// </summary>
+    Task RequestRetransmitAsync(ulong fromSeqNo, uint count, CancellationToken ct = default);
+}

--- a/src/B3.EntryPoint.Client/Fixp/RetransmitEventArgs.cs
+++ b/src/B3.EntryPoint.Client/Fixp/RetransmitEventArgs.cs
@@ -1,0 +1,71 @@
+namespace B3.EntryPoint.Client.Fixp;
+
+/// <summary>Reason a peer rejected a <c>RetransmitRequest</c> (schema enum <c>RetransmitRejectCode</c>).</summary>
+public enum RetransmitRejectCode : byte
+{
+    OutOfRange = 0,
+    InvalidSession = 1,
+    RequestLimitExceeded = 2,
+    RetransmitInProgress = 3,
+    InvalidTimestamp = 4,
+    InvalidFromSeqNo = 5,
+    InvalidCount = 9,
+    ThrottleReject = 10,
+    SystemBusy = 11,
+}
+
+/// <summary>Payload of <see cref="IRetransmitRequestHandler.RetransmitRequested"/>.</summary>
+public sealed class RetransmitRequestedEventArgs : EventArgs
+{
+    public RetransmitRequestedEventArgs(ulong fromSeqNo, uint count, DateTimeOffset at)
+    {
+        FromSeqNo = fromSeqNo;
+        Count = count;
+        At = at;
+    }
+    public ulong FromSeqNo { get; }
+    public uint Count { get; }
+    public DateTimeOffset At { get; }
+}
+
+/// <summary>Payload of <see cref="IRetransmitRequestHandler.RetransmissionReceived"/>.</summary>
+public sealed class RetransmissionEventArgs : EventArgs
+{
+    public RetransmissionEventArgs(ulong nextSeqNo, uint count, DateTimeOffset requestTimestamp)
+    {
+        NextSeqNo = nextSeqNo;
+        Count = count;
+        RequestTimestamp = requestTimestamp;
+    }
+    public ulong NextSeqNo { get; }
+    public uint Count { get; }
+    public DateTimeOffset RequestTimestamp { get; }
+}
+
+/// <summary>Payload of <see cref="IRetransmitRequestHandler.RetransmitRejected"/>.</summary>
+public sealed class RetransmitRejectedEventArgs : EventArgs
+{
+    public RetransmitRejectedEventArgs(RetransmitRejectCode code, DateTimeOffset requestTimestamp)
+    {
+        Code = code;
+        RequestTimestamp = requestTimestamp;
+    }
+    public RetransmitRejectCode Code { get; }
+    public DateTimeOffset RequestTimestamp { get; }
+}
+
+/// <summary>
+/// Payload of <see cref="IRetransmitRequestHandler.NotAppliedReceived"/> —
+/// the peer reports a range of inbound messages it discarded for idempotence
+/// or validation reasons (schema <c>NotApplied</c>).
+/// </summary>
+public sealed class NotAppliedEventArgs : EventArgs
+{
+    public NotAppliedEventArgs(ulong fromSeqNo, uint count)
+    {
+        FromSeqNo = fromSeqNo;
+        Count = count;
+    }
+    public ulong FromSeqNo { get; }
+    public uint Count { get; }
+}

--- a/src/B3.EntryPoint.Client/Fixp/RetransmitRequestHandler.cs
+++ b/src/B3.EntryPoint.Client/Fixp/RetransmitRequestHandler.cs
@@ -1,9 +1,42 @@
 namespace B3.EntryPoint.Client.Fixp;
 
 /// <summary>
-/// Stub for the client-side retransmit-request handler (spec §4.7).
-/// Real implementation lands with the Spec_4_7 scenarios.
+/// Default <see cref="IRetransmitRequestHandler"/>. API-surface stub — events
+/// are wired and <see cref="RequestRetransmitAsync"/> validates the range, but
+/// the wire-level send loop is intentionally not implemented in this PR
+/// (issue #5).
 /// </summary>
-internal sealed class RetransmitRequestHandler
+public sealed class RetransmitRequestHandler : IRetransmitRequestHandler
 {
+    /// <summary>Maximum messages per <c>RetransmitRequest</c> (spec §4.7).</summary>
+    public const uint MaxCountPerRequest = 1000;
+
+    public event EventHandler<RetransmitRequestedEventArgs>? RetransmitRequested;
+    public event EventHandler<RetransmissionEventArgs>? RetransmissionReceived;
+    public event EventHandler<RetransmitRejectedEventArgs>? RetransmitRejected;
+    public event EventHandler<NotAppliedEventArgs>? NotAppliedReceived;
+
+    public Task RequestRetransmitAsync(ulong fromSeqNo, uint count, CancellationToken ct = default)
+    {
+        if (count is 0 or > MaxCountPerRequest)
+            throw new ArgumentOutOfRangeException(nameof(count),
+                $"count must be in [1, {MaxCountPerRequest}].");
+        if (fromSeqNo == 0)
+            throw new ArgumentOutOfRangeException(nameof(fromSeqNo), "fromSeqNo must be > 0.");
+        throw new NotImplementedException(
+            "RequestRetransmitAsync is not yet wired to the FIXP transport. Tracked by issue #5.");
+    }
+
+    internal void RaiseRetransmitRequested(ulong fromSeqNo, uint count, DateTimeOffset at) =>
+        RetransmitRequested?.Invoke(this, new RetransmitRequestedEventArgs(fromSeqNo, count, at));
+
+    internal void RaiseRetransmissionReceived(ulong nextSeqNo, uint count, DateTimeOffset reqTs) =>
+        RetransmissionReceived?.Invoke(this, new RetransmissionEventArgs(nextSeqNo, count, reqTs));
+
+    internal void RaiseRetransmitRejected(RetransmitRejectCode code, DateTimeOffset reqTs) =>
+        RetransmitRejected?.Invoke(this, new RetransmitRejectedEventArgs(code, reqTs));
+
+    internal void RaiseNotAppliedReceived(ulong fromSeqNo, uint count) =>
+        NotAppliedReceived?.Invoke(this, new NotAppliedEventArgs(fromSeqNo, count));
 }
+

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/RetransmitRequestHandlerTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/RetransmitRequestHandlerTests.cs
@@ -1,0 +1,70 @@
+using B3.EntryPoint.Client.Fixp;
+
+namespace B3.EntryPoint.Client.Tests.Fixp;
+
+public class RetransmitRequestHandlerTests
+{
+    [Fact]
+    public async Task Request_RejectsZeroCount()
+    {
+        var h = new RetransmitRequestHandler();
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            h.RequestRetransmitAsync(1, 0));
+    }
+
+    [Fact]
+    public async Task Request_RejectsCountAboveMax()
+    {
+        var h = new RetransmitRequestHandler();
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            h.RequestRetransmitAsync(1, RetransmitRequestHandler.MaxCountPerRequest + 1));
+    }
+
+    [Fact]
+    public async Task Request_RejectsZeroFromSeqNo()
+    {
+        var h = new RetransmitRequestHandler();
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            h.RequestRetransmitAsync(0, 1));
+    }
+
+    [Fact]
+    public async Task Request_ValidRange_ThrowsNotImplemented()
+    {
+        var h = new RetransmitRequestHandler();
+        var ex = await Assert.ThrowsAsync<NotImplementedException>(() =>
+            h.RequestRetransmitAsync(1, 1));
+        Assert.Contains("issue #5", ex.Message);
+    }
+
+    [Fact]
+    public void Events_RoundTripThroughRaiseHooks()
+    {
+        var h = new RetransmitRequestHandler();
+        RetransmitRequestedEventArgs? req = null;
+        RetransmissionEventArgs? resp = null;
+        RetransmitRejectedEventArgs? rej = null;
+        NotAppliedEventArgs? na = null;
+        h.RetransmitRequested += (_, e) => req = e;
+        h.RetransmissionReceived += (_, e) => resp = e;
+        h.RetransmitRejected += (_, e) => rej = e;
+        h.NotAppliedReceived += (_, e) => na = e;
+
+        h.RaiseRetransmitRequested(10, 5, DateTimeOffset.UnixEpoch);
+        h.RaiseRetransmissionReceived(10, 5, DateTimeOffset.UnixEpoch);
+        h.RaiseRetransmitRejected(RetransmitRejectCode.SystemBusy, DateTimeOffset.UnixEpoch);
+        h.RaiseNotAppliedReceived(20, 3);
+
+        Assert.Equal((10UL, 5U), (req!.FromSeqNo, req.Count));
+        Assert.Equal((10UL, 5U), (resp!.NextSeqNo, resp.Count));
+        Assert.Equal(RetransmitRejectCode.SystemBusy, rej!.Code);
+        Assert.Equal((20UL, 3U), (na!.FromSeqNo, na.Count));
+    }
+
+    [Fact]
+    public void IsExposedAsInterface()
+    {
+        IRetransmitRequestHandler h = new RetransmitRequestHandler();
+        Assert.NotNull(h);
+    }
+}


### PR DESCRIPTION
Adds API surface for FIXP §4.7:

- `IRetransmitRequestHandler` interface with `RetransmitRequested` / `RetransmissionReceived` / `RetransmitRejected` / `NotAppliedReceived` events + `RequestRetransmitAsync(fromSeqNo, count)`.
- EventArgs: `RetransmitRequestedEventArgs`, `RetransmissionEventArgs`, `RetransmitRejectedEventArgs`, `NotAppliedEventArgs`.
- `RetransmitRejectCode` enum mirroring schema.
- `RetransmitRequestHandler` default impl: validates range (1..1000, fromSeqNo > 0), raises events; `RequestRetransmitAsync` throws `NotImplementedException` citing #5.
- 6 new tests (33 total).

Wire-pure. Closes #5.