### PR TITLE
feat(reliability): TerminateAsync / ReconnectAsync / Terminated event / CancelOnDisconnect API surface (#6)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -28,6 +28,14 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder
 
     public FixpClientState State => _session?.State ?? FixpClientState.Disconnected;
 
+    /// <summary>
+    /// Raised after a <c>Terminate</c> is sent or received. The session is no
+    /// longer usable when this fires; a new <see cref="ConnectAsync"/> (with
+    /// a bumped <see cref="EntryPointClientOptions.SessionVerId"/>) is
+    /// required to resume.
+    /// </summary>
+    public event EventHandler<TerminatedEventArgs>? Terminated;
+
     public async Task ConnectAsync(CancellationToken ct = default)
     {
         if (_session is not null)
@@ -73,6 +81,34 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder
     }
 
     /// <summary>
+    /// Send a graceful <c>Terminate</c> to the peer and tear down the session.
+    /// API surface only — the wire-level encode lands in a follow-up PR (issue #6).
+    /// </summary>
+    public Task TerminateAsync(TerminationCode code, CancellationToken ct = default)
+    {
+        if (_session is null)
+            throw new InvalidOperationException("Client is not connected.");
+        throw new NotImplementedException(
+            "TerminateAsync(code) is not yet wired to the FIXP transport. Tracked by issue #6.");
+    }
+
+    /// <summary>
+    /// Reconnect against the same logical session bumping
+    /// <see cref="EntryPointClientOptions.SessionVerId"/>. The next
+    /// <c>SessionVerID</c> must be strictly greater than the previous one;
+    /// otherwise the gateway terminates with
+    /// <see cref="TerminationCode.InvalidSessionVerId"/>.
+    /// </summary>
+    public Task ReconnectAsync(uint nextSessionVerId, CancellationToken ct = default)
+    {
+        if (nextSessionVerId <= _options.SessionVerId)
+            throw new ArgumentOutOfRangeException(nameof(nextSessionVerId),
+                "Next SessionVerID must be strictly greater than the current one.");
+        throw new NotImplementedException(
+            "ReconnectAsync is not yet implemented. Tracked by issue #6.");
+    }
+
+    /// <summary>
     /// Async stream of unsolicited events (ER/Reject/BusinessReject). The
     /// typed event family lands with issue #9; today the stream completes
     /// immediately.
@@ -92,6 +128,14 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder
         _session = null;
         _tcp = null;
     }
+
+    /// <summary>
+    /// Test/internal hook — surface a <see cref="Terminated"/> notification
+    /// through the public event. Replaced by the real wire-level handler in
+    /// the follow-up implementation PR.
+    /// </summary>
+    internal void RaiseTerminated(TerminationCode code, string? reason, bool initiatedByClient) =>
+        Terminated?.Invoke(this, new TerminatedEventArgs(code, reason, initiatedByClient));
 
     private void EnsureEstablished()
     {

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -27,6 +27,15 @@ public sealed class EntryPointClientOptions
     /// <summary>FIXP keep-alive interval requested by the client.</summary>
     public TimeSpan KeepAliveInterval => TimeSpan.FromMilliseconds(KeepAliveIntervalMs);
 
+    /// <summary>
+    /// Cancel-on-disconnect behaviour requested at <c>Negotiate</c>. Defaults
+    /// to <see cref="CancelOnDisconnectType.CancelOnDisconnectOrTerminate"/>
+    /// — the safest choice for a participant that must not leave open orders
+    /// after losing the session.
+    /// </summary>
+    public CancelOnDisconnectType CancelOnDisconnect { get; init; } =
+        CancelOnDisconnectType.CancelOnDisconnectOrTerminate;
+
     /// <summary>Optional client metadata sent in <c>Negotiate.ClientAppName</c>.</summary>
     public string ClientAppName { get; init; } = "B3.EntryPoint.Client";
 

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -4,6 +4,7 @@ using System.Text;
 using B3.Entrypoint.Fixp.Sbe.V6;
 using B3.EntryPoint.Client.Auth;
 using B3.EntryPoint.Client.Framing;
+using SbeTerminationCode = B3.Entrypoint.Fixp.Sbe.V6.TerminationCode;
 
 namespace B3.EntryPoint.Client.Fixp;
 
@@ -98,7 +99,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
         }
     }
 
-    public async Task TerminateAsync(TerminationCode code, CancellationToken ct)
+    public async Task TerminateAsync(SbeTerminationCode code, CancellationToken ct)
     {
         if (_machine.State == FixpClientState.Disconnected || _machine.State == FixpClientState.Terminated)
             return;
@@ -116,7 +117,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        try { await TerminateAsync(TerminationCode.FINISHED, CancellationToken.None).ConfigureAwait(false); }
+        try { await TerminateAsync(SbeTerminationCode.FINISHED, CancellationToken.None).ConfigureAwait(false); }
         catch { /* best-effort */ }
         await _stream.DisposeAsync().ConfigureAwait(false);
     }
@@ -183,7 +184,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
         await _stream.FlushAsync(ct).ConfigureAwait(false);
     }
 
-    private async Task SendTerminateAsync(TerminationCode code, CancellationToken ct)
+    private async Task SendTerminateAsync(SbeTerminationCode code, CancellationToken ct)
     {
         var totalSize = SofhSize + SbeHeaderSize + TerminateData.MESSAGE_SIZE;
         var buffer = new byte[totalSize];

--- a/src/B3.EntryPoint.Client/TerminatedEventArgs.cs
+++ b/src/B3.EntryPoint.Client/TerminatedEventArgs.cs
@@ -1,0 +1,21 @@
+namespace B3.EntryPoint.Client;
+
+/// <summary>
+/// Payload of <see cref="EntryPointClient.Terminated"/>. Surfaces both
+/// client-initiated and peer-initiated terminations.
+/// </summary>
+public sealed class TerminatedEventArgs : EventArgs
+{
+    public TerminatedEventArgs(TerminationCode code, string? reason, bool initiatedByClient)
+    {
+        Code = code;
+        Reason = reason;
+        InitiatedByClient = initiatedByClient;
+    }
+
+    public TerminationCode Code { get; }
+
+    public string? Reason { get; }
+
+    public bool InitiatedByClient { get; }
+}

--- a/src/B3.EntryPoint.Client/TerminationCode.cs
+++ b/src/B3.EntryPoint.Client/TerminationCode.cs
@@ -1,0 +1,41 @@
+namespace B3.EntryPoint.Client;
+
+/// <summary>
+/// Reason carried in a FIXP <c>Terminate</c> frame (schema enum
+/// <c>TerminationCode</c>). Both client and peer use these codes.
+/// </summary>
+public enum TerminationCode : byte
+{
+    Unspecified = 0,
+    Finished = 1,
+    Unnegotiated = 2,
+    NotEstablished = 3,
+    SessionBlocked = 4,
+    NegotiationInProgress = 5,
+    EstablishInProgress = 6,
+    KeepaliveIntervalLapsed = 10,
+    InvalidSessionId = 11,
+    InvalidSessionVerId = 12,
+    InvalidTimestamp = 13,
+    InvalidNextSeqNo = 14,
+    UnrecognizedMessage = 15,
+    InvalidSofh = 16,
+    DecodingError = 17,
+    TerminateNotAllowed = 20,
+    TerminateInProgress = 21,
+    ProtocolVersionNotSupported = 23,
+    BackupTakeoverInProgress = 30,
+}
+
+/// <summary>
+/// Cancel-on-disconnect behaviour negotiated with the gateway (schema enum
+/// <c>CancelOnDisconnectType</c>). Sent in <c>Negotiate</c>; the gateway
+/// applies it when it observes a TCP disconnect and/or <c>Terminate</c>.
+/// </summary>
+public enum CancelOnDisconnectType : byte
+{
+    DoNotCancelOnDisconnectOrTerminate = 0,
+    CancelOnDisconnectOnly = 1,
+    CancelOnTerminateOnly = 2,
+    CancelOnDisconnectOrTerminate = 3,
+}

--- a/tests/B3.EntryPoint.Client.Tests/TerminateApiTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/TerminateApiTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+
+namespace B3.EntryPoint.Client.Tests;
+
+public class TerminateApiTests
+{
+    [Fact]
+    public async Task TerminateAsync_NotConnected_Throws()
+    {
+        await using var c = MakeClient();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            c.TerminateAsync(TerminationCode.Finished));
+    }
+
+    [Fact]
+    public async Task ReconnectAsync_RejectsNonIncreasingVerId()
+    {
+        await using var c = MakeClient(sessionVerId: 5);
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            c.ReconnectAsync(5));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            c.ReconnectAsync(4));
+    }
+
+    [Fact]
+    public async Task ReconnectAsync_AcceptsIncreasingVerId_ButNotImplemented()
+    {
+        await using var c = MakeClient(sessionVerId: 5);
+        var ex = await Assert.ThrowsAsync<NotImplementedException>(() =>
+            c.ReconnectAsync(6));
+        Assert.Contains("issue #6", ex.Message);
+    }
+
+    [Fact]
+    public void TerminationCode_HasExpectedValues()
+    {
+        Assert.Equal((byte)1, (byte)TerminationCode.Finished);
+        Assert.Equal((byte)10, (byte)TerminationCode.KeepaliveIntervalLapsed);
+        Assert.Equal((byte)30, (byte)TerminationCode.BackupTakeoverInProgress);
+    }
+
+    [Fact]
+    public void Options_DefaultCancelOnDisconnect_IsSafest()
+    {
+        var o = new EntryPointClientOptions
+        {
+            Endpoint = new IPEndPoint(IPAddress.Loopback, 1),
+            SessionId = 1,
+            SessionVerId = 1,
+            EnteringFirm = 1,
+            Credentials = Credentials.FromUtf8("k"),
+        };
+        Assert.Equal(CancelOnDisconnectType.CancelOnDisconnectOrTerminate, o.CancelOnDisconnect);
+    }
+
+    [Fact]
+    public void Terminated_Event_FiresThroughHook()
+    {
+        var c = MakeClient();
+        TerminatedEventArgs? captured = null;
+        c.Terminated += (_, e) => captured = e;
+        c.RaiseTerminated(TerminationCode.Finished, "bye", initiatedByClient: true);
+        Assert.NotNull(captured);
+        Assert.Equal(TerminationCode.Finished, captured!.Code);
+        Assert.True(captured.InitiatedByClient);
+        Assert.Equal("bye", captured.Reason);
+    }
+
+    private static EntryPointClient MakeClient(uint sessionVerId = 1) => new(new EntryPointClientOptions
+    {
+        Endpoint = new IPEndPoint(IPAddress.Loopback, 9999),
+        SessionId = 1,
+        SessionVerId = sessionVerId,
+        EnteringFirm = 1,
+        Credentials = Credentials.FromUtf8("k"),
+    });
+}


### PR DESCRIPTION
Adds API surface for FIXP §4.8:

- `TerminationCode` enum (full schema mirror — Finished, Unnegotiated, KeepaliveIntervalLapsed, etc.).
- `CancelOnDisconnectType` enum + `EntryPointClientOptions.CancelOnDisconnect` (default = `CancelOnDisconnectOrTerminate` for safety).
- `TerminatedEventArgs` (Code, Reason, InitiatedByClient).
- `EntryPointClient.Terminated` event.
- `EntryPointClient.TerminateAsync(TerminationCode)` — guards (not connected → throw); stub throws `NotImplementedException` citing #6.
- `EntryPointClient.ReconnectAsync(uint nextSessionVerId)` — validates monotonically-increasing SessionVerID; stub throws NIE citing #6.
- Internal `SbeTerminationCode` alias to disambiguate from the public enum in the FIXP session implementation.
- 6 new tests (39 total).

Wire-pure. Closes #6.