### PR TITLE
feat(order-entry): IReplaceOrder API surface (#7)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -14,7 +14,7 @@ namespace B3.EntryPoint.Client;
 /// public API surface; their wire-level implementations land incrementally
 /// (see <c>docs/CONFORMANCE.md</c> and the issues tagged <c>area/api-surface</c>).
 /// </summary>
-public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder
+public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceOrder
 {
     private readonly EntryPointClientOptions _options;
     private TcpClient? _tcp;
@@ -78,6 +78,24 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder
         EnsureEstablished();
         throw new NotImplementedException(
             "SubmitSimpleAsync is not yet wired to the FIXP transport. Tracked by issue #4.");
+    }
+
+    /// <inheritdoc />
+    public Task<ClOrdID> ReplaceAsync(ReplaceOrderRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureEstablished();
+        throw new NotImplementedException(
+            "ReplaceAsync is not yet wired to the FIXP transport. Tracked by issue #7.");
+    }
+
+    /// <inheritdoc />
+    public Task<ClOrdID> ReplaceSimpleAsync(SimpleModifyRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureEstablished();
+        throw new NotImplementedException(
+            "ReplaceSimpleAsync is not yet wired to the FIXP transport. Tracked by issue #7.");
     }
 
     /// <summary>

--- a/src/B3.EntryPoint.Client/IReplaceOrder.cs
+++ b/src/B3.EntryPoint.Client/IReplaceOrder.cs
@@ -1,0 +1,20 @@
+using B3.EntryPoint.Client.Models;
+using ClOrdID = B3.EntryPoint.Client.Models.ClOrdID;
+
+namespace B3.EntryPoint.Client;
+
+/// <summary>
+/// Replace previously submitted orders. Implemented by
+/// <see cref="EntryPointClient"/>.
+/// </summary>
+/// <remarks>
+/// API surface only — the SBE encoding lands in a follow-up PR (issue #7).
+/// </remarks>
+public interface IReplaceOrder
+{
+    /// <summary>Submit an <c>OrderCancelReplaceRequest</c>.</summary>
+    Task<ClOrdID> ReplaceAsync(ReplaceOrderRequest request, CancellationToken ct = default);
+
+    /// <summary>Submit a <c>SimpleModifyOrder</c>.</summary>
+    Task<ClOrdID> ReplaceSimpleAsync(SimpleModifyRequest request, CancellationToken ct = default);
+}

--- a/src/B3.EntryPoint.Client/Models/ReplaceOrderRequest.cs
+++ b/src/B3.EntryPoint.Client/Models/ReplaceOrderRequest.cs
@@ -1,0 +1,41 @@
+namespace B3.EntryPoint.Client.Models;
+
+/// <summary>
+/// Logical request shape for <c>OrderCancelReplaceRequest</c> (schema §6).
+/// Carries the new ClOrdID assigned to the replacement plus the original
+/// ClOrdID being modified.
+/// </summary>
+public sealed record ReplaceOrderRequest
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required ClOrdID OrigClOrdID { get; init; }
+    public required ulong SecurityId { get; init; }
+    public required Side Side { get; init; }
+    public required OrderType OrderType { get; init; }
+    public decimal? Price { get; init; }
+    public decimal? StopPrice { get; init; }
+    public required ulong OrderQty { get; init; }
+    public TimeInForce TimeInForce { get; init; } = TimeInForce.Day;
+    public AccountType AccountType { get; init; } = AccountType.RegularAccount;
+    public ulong? Account { get; init; }
+    public DateTimeOffset? ExpireDate { get; init; }
+    public ulong? MinQty { get; init; }
+    public ulong? MaxFloor { get; init; }
+    public string? MemoText { get; init; }
+}
+
+/// <summary>
+/// Logical request shape for <c>SimpleModifyOrder</c> — minimal modification
+/// path matching <c>SimpleNewOrder</c> (schema §6).
+/// </summary>
+public sealed record SimpleModifyRequest
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required ClOrdID OrigClOrdID { get; init; }
+    public required ulong SecurityId { get; init; }
+    public required Side Side { get; init; }
+    public required SimpleOrderType OrderType { get; init; }
+    public decimal? Price { get; init; }
+    public required ulong OrderQty { get; init; }
+    public SimpleTimeInForce TimeInForce { get; init; } = SimpleTimeInForce.Day;
+}

--- a/tests/B3.EntryPoint.Client.Tests/Models/ReplaceOrderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Models/ReplaceOrderTests.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client.Tests.Models;
+
+public class ReplaceOrderTests
+{
+    [Fact]
+    public void ReplaceOrderRequest_RoundTrips()
+    {
+        var req = new ReplaceOrderRequest
+        {
+            ClOrdID = new ClOrdID("R1"),
+            OrigClOrdID = new ClOrdID("O1"),
+            SecurityId = 1,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            OrderQty = 10,
+            Price = 5.0m,
+        };
+        Assert.Equal("R1", req.ClOrdID.Value);
+        Assert.Equal("O1", req.OrigClOrdID.Value);
+    }
+
+    [Fact]
+    public void SimpleModifyRequest_RoundTrips()
+    {
+        var req = new SimpleModifyRequest
+        {
+            ClOrdID = new ClOrdID("R1"),
+            OrigClOrdID = new ClOrdID("O1"),
+            SecurityId = 1,
+            Side = Side.Sell,
+            OrderType = SimpleOrderType.Limit,
+            OrderQty = 10,
+            Price = 5.0m,
+        };
+        Assert.Equal(SimpleTimeInForce.Day, req.TimeInForce);
+    }
+
+    [Fact]
+    public async Task IReplaceOrder_NullRequest_Throws()
+    {
+        IReplaceOrder client = MakeClient();
+        await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceAsync(null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => client.ReplaceSimpleAsync(null!));
+    }
+
+    [Fact]
+    public async Task IReplaceOrder_GuardsBeforeEstablished()
+    {
+        IReplaceOrder client = MakeClient();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.ReplaceAsync(new ReplaceOrderRequest
+            {
+                ClOrdID = new ClOrdID("R"),
+                OrigClOrdID = new ClOrdID("O"),
+                SecurityId = 1,
+                Side = Side.Buy,
+                OrderType = OrderType.Limit,
+                OrderQty = 1,
+            }));
+        Assert.Contains("Established", ex.Message);
+    }
+
+    private static EntryPointClient MakeClient() => new(new EntryPointClientOptions
+    {
+        Endpoint = new IPEndPoint(IPAddress.Loopback, 9999),
+        SessionId = 1,
+        SessionVerId = 1,
+        EnteringFirm = 1,
+        Credentials = Credentials.FromUtf8("k"),
+    });
+}


### PR DESCRIPTION
Adds API surface for issue #7:

- `ReplaceOrderRequest` + `SimpleModifyRequest` records (carry both `ClOrdID` and `OrigClOrdID`).
- `IReplaceOrder` with `ReplaceAsync` / `ReplaceSimpleAsync`.
- `EntryPointClient` implements `IReplaceOrder`; stubs throw `NotImplementedException` citing #7.
- 4 new tests (43 total).

Wire-pure. Closes #7.