### PR TITLE
feat(order-entry): ICancelOrder + MassAction API surface (#8)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -14,7 +14,7 @@ namespace B3.EntryPoint.Client;
 /// public API surface; their wire-level implementations land incrementally
 /// (see <c>docs/CONFORMANCE.md</c> and the issues tagged <c>area/api-surface</c>).
 /// </summary>
-public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceOrder
+public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceOrder, ICancelOrder
 {
     private readonly EntryPointClientOptions _options;
     private TcpClient? _tcp;
@@ -96,6 +96,24 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
         EnsureEstablished();
         throw new NotImplementedException(
             "ReplaceSimpleAsync is not yet wired to the FIXP transport. Tracked by issue #7.");
+    }
+
+    /// <inheritdoc />
+    public Task CancelAsync(CancelOrderRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureEstablished();
+        throw new NotImplementedException(
+            "CancelAsync is not yet wired to the FIXP transport. Tracked by issue #8.");
+    }
+
+    /// <inheritdoc />
+    public Task<MassActionReport> MassActionAsync(MassActionRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureEstablished();
+        throw new NotImplementedException(
+            "MassActionAsync is not yet wired to the FIXP transport. Tracked by issue #8.");
     }
 
     /// <summary>

--- a/src/B3.EntryPoint.Client/ICancelOrder.cs
+++ b/src/B3.EntryPoint.Client/ICancelOrder.cs
@@ -1,0 +1,22 @@
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client;
+
+/// <summary>
+/// Cancel previously submitted orders, individually or via mass action.
+/// Implemented by <see cref="EntryPointClient"/>.
+/// </summary>
+/// <remarks>
+/// API surface only — the SBE encoding lands in a follow-up PR (issue #8).
+/// </remarks>
+public interface ICancelOrder
+{
+    /// <summary>Submit an <c>OrderCancelRequest</c>.</summary>
+    Task CancelAsync(CancelOrderRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Submit an <c>OrderMassActionRequest</c> and await the matching
+    /// <c>OrderMassActionReport</c>.
+    /// </summary>
+    Task<MassActionReport> MassActionAsync(MassActionRequest request, CancellationToken ct = default);
+}

--- a/src/B3.EntryPoint.Client/Models/CancelOrderRequest.cs
+++ b/src/B3.EntryPoint.Client/Models/CancelOrderRequest.cs
@@ -1,0 +1,71 @@
+namespace B3.EntryPoint.Client.Models;
+
+/// <summary>Type of mass action requested (schema enum <c>MassActionType</c>).</summary>
+public enum MassActionType : byte
+{
+    ReleaseOrdersFromSuspension = 2,
+    CancelOrders = 3,
+    CancelAndSuspendOrders = 4,
+}
+
+/// <summary>Scope of mass action (schema enum <c>MassActionScope</c>).</summary>
+public enum MassActionScope : byte
+{
+    AllOrdersForATradingSession = 6,
+}
+
+/// <summary>Mass action response (schema enum <c>MassActionResponse</c>).</summary>
+public enum MassActionResponse : byte
+{
+    Rejected = (byte)'0',
+    Accepted = (byte)'1',
+}
+
+/// <summary>Reason a mass action was rejected (schema enum <c>MassActionRejectReason</c>).</summary>
+public enum MassActionRejectReason : byte
+{
+    MassActionNotSupported = 0,
+    InvalidOrUnknownMarketSegment = 8,
+    Other = 99,
+}
+
+/// <summary>
+/// Logical request shape for <c>OrderCancelRequest</c> (schema §6).
+/// </summary>
+public sealed record CancelOrderRequest
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required ClOrdID OrigClOrdID { get; init; }
+    public required ulong SecurityId { get; init; }
+    public required Side Side { get; init; }
+    public ulong? Account { get; init; }
+    public string? MemoText { get; init; }
+}
+
+/// <summary>
+/// Logical request shape for <c>OrderMassActionRequest</c> (schema §6).
+/// </summary>
+public sealed record MassActionRequest
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required MassActionType ActionType { get; init; }
+    public MassActionScope Scope { get; init; } = MassActionScope.AllOrdersForATradingSession;
+    public ulong? SecurityId { get; init; }
+    public Side? Side { get; init; }
+    public ulong? Account { get; init; }
+    public string? MarketSegment { get; init; }
+}
+
+/// <summary>
+/// Logical response shape for <c>OrderMassActionReport</c> (schema §6).
+/// </summary>
+public sealed record MassActionReport
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required MassActionResponse Response { get; init; }
+    public required MassActionType ActionType { get; init; }
+    public required MassActionScope Scope { get; init; }
+    public uint? TotalAffectedOrders { get; init; }
+    public MassActionRejectReason? RejectReason { get; init; }
+    public string? Reason { get; init; }
+}

--- a/tests/B3.EntryPoint.Client.Tests/Models/CancelOrderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Models/CancelOrderTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client.Tests.Models;
+
+public class CancelOrderTests
+{
+    [Fact]
+    public void CancelOrderRequest_RoundTrips()
+    {
+        var req = new CancelOrderRequest
+        {
+            ClOrdID = new ClOrdID("C1"),
+            OrigClOrdID = new ClOrdID("O1"),
+            SecurityId = 1,
+            Side = Side.Buy,
+        };
+        Assert.Equal("C1", req.ClOrdID.Value);
+    }
+
+    [Fact]
+    public void MassActionRequest_DefaultsScopeToTradingSession()
+    {
+        var req = new MassActionRequest
+        {
+            ClOrdID = new ClOrdID("M1"),
+            ActionType = MassActionType.CancelOrders,
+        };
+        Assert.Equal(MassActionScope.AllOrdersForATradingSession, req.Scope);
+    }
+
+    [Fact]
+    public void MassActionReport_RoundTrips()
+    {
+        var rpt = new MassActionReport
+        {
+            ClOrdID = new ClOrdID("M1"),
+            Response = MassActionResponse.Accepted,
+            ActionType = MassActionType.CancelOrders,
+            Scope = MassActionScope.AllOrdersForATradingSession,
+            TotalAffectedOrders = 17,
+        };
+        Assert.Equal(17u, rpt.TotalAffectedOrders);
+    }
+
+    [Fact]
+    public async Task ICancelOrder_NullRequest_Throws()
+    {
+        ICancelOrder client = MakeClient();
+        await Assert.ThrowsAsync<ArgumentNullException>(() => client.CancelAsync(null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => client.MassActionAsync(null!));
+    }
+
+    [Fact]
+    public async Task ICancelOrder_GuardsBeforeEstablished()
+    {
+        ICancelOrder client = MakeClient();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.CancelAsync(new CancelOrderRequest
+            {
+                ClOrdID = new ClOrdID("C"),
+                OrigClOrdID = new ClOrdID("O"),
+                SecurityId = 1,
+                Side = Side.Buy,
+            }));
+        Assert.Contains("Established", ex.Message);
+    }
+
+    private static EntryPointClient MakeClient() => new(new EntryPointClientOptions
+    {
+        Endpoint = new IPEndPoint(IPAddress.Loopback, 9999),
+        SessionId = 1,
+        SessionVerId = 1,
+        EnteringFirm = 1,
+        Credentials = Credentials.FromUtf8("k"),
+    });
+}


### PR DESCRIPTION
Adds API surface for issue #8:

- `CancelOrderRequest`, `MassActionRequest`, `MassActionReport` records.
- Mass-action enums: `MassActionType`, `MassActionScope`, `MassActionResponse`, `MassActionRejectReason`.
- `ICancelOrder` with `CancelAsync` / `MassActionAsync`.
- `EntryPointClient` implements `ICancelOrder`; stubs throw `NotImplementedException` citing #8.
- 5 new tests (48 total).

Wire-pure. Closes #8.