### PR TITLE
feat(events): typed ExecutionReport family + BusinessReject Events stream API surface (#9)

### DIFF
--- a/src/B3.EntryPoint.Client/Models/EntryPointEvents.cs
+++ b/src/B3.EntryPoint.Client/Models/EntryPointEvents.cs
@@ -1,14 +1,133 @@
 namespace B3.EntryPoint.Client.Models;
 
+/// <summary>Order status (schema enum <c>OrdStatus</c>).</summary>
+public enum OrderStatus : byte
+{
+    New = (byte)'0',
+    PartiallyFilled = (byte)'1',
+    Filled = (byte)'2',
+    Cancelled = (byte)'4',
+    Replaced = (byte)'5',
+    Rejected = (byte)'8',
+    Expired = (byte)'C',
+    Restated = (byte)'R',
+    PreviousFinalState = (byte)'Z',
+}
+
+/// <summary>Reason for an Execution Report restatement (schema enum <c>ExecRestatementReason</c>).</summary>
+public enum ExecRestatementReason : byte
+{
+    GtRestatement = 1,
+    MarketOption = 8,
+    CancelOnHardDisconnection = 100,
+    CancelOnTerminate = 101,
+    CancelOnDisconnectAndTerminate = 102,
+    SelfTradingPrevention = 103,
+    CancelFromFirmsoft = 105,
+    CancelRestingOrderOnSelfTrade = 107,
+    MarketMakerProtection = 200,
+    RiskManagementCancellation = 201,
+    OrderMassActionFromClientRequest = 202,
+    CancelOrderDueToOperationalError = 203,
+    OrderCancelledDueToOperationalError = 204,
+    CancelOrderFirmsoftDueToOperationalError = 205,
+    OrderCancelledFirmsoftDueToOperationalError = 206,
+    MassCancelOrderDueToOperationalErrorRequest = 207,
+    MassCancelOrderDueToOperationalErrorEffective = 208,
+    CancelMinimumQtyBlock = 209,
+    CancelRemainingFromSweepCross = 210,
+    MassCancelOnBehalf = 211,
+    MassCancelOnBehalfDueToOperationalErrorEffective = 212,
+    CancelOnMidpointBrokerOnlyRemoval = 213,
+}
+
 /// <summary>
-/// Marker base for events surfaced via <c>EntryPointClient.Events</c>.
-/// Concrete shapes are intentionally minimal in the bootstrap; the full
-/// ExecutionReport/Reject mapping lands with the Spec_5 scenarios.
+/// Base discriminated record for unsolicited events surfaced by
+/// <see cref="EntryPointClient.Events"/>. Subtypes map 1-to-1 to the
+/// <c>ExecutionReport_*</c> family plus <c>BusinessMessageReject</c>
+/// (schema §6).
 /// </summary>
-public abstract record EntryPointEvent;
+public abstract record EntryPointEvent
+{
+    /// <summary>Sequence number assigned by the gateway.</summary>
+    public required ulong SeqNum { get; init; }
 
-public sealed record ExecutionEvent(string ClOrdID, ulong OrderId) : EntryPointEvent;
+    /// <summary>Time the event was sent by the gateway.</summary>
+    public required DateTimeOffset SendingTime { get; init; }
+}
 
-public sealed record RejectEvent(string ClOrdID, string Reason) : EntryPointEvent;
+/// <summary>Maps to <c>ExecutionReport_New</c> — order acknowledged.</summary>
+public sealed record OrderAccepted : EntryPointEvent
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required ulong OrderId { get; init; }
+    public required OrderStatus OrderStatus { get; init; }
+    public required ulong SecurityId { get; init; }
+    public required Side Side { get; init; }
+    public ulong? LeavesQty { get; init; }
+    public ulong? CumQty { get; init; }
+    public DateTimeOffset? TransactTime { get; init; }
+}
 
-public sealed record BusinessRejectEvent(string RefSeqNum, string Reason) : EntryPointEvent;
+/// <summary>Maps to <c>ExecutionReport_Modify</c>.</summary>
+public sealed record OrderModified : EntryPointEvent
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required ClOrdID OrigClOrdID { get; init; }
+    public required ulong OrderId { get; init; }
+    public required OrderStatus OrderStatus { get; init; }
+    public ulong? LeavesQty { get; init; }
+    public ulong? CumQty { get; init; }
+    public DateTimeOffset? TransactTime { get; init; }
+}
+
+/// <summary>Maps to <c>ExecutionReport_Cancel</c>.</summary>
+public sealed record OrderCancelled : EntryPointEvent
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required ClOrdID? OrigClOrdID { get; init; }
+    public required ulong OrderId { get; init; }
+    public required OrderStatus OrderStatus { get; init; }
+    public ExecRestatementReason? RestatementReason { get; init; }
+    public DateTimeOffset? TransactTime { get; init; }
+}
+
+/// <summary>Maps to <c>ExecutionReport_Trade</c>.</summary>
+public sealed record OrderTrade : EntryPointEvent
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required ulong OrderId { get; init; }
+    public required ulong TradeId { get; init; }
+    public required OrderStatus OrderStatus { get; init; }
+    public required decimal LastPx { get; init; }
+    public required ulong LastQty { get; init; }
+    public ulong? LeavesQty { get; init; }
+    public ulong? CumQty { get; init; }
+    public DateTimeOffset? TransactTime { get; init; }
+}
+
+/// <summary>Maps to <c>ExecutionReport_Reject</c>.</summary>
+public sealed record OrderRejected : EntryPointEvent
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required ulong OrderId { get; init; }
+    public required ushort RejectCode { get; init; }
+    public string? Reason { get; init; }
+    public DateTimeOffset? TransactTime { get; init; }
+}
+
+/// <summary>Maps to <c>ExecutionReport_Forward</c> — order forwarded to another venue/segment.</summary>
+public sealed record OrderForwarded : EntryPointEvent
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required ulong OrderId { get; init; }
+    public DateTimeOffset? TransactTime { get; init; }
+}
+
+/// <summary>Maps to <c>BusinessMessageReject</c>.</summary>
+public sealed record BusinessReject : EntryPointEvent
+{
+    public required ulong RefSeqNum { get; init; }
+    public required ushort RejectReason { get; init; }
+    public string? Text { get; init; }
+}

--- a/tests/B3.EntryPoint.Client.Tests/Models/EntryPointEventsTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Models/EntryPointEventsTests.cs
@@ -1,0 +1,87 @@
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client.Tests.Models;
+
+public class EntryPointEventsTests
+{
+    [Fact]
+    public void OrderAccepted_RoundTrips()
+    {
+        var ev = new OrderAccepted
+        {
+            SeqNum = 1,
+            SendingTime = DateTimeOffset.UnixEpoch,
+            ClOrdID = new ClOrdID("X"),
+            OrderId = 100,
+            OrderStatus = OrderStatus.New,
+            SecurityId = 1,
+            Side = Side.Buy,
+        };
+        Assert.IsType<EntryPointEvent>(ev, exactMatch: false);
+    }
+
+    [Fact]
+    public void OrderTrade_CarriesPriceAndQty()
+    {
+        var ev = new OrderTrade
+        {
+            SeqNum = 2,
+            SendingTime = DateTimeOffset.UnixEpoch,
+            ClOrdID = new ClOrdID("X"),
+            OrderId = 100,
+            TradeId = 200,
+            OrderStatus = OrderStatus.PartiallyFilled,
+            LastPx = 12.5m,
+            LastQty = 10,
+        };
+        Assert.Equal(12.5m, ev.LastPx);
+    }
+
+    [Fact]
+    public void BusinessReject_RoundTrips()
+    {
+        var ev = new BusinessReject
+        {
+            SeqNum = 3,
+            SendingTime = DateTimeOffset.UnixEpoch,
+            RefSeqNum = 1,
+            RejectReason = 99,
+            Text = "nope",
+        };
+        Assert.Equal((ushort)99, ev.RejectReason);
+    }
+
+    [Fact]
+    public void OrderCancelled_AllowsRestatementReason()
+    {
+        var ev = new OrderCancelled
+        {
+            SeqNum = 4,
+            SendingTime = DateTimeOffset.UnixEpoch,
+            ClOrdID = new ClOrdID("X"),
+            OrigClOrdID = new ClOrdID("O"),
+            OrderId = 1,
+            OrderStatus = OrderStatus.Cancelled,
+            RestatementReason = ExecRestatementReason.CancelOnTerminate,
+        };
+        Assert.Equal(ExecRestatementReason.CancelOnTerminate, ev.RestatementReason);
+    }
+
+    [Fact]
+    public async Task EntryPointClient_Events_CompletesEmptyForNow()
+    {
+        await using var c = new EntryPointClient(new EntryPointClientOptions
+        {
+            Endpoint = new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 1),
+            SessionId = 1,
+            SessionVerId = 1,
+            EnteringFirm = 1,
+            Credentials = B3.EntryPoint.Client.Auth.Credentials.FromUtf8("k"),
+        });
+        // Stream guards before Established — that's the documented contract.
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in c.Events()) { }
+        });
+    }
+}


### PR DESCRIPTION
Adds API surface for issue #9:

- `EntryPointEvent` abstract record with `SeqNum` + `SendingTime`.
- 7 sealed record subtypes mapping schema 1-to-1:
  - `OrderAccepted` (← `ExecutionReport_New`)
  - `OrderModified` (← `ExecutionReport_Modify`)
  - `OrderCancelled` (← `ExecutionReport_Cancel`)
  - `OrderTrade` (← `ExecutionReport_Trade`)
  - `OrderRejected` (← `ExecutionReport_Reject`)
  - `OrderForwarded` (← `ExecutionReport_Forward`)
  - `BusinessReject` (← `BusinessMessageReject`)
- `OrderStatus` and `ExecRestatementReason` enums (full schema mirror).
- Old loose `ExecutionEvent` / `RejectEvent` / `BusinessRejectEvent` placeholders replaced.
- `EntryPointClient.Events` continues to surface `IAsyncEnumerable<EntryPointEvent>` (empty until wired); ClOrdID correlation now type-safe.
- 5 new tests (53 total).

Wire-pure. Closes #9.