### PR TITLE
feat(drop-copy): DropCopyClient + SessionProfile API surface (#10)

### DIFF
--- a/src/B3.EntryPoint.Client/DropCopy/DropCopyClient.cs
+++ b/src/B3.EntryPoint.Client/DropCopy/DropCopyClient.cs
@@ -1,0 +1,49 @@
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client.DropCopy;
+
+/// <summary>
+/// Read-only Drop Copy session. Establishes a FIXP session with
+/// <see cref="SessionProfile.DropCopy"/> and surfaces only the
+/// <see cref="EntryPointEvent"/> stream for the entitled firm.
+/// Submission (NewOrder / Replace / Cancel) is intentionally absent —
+/// callers should use <see cref="EntryPointClient"/> for that.
+/// </summary>
+public sealed class DropCopyClient : IAsyncDisposable
+{
+    private readonly EntryPointClient _inner;
+
+    public DropCopyClient(EntryPointClientOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.Profile != SessionProfile.DropCopy)
+        {
+            throw new ArgumentException(
+                $"DropCopyClient requires {nameof(EntryPointClientOptions.Profile)} = {SessionProfile.DropCopy}.",
+                nameof(options));
+        }
+        _inner = new EntryPointClient(options);
+    }
+
+    /// <summary>Establishes the Drop Copy FIXP session.</summary>
+    public Task ConnectAsync(CancellationToken cancellationToken = default)
+        => throw new NotImplementedException(
+            "Drop Copy session establishment is part of the wire-up. Tracked by issue #10.");
+
+    /// <summary>Read-only event stream — same shape as <see cref="EntryPointClient.Events"/>.</summary>
+    public IAsyncEnumerable<EntryPointEvent> Events(CancellationToken cancellationToken = default)
+        => _inner.Events(cancellationToken);
+
+    /// <summary>Terminates the Drop Copy FIXP session.</summary>
+    public Task TerminateAsync(TerminationCode code = TerminationCode.Finished, CancellationToken cancellationToken = default)
+        => _inner.TerminateAsync(code, cancellationToken);
+
+    /// <summary>Raised when the gateway terminates the session.</summary>
+    public event EventHandler<TerminatedEventArgs>? Terminated
+    {
+        add => _inner.Terminated += value;
+        remove => _inner.Terminated -= value;
+    }
+
+    public ValueTask DisposeAsync() => _inner.DisposeAsync();
+}

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -36,6 +36,13 @@ public sealed class EntryPointClientOptions
     public CancelOnDisconnectType CancelOnDisconnect { get; init; } =
         CancelOnDisconnectType.CancelOnDisconnectOrTerminate;
 
+    /// <summary>
+    /// Profile of the FIXP session. <see cref="SessionProfile.OrderEntry"/> is
+    /// the default and allows order submission. <see cref="SessionProfile.DropCopy"/>
+    /// is read-only and used by <see cref="DropCopy.DropCopyClient"/>.
+    /// </summary>
+    public SessionProfile Profile { get; init; } = SessionProfile.OrderEntry;
+
     /// <summary>Optional client metadata sent in <c>Negotiate.ClientAppName</c>.</summary>
     public string ClientAppName { get; init; } = "B3.EntryPoint.Client";
 

--- a/src/B3.EntryPoint.Client/SessionProfile.cs
+++ b/src/B3.EntryPoint.Client/SessionProfile.cs
@@ -1,0 +1,15 @@
+namespace B3.EntryPoint.Client;
+
+/// <summary>
+/// Identifies which gateway profile a FIXP session targets. Drop Copy sessions
+/// share the same wire protocol as Order Entry but are read-only and surface
+/// only the <c>ExecutionReport</c> family for the entitled firm.
+/// </summary>
+public enum SessionProfile
+{
+    /// <summary>Standard order entry session — full submit/replace/cancel API.</summary>
+    OrderEntry = 0,
+
+    /// <summary>Read-only fan-out of execution reports for entitled firms.</summary>
+    DropCopy = 1,
+}

--- a/tests/B3.EntryPoint.Client.Tests/DropCopy/DropCopyClientTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/DropCopy/DropCopyClientTests.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.DropCopy;
+
+namespace B3.EntryPoint.Client.Tests.DropCopy;
+
+public class DropCopyClientTests
+{
+    private static EntryPointClientOptions Opts(SessionProfile profile) => new()
+    {
+        Endpoint = new IPEndPoint(IPAddress.Loopback, 9999),
+        SessionId = 1,
+        SessionVerId = 1,
+        EnteringFirm = 1,
+        Credentials = Credentials.FromUtf8("k"),
+        Profile = profile,
+    };
+
+    [Fact]
+    public void Ctor_Rejects_NonDropCopy_Profile()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new DropCopyClient(Opts(SessionProfile.OrderEntry)));
+        Assert.Contains("DropCopy", ex.Message);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_Throws_With_Issue_Citation()
+    {
+        await using var c = new DropCopyClient(Opts(SessionProfile.DropCopy));
+        var ex = await Assert.ThrowsAsync<NotImplementedException>(() => c.ConnectAsync());
+        Assert.Contains("issue #10", ex.Message);
+    }
+}


### PR DESCRIPTION
Adds API surface for issue #10:

- New `SessionProfile` enum (`OrderEntry` default, `DropCopy`).
- `EntryPointClientOptions.Profile` property.
- New `DropCopy.DropCopyClient` — read-only session that surfaces `Events()` plus `Terminated` event; rejects non-DropCopy options at construction; `ConnectAsync` throws `NotImplementedException` citing issue #10.
- 2 new tests (55 total).

Wire-pure. Closes #10.