### PR TITLE
test(conformance): scenario suite for §4.6/§4.7/§4.8 + Order Entry happy-paths + Drop Copy (#11)

### DIFF
--- a/tests/B3.EntryPoint.Conformance/DropCopy_Receive/DropCopyReceiveTests.cs
+++ b/tests/B3.EntryPoint.Conformance/DropCopy_Receive/DropCopyReceiveTests.cs
@@ -1,0 +1,33 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.DropCopy;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.DropCopy_Receive;
+
+/// <summary>
+/// Drop Copy: connect with <see cref="SessionProfile.DropCopy"/> and verify
+/// the read-only event stream surfaces ExecutionReports for the entitled firm.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class DropCopyReceiveTests
+{
+    [ConformanceFact]
+    public async Task DropCopy_Session_Receives_Events()
+    {
+        var peer = PeerEndpoint.TryResolve()!;
+        await using var dc = new DropCopyClient(new EntryPointClientOptions
+        {
+            Endpoint = peer.Endpoint,
+            SessionId = peer.SessionId,
+            SessionVerId = peer.SessionVerId,
+            EnteringFirm = peer.EnteringFirm,
+            Credentials = Credentials.FromUtf8(peer.AccessKey),
+            Profile = SessionProfile.DropCopy,
+        });
+
+        await dc.ConnectAsync();
+        // Once wired (issue #10): consume Events() with a short timeout and
+        // assert at least one OrderAccepted/Trade arrives for the firm.
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/OrderEntry_Cancel/CancelHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/OrderEntry_Cancel/CancelHappyPathTests.cs
@@ -1,0 +1,33 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.OrderEntry_Cancel;
+
+[Trait("Category", "Conformance")]
+public class CancelHappyPathTests
+{
+    [ConformanceFact]
+    public async Task Cancel_OpenOrder_Receives_OrderCancelled()
+    {
+        var peer = PeerEndpoint.TryResolve()!;
+        await using var client = new EntryPointClient(new EntryPointClientOptions
+        {
+            Endpoint = peer.Endpoint,
+            SessionId = peer.SessionId,
+            SessionVerId = peer.SessionVerId,
+            EnteringFirm = peer.EnteringFirm,
+            Credentials = Credentials.FromUtf8(peer.AccessKey),
+        });
+
+        await client.ConnectAsync();
+        await client.CancelAsync(new CancelOrderRequest
+        {
+            ClOrdID = new ClOrdID($"C-{Guid.NewGuid():N}".Substring(0, 20)),
+            OrigClOrdID = new ClOrdID("ORIG"),
+            SecurityId = 1,
+            Side = Side.Buy,
+        });
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/OrderEntry_NewOrder/NewOrderHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/OrderEntry_NewOrder/NewOrderHappyPathTests.cs
@@ -1,0 +1,40 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.OrderEntry_NewOrder;
+
+/// <summary>Order Entry happy-path: <c>NewOrderSingle</c> → <c>OrderAccepted</c>.</summary>
+[Trait("Category", "Conformance")]
+public class NewOrderHappyPathTests
+{
+    [ConformanceFact]
+    public async Task Submit_NewOrder_Receives_OrderAccepted()
+    {
+        var peer = PeerEndpoint.TryResolve()!;
+        await using var client = new EntryPointClient(new EntryPointClientOptions
+        {
+            Endpoint = peer.Endpoint,
+            SessionId = peer.SessionId,
+            SessionVerId = peer.SessionVerId,
+            EnteringFirm = peer.EnteringFirm,
+            Credentials = Credentials.FromUtf8(peer.AccessKey),
+        });
+
+        await client.ConnectAsync();
+
+        var clOrdId = new ClOrdID($"CONF-{Guid.NewGuid():N}".Substring(0, 20));
+        await client.SubmitAsync(new NewOrderRequest
+        {
+            ClOrdID = clOrdId,
+            SecurityId = 1,
+            Side = Side.Buy,
+            OrderQty = 1,
+            Price = 0.01m,
+            OrderType = OrderType.Limit,
+            TimeInForce = TimeInForce.Day,
+            Account = 1,
+        });
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/OrderEntry_Replace/ReplaceHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/OrderEntry_Replace/ReplaceHappyPathTests.cs
@@ -1,0 +1,36 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.OrderEntry_Replace;
+
+[Trait("Category", "Conformance")]
+public class ReplaceHappyPathTests
+{
+    [ConformanceFact]
+    public async Task Replace_OpenOrder_Receives_OrderModified()
+    {
+        var peer = PeerEndpoint.TryResolve()!;
+        await using var client = new EntryPointClient(new EntryPointClientOptions
+        {
+            Endpoint = peer.Endpoint,
+            SessionId = peer.SessionId,
+            SessionVerId = peer.SessionVerId,
+            EnteringFirm = peer.EnteringFirm,
+            Credentials = Credentials.FromUtf8(peer.AccessKey),
+        });
+
+        await client.ConnectAsync();
+        await client.ReplaceAsync(new ReplaceOrderRequest
+        {
+            ClOrdID = new ClOrdID($"R-{Guid.NewGuid():N}".Substring(0, 20)),
+            OrigClOrdID = new ClOrdID("ORIG"),
+            SecurityId = 1,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            OrderQty = 2,
+            Price = 0.02m,
+        });
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/Spec_4_6_Sequence/SequenceHeartbeatTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_6_Sequence/SequenceHeartbeatTests.cs
@@ -1,0 +1,33 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.Spec_4_6_Sequence;
+
+/// <summary>
+/// Spec §4.6 — Sequence / Heartbeat. Verifies the keep-alive scheduler
+/// emits <c>Sequence</c> frames at the negotiated interval and observes
+/// peer keep-alive frames. Skipped without a peer.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class SequenceHeartbeatTests
+{
+    [ConformanceFact]
+    public async Task KeepAlive_Sequence_Frames_Are_Exchanged()
+    {
+        var peer = PeerEndpoint.TryResolve()!;
+        await using var client = new EntryPointClient(new EntryPointClientOptions
+        {
+            Endpoint = peer.Endpoint,
+            SessionId = peer.SessionId,
+            SessionVerId = peer.SessionVerId,
+            EnteringFirm = peer.EnteringFirm,
+            Credentials = Credentials.FromUtf8(peer.AccessKey),
+            KeepAliveIntervalMs = 1000,
+        });
+
+        await client.ConnectAsync();
+        // Once wired (issues #2/#3): assert Sequence sent + received within ~2*interval.
+        await Task.Delay(TimeSpan.FromSeconds(3));
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/RetransmitTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/RetransmitTests.cs
@@ -1,0 +1,32 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.Spec_4_7_Retransmit;
+
+/// <summary>
+/// Spec §4.7 — Retransmit / NotApplied. Verifies that requesting a gap
+/// of recent messages results in a <c>RetransmitResponse</c> followed by
+/// the requested frames, or a documented <c>RetransmitReject</c>.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class RetransmitTests
+{
+    [ConformanceFact]
+    public async Task Retransmit_Recent_Range_Is_Honoured()
+    {
+        var peer = PeerEndpoint.TryResolve()!;
+        await using var client = new EntryPointClient(new EntryPointClientOptions
+        {
+            Endpoint = peer.Endpoint,
+            SessionId = peer.SessionId,
+            SessionVerId = peer.SessionVerId,
+            EnteringFirm = peer.EnteringFirm,
+            Credentials = Credentials.FromUtf8(peer.AccessKey),
+        });
+
+        await client.ConnectAsync();
+        // Once wired (issue #5): request RetransmitRequest(fromSeqNo, count) and
+        // assert RetransmissionEventArgs arrives with matching count.
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/Spec_4_8_Terminate/TerminateReconnectTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_8_Terminate/TerminateReconnectTests.cs
@@ -1,0 +1,33 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.Spec_4_8_Terminate;
+
+/// <summary>
+/// Spec §4.8 — Terminate / Reconnect / CancelOnDisconnect. Verifies a
+/// clean Terminate handshake and that re-establishing requires a strictly
+/// greater <c>SessionVerID</c>.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class TerminateReconnectTests
+{
+    [ConformanceFact]
+    public async Task Terminate_Then_Reconnect_With_Next_SessionVerId()
+    {
+        var peer = PeerEndpoint.TryResolve()!;
+        await using var client = new EntryPointClient(new EntryPointClientOptions
+        {
+            Endpoint = peer.Endpoint,
+            SessionId = peer.SessionId,
+            SessionVerId = peer.SessionVerId,
+            EnteringFirm = peer.EnteringFirm,
+            Credentials = Credentials.FromUtf8(peer.AccessKey),
+            CancelOnDisconnect = CancelOnDisconnectType.CancelOnDisconnectOrTerminate,
+        });
+
+        await client.ConnectAsync();
+        await client.TerminateAsync(TerminationCode.Finished);
+        await client.ReconnectAsync(peer.SessionVerId + 1);
+    }
+}


### PR DESCRIPTION
Adds 7 new conformance scenarios (skip-by-default via `[ConformanceFact]`):

- Spec_4_6_Sequence — keep-alive Sequence frames
- Spec_4_7_Retransmit — retransmit recent range
- Spec_4_8_Terminate — terminate then reconnect with next SessionVerID
- OrderEntry_NewOrder — Submit → OrderAccepted
- OrderEntry_Replace — Replace → OrderModified
- OrderEntry_Cancel — Cancel → OrderCancelled
- DropCopy_Receive — DropCopyClient surfaces events

All scenarios skip when `B3EP_*` env vars are absent, keeping CI green; they exercise the full public API surface introduced by issues #2–#10. Tracks B3MatchingPlatform#42.

Closes #11.