### PR TITLE
feat(wire): SBE encoders for Order Entry messages (#22)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -63,48 +63,62 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     }
 
     /// <inheritdoc />
-    public Task<ClOrdID> SubmitAsync(NewOrderRequest request, CancellationToken ct = default)
+    public async Task<ClOrdID> SubmitAsync(NewOrderRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
-        throw new NotImplementedException(
-            "SubmitAsync is not yet wired to the FIXP transport. Tracked by issue #4.");
+        var seq = _session!.NextOutboundSeqNum();
+        var buffer = new byte[NewOrderSingleData.MESSAGE_SIZE + 256];
+        var len = OrderEntryEncoder.EncodeNewOrderSingle(buffer, request, _options, seq);
+        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        return request.ClOrdID;
     }
 
     /// <inheritdoc />
-    public Task<ClOrdID> SubmitSimpleAsync(SimpleNewOrderRequest request, CancellationToken ct = default)
+    public async Task<ClOrdID> SubmitSimpleAsync(SimpleNewOrderRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
-        throw new NotImplementedException(
-            "SubmitSimpleAsync is not yet wired to the FIXP transport. Tracked by issue #4.");
+        var seq = _session!.NextOutboundSeqNum();
+        var buffer = new byte[SimpleNewOrderData.MESSAGE_SIZE + 64];
+        var len = OrderEntryEncoder.EncodeSimpleNewOrder(buffer, request, _options, seq);
+        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        return request.ClOrdID;
     }
 
     /// <inheritdoc />
-    public Task<ClOrdID> ReplaceAsync(ReplaceOrderRequest request, CancellationToken ct = default)
+    public async Task<ClOrdID> ReplaceAsync(ReplaceOrderRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
-        throw new NotImplementedException(
-            "ReplaceAsync is not yet wired to the FIXP transport. Tracked by issue #7.");
+        var seq = _session!.NextOutboundSeqNum();
+        var buffer = new byte[OrderCancelReplaceRequestData.MESSAGE_SIZE + 256];
+        var len = OrderEntryEncoder.EncodeOrderCancelReplace(buffer, request, _options, seq);
+        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        return request.ClOrdID;
     }
 
     /// <inheritdoc />
-    public Task<ClOrdID> ReplaceSimpleAsync(SimpleModifyRequest request, CancellationToken ct = default)
+    public async Task<ClOrdID> ReplaceSimpleAsync(SimpleModifyRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
-        throw new NotImplementedException(
-            "ReplaceSimpleAsync is not yet wired to the FIXP transport. Tracked by issue #7.");
+        var seq = _session!.NextOutboundSeqNum();
+        var buffer = new byte[SimpleModifyOrderData.MESSAGE_SIZE + 64];
+        var len = OrderEntryEncoder.EncodeSimpleModifyOrder(buffer, request, _options, seq);
+        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        return request.ClOrdID;
     }
 
     /// <inheritdoc />
-    public Task CancelAsync(CancelOrderRequest request, CancellationToken ct = default)
+    public async Task CancelAsync(CancelOrderRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
-        throw new NotImplementedException(
-            "CancelAsync is not yet wired to the FIXP transport. Tracked by issue #8.");
+        var seq = _session!.NextOutboundSeqNum();
+        var buffer = new byte[OrderCancelRequestData.MESSAGE_SIZE + 256];
+        var len = OrderEntryEncoder.EncodeOrderCancel(buffer, request, _options, seq);
+        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -112,8 +126,26 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
-        throw new NotImplementedException(
-            "MassActionAsync is not yet wired to the FIXP transport. Tracked by issue #8.");
+        var seq = _session!.NextOutboundSeqNum();
+        var buffer = new byte[OrderMassActionRequestData.MESSAGE_SIZE + 32];
+        var len = OrderEntryEncoder.EncodeOrderMassAction(buffer, request, _options, seq);
+        // Fire-and-forget the request; the matching MassActionReport will be
+        // surfaced through the inbound dispatcher (issue #23) — until then,
+        // we encode+send and return a synthetic Acknowledged report.
+        return SendMassActionAsync(buffer, len, request, ct);
+
+        async Task<MassActionReport> SendMassActionAsync(byte[] buf, int length, MassActionRequest req, CancellationToken token)
+        {
+            await _session.SendApplicationFrameAsync(buf, length, token).ConfigureAwait(false);
+            return new MassActionReport
+            {
+                ClOrdID = req.ClOrdID,
+                ActionType = req.ActionType,
+                Response = B3.EntryPoint.Client.Models.MassActionResponse.Accepted,
+                Scope = req.Scope,
+                TotalAffectedOrders = 0,
+            };
+        }
     }
 
     /// <summary>

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -28,6 +28,24 @@ public sealed class EntryPointClientOptions
     public TimeSpan KeepAliveInterval => TimeSpan.FromMilliseconds(KeepAliveIntervalMs);
 
     /// <summary>
+    /// Identifies the original location for routing orders (FIX <c>SenderLocation</c>,
+    /// max 10 chars). Required on every order entry message.
+    /// </summary>
+    public string SenderLocation { get; init; } = "";
+
+    /// <summary>
+    /// Identifier of the trader entering the orders (FIX <c>EnteringTrader</c>,
+    /// max 5 chars). Required on every order entry message.
+    /// </summary>
+    public string EnteringTrader { get; init; } = "";
+
+    /// <summary>
+    /// Default <c>MarketSegmentID</c> stamped on the inbound business header
+    /// when a request does not specify one. Defaults to 1 (single-segment).
+    /// </summary>
+    public byte DefaultMarketSegmentId { get; init; } = 1;
+
+    /// <summary>
     /// Cancel-on-disconnect behaviour requested at <c>Negotiate</c>. Defaults
     /// to <see cref="CancelOnDisconnectType.CancelOnDisconnectOrTerminate"/>
     /// — the safest choice for a participant that must not leave open orders

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -115,6 +115,24 @@ internal sealed class FixpClientSession : IAsyncDisposable
             _machine.Fire(FixpClientTrigger.SendTerminate);
     }
 
+    private long _outboundSeqNum;
+
+    /// <summary>
+    /// Sends an Order Entry application frame previously encoded into <paramref name="buffer"/>
+    /// via <see cref="OrderEntryEncoder"/>. The first <paramref name="length"/> bytes are flushed.
+    /// </summary>
+    public async Task SendApplicationFrameAsync(byte[] buffer, int length, CancellationToken ct)
+    {
+        if (_machine.State != FixpClientState.Established)
+            throw new InvalidOperationException($"Cannot send application frame from state {_machine.State}.");
+        await _stream.WriteAsync(buffer.AsMemory(0, length), ct).ConfigureAwait(false);
+        await _stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Returns the next outbound MsgSeqNum and increments the counter.</summary>
+    public ulong NextOutboundSeqNum() =>
+        (ulong)System.Threading.Interlocked.Increment(ref _outboundSeqNum);
+
     public async ValueTask DisposeAsync()
     {
         try { await TerminateAsync(SbeTerminationCode.FINISHED, CancellationToken.None).ConfigureAwait(false); }

--- a/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
@@ -1,0 +1,298 @@
+using System.Buffers.Binary;
+using System.Text;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.EntryPoint.Client.Framing;
+using B3.EntryPoint.Client.Models;
+using SbeClOrdID = B3.Entrypoint.Fixp.Sbe.V6.ClOrdID;
+using ClOrdID = B3.EntryPoint.Client.Models.ClOrdID;
+using SbeSide = B3.Entrypoint.Fixp.Sbe.V6.Side;
+using SbeOrdType = B3.Entrypoint.Fixp.Sbe.V6.OrdType;
+using SbeSimpleOrdType = B3.Entrypoint.Fixp.Sbe.V6.SimpleOrdType;
+using SbeTimeInForce = B3.Entrypoint.Fixp.Sbe.V6.TimeInForce;
+using SbeSimpleTimeInForce = B3.Entrypoint.Fixp.Sbe.V6.SimpleTimeInForce;
+using SbeAccountType = B3.Entrypoint.Fixp.Sbe.V6.AccountType;
+using SbeMassActionType = B3.Entrypoint.Fixp.Sbe.V6.MassActionType;
+using SbeMassActionScope = B3.Entrypoint.Fixp.Sbe.V6.MassActionScope;
+
+namespace B3.EntryPoint.Client.Fixp;
+
+/// <summary>
+/// Encodes Order Entry application messages (NewOrderSingle, SimpleNewOrder,
+/// OrderCancelReplaceRequest, SimpleModifyOrder, OrderCancelRequest,
+/// OrderMassActionRequest) into SOFH-framed SBE buffers. Maps the public
+/// <see cref="Models"/> DTOs to wire fields per the v8.4.2 schema.
+/// </summary>
+internal static class OrderEntryEncoder
+{
+    private const int SofhSize = SofhFrameReader.HeaderSize;
+    private const int SbeHeaderSize = MessageHeader.MESSAGE_SIZE;
+    private const sbyte PriceExponent = -4;
+
+    private static long PriceMantissa(decimal price) =>
+        (long)(price * 10_000m);
+
+    private static InboundBusinessHeader BuildBusinessHeader(EntryPointClientOptions options, ulong msgSeqNum)
+    {
+        var header = default(InboundBusinessHeader);
+        header.SessionID = new SessionID(options.SessionId);
+        header.MsgSeqNum = new SeqNum(checked((uint)msgSeqNum));
+        header.SendingTime = default;
+        header.MarketSegmentID = new MarketSegmentID(options.DefaultMarketSegmentId);
+        return header;
+    }
+
+    private static void WriteHeaders(Span<byte> buffer, int totalSize, Action<Span<byte>> writeSbeHeader)
+    {
+        SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
+        writeSbeHeader(buffer.Slice(SofhSize));
+    }
+
+    private static void WriteFixedString(Span<byte> destination, string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            destination.Clear();
+            return;
+        }
+        var byteCount = Encoding.ASCII.GetByteCount(value);
+        if (byteCount > destination.Length)
+            throw new ArgumentException(
+                $"Value '{value}' exceeds wire length {destination.Length}.", nameof(value));
+        Encoding.ASCII.GetBytes(value, destination);
+        destination.Slice(byteCount).Clear();
+    }
+
+    /// <summary>Encodes a SimpleNewOrder (template id 100). Returns total bytes written.</summary>
+    public static int EncodeSimpleNewOrder(
+        Span<byte> buffer,
+        SimpleNewOrderRequest request,
+        EntryPointClientOptions options,
+        ulong msgSeqNum)
+    {
+        var memo = MemoBytes(request.Account is null ? null : null); // SimpleNewOrder has no memo per schema
+        var payloadSize = SimpleNewOrderData.MESSAGE_SIZE + 1 + 0;
+        var totalSize = SofhSize + SbeHeaderSize + payloadSize;
+        WriteHeaders(buffer.Slice(0, totalSize), totalSize,
+            payload => SimpleNewOrderData.WriteHeader(payload));
+
+        var msg = default(SimpleNewOrderData);
+        msg.BusinessHeader = BuildBusinessHeader(options, msgSeqNum);
+        msg.MmProtectionReset = global::B3.Entrypoint.Fixp.Sbe.V6.Boolean.FALSE_VALUE;
+        msg.ClOrdID = new SbeClOrdID(request.ClOrdID.Value);
+        msg.SetAccount(request.Account is null ? null : (uint?)checked((uint)request.Account.Value));
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 32, 10), options.SenderLocation);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 42, 5), options.EnteringTrader);
+        msg.SecurityID = new SecurityID(request.SecurityId);
+        msg.Side = (SbeSide)(byte)request.Side;
+        msg.OrdType = (SbeSimpleOrdType)(byte)request.OrderType;
+        msg.TimeInForce = (SbeSimpleTimeInForce)(byte)request.TimeInForce;
+        msg.OrderQty = new Quantity(request.OrderQty);
+        if (request.Price.HasValue)
+        {
+            // PriceOptional has private mantissa; write directly.
+            var mantissa = PriceMantissa(request.Price.Value);
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 68, 8), mantissa);
+        }
+        else
+        {
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 68, 8), long.MinValue);
+        }
+
+        if (!SimpleNewOrderData.TryEncode(msg, buffer.Slice(SofhSize + SbeHeaderSize), ReadOnlySpan<byte>.Empty, out _))
+            throw new InvalidOperationException("Failed to encode SimpleNewOrderData.");
+        return totalSize;
+    }
+
+    /// <summary>Encodes a SimpleModifyOrder (template id 101). Returns total bytes written.</summary>
+    public static int EncodeSimpleModifyOrder(
+        Span<byte> buffer,
+        SimpleModifyRequest request,
+        EntryPointClientOptions options,
+        ulong msgSeqNum)
+    {
+        var payloadSize = SimpleModifyOrderData.MESSAGE_SIZE + 1 + 0;
+        var totalSize = SofhSize + SbeHeaderSize + payloadSize;
+        WriteHeaders(buffer.Slice(0, totalSize), totalSize, p => SimpleModifyOrderData.WriteHeader(p));
+
+        var msg = default(SimpleModifyOrderData);
+        msg.BusinessHeader = BuildBusinessHeader(options, msgSeqNum);
+        msg.ClOrdID = new SbeClOrdID(request.ClOrdID.Value);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 32, 10), options.SenderLocation);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 42, 5), options.EnteringTrader);
+        msg.SecurityID = new SecurityID(request.SecurityId);
+        msg.Side = (SbeSide)(byte)request.Side;
+        msg.OrdType = (SbeSimpleOrdType)(byte)request.OrderType;
+        msg.TimeInForce = (SbeSimpleTimeInForce)(byte)request.TimeInForce;
+        msg.OrderQty = new Quantity(request.OrderQty);
+        if (request.Price.HasValue)
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 68, 8), PriceMantissa(request.Price.Value));
+        else
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 68, 8), long.MinValue);
+        msg.SetOrigClOrdID((ulong?)request.OrigClOrdID.Value);
+
+        if (!SimpleModifyOrderData.TryEncode(msg, buffer.Slice(SofhSize + SbeHeaderSize), ReadOnlySpan<byte>.Empty, out _))
+            throw new InvalidOperationException("Failed to encode SimpleModifyOrderData.");
+        return totalSize;
+    }
+
+    /// <summary>Encodes an OrderCancelRequest (template id 104). Returns total bytes written.</summary>
+    public static int EncodeOrderCancel(
+        Span<byte> buffer,
+        CancelOrderRequest request,
+        EntryPointClientOptions options,
+        ulong msgSeqNum)
+    {
+        var memoBytes = MemoBytes(request.MemoText);
+        var payloadSize = OrderCancelRequestData.MESSAGE_SIZE + 1 + 0 + 1 + memoBytes.Length;
+        var totalSize = SofhSize + SbeHeaderSize + payloadSize;
+        WriteHeaders(buffer.Slice(0, totalSize), totalSize, p => OrderCancelRequestData.WriteHeader(p));
+
+        var msg = default(OrderCancelRequestData);
+        msg.BusinessHeader = BuildBusinessHeader(options, msgSeqNum);
+        msg.ClOrdID = new SbeClOrdID(request.ClOrdID.Value);
+        msg.SecurityID = new SecurityID(request.SecurityId);
+        msg.SetOrigClOrdID(request.OrigClOrdID.Value);
+        msg.Side = (SbeSide)(byte)request.Side;
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 56, 10), options.SenderLocation);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 66, 5), options.EnteringTrader);
+
+        if (!OrderCancelRequestData.TryEncode(msg, buffer.Slice(SofhSize + SbeHeaderSize),
+                ReadOnlySpan<byte>.Empty, memoBytes, out _))
+            throw new InvalidOperationException("Failed to encode OrderCancelRequestData.");
+        return totalSize;
+    }
+
+    /// <summary>Encodes a NewOrderSingle (template id 102). Returns total bytes written.</summary>
+    public static int EncodeNewOrderSingle(
+        Span<byte> buffer,
+        NewOrderRequest request,
+        EntryPointClientOptions options,
+        ulong msgSeqNum)
+    {
+        var memoBytes = MemoBytes(request.MemoText);
+        var payloadSize = NewOrderSingleData.MESSAGE_SIZE + 1 + 0 + 1 + memoBytes.Length;
+        var totalSize = SofhSize + SbeHeaderSize + payloadSize;
+        WriteHeaders(buffer.Slice(0, totalSize), totalSize, p => NewOrderSingleData.WriteHeader(p));
+
+        var msg = default(NewOrderSingleData);
+        msg.BusinessHeader = BuildBusinessHeader(options, msgSeqNum);
+        msg.MmProtectionReset = global::B3.Entrypoint.Fixp.Sbe.V6.Boolean.FALSE_VALUE;
+        msg.ClOrdID = new SbeClOrdID(request.ClOrdID.Value);
+        msg.SetAccount(request.Account is null ? null : checked((uint)request.Account.Value));
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 32, 10), options.SenderLocation);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 42, 5), options.EnteringTrader);
+        msg.SecurityID = new SecurityID(request.SecurityId);
+        msg.Side = (SbeSide)(byte)request.Side;
+        msg.OrdType = (SbeOrdType)(byte)request.OrderType;
+        msg.TimeInForce = (SbeTimeInForce)(byte)request.TimeInForce;
+        msg.OrderQty = new Quantity(request.OrderQty);
+        if (request.Price.HasValue)
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 68, 8), PriceMantissa(request.Price.Value));
+        else
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 68, 8), long.MinValue);
+        if (request.StopPrice.HasValue)
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 76, 8), PriceMantissa(request.StopPrice.Value));
+        else
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 76, 8), long.MinValue);
+        if (request.MinQty.HasValue)
+            BinaryPrimitives.WriteUInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 84, 8), request.MinQty.Value);
+        if (request.MaxFloor.HasValue)
+            BinaryPrimitives.WriteUInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 92, 8), request.MaxFloor.Value);
+        MemoryMarshalAsBytes(ref msg, 100, 1)[0] = (byte)request.AccountType;
+        if (request.ExpireDate.HasValue)
+            BinaryPrimitives.WriteUInt16LittleEndian(MemoryMarshalAsBytes(ref msg, 105, 2),
+                (ushort)((request.ExpireDate.Value - DateTimeOffset.UnixEpoch).Days));
+
+        if (!NewOrderSingleData.TryEncode(msg, buffer.Slice(SofhSize + SbeHeaderSize),
+                ReadOnlySpan<byte>.Empty, memoBytes, out _))
+            throw new InvalidOperationException("Failed to encode NewOrderSingleData.");
+        return totalSize;
+    }
+
+    /// <summary>Encodes an OrderCancelReplaceRequest (template id 103). Returns total bytes written.</summary>
+    public static int EncodeOrderCancelReplace(
+        Span<byte> buffer,
+        ReplaceOrderRequest request,
+        EntryPointClientOptions options,
+        ulong msgSeqNum)
+    {
+        var memoBytes = MemoBytes(request.MemoText);
+        var payloadSize = OrderCancelReplaceRequestData.MESSAGE_SIZE + 1 + 0 + 1 + memoBytes.Length;
+        var totalSize = SofhSize + SbeHeaderSize + payloadSize;
+        WriteHeaders(buffer.Slice(0, totalSize), totalSize, p => OrderCancelReplaceRequestData.WriteHeader(p));
+
+        var msg = default(OrderCancelReplaceRequestData);
+        msg.BusinessHeader = BuildBusinessHeader(options, msgSeqNum);
+        msg.MmProtectionReset = global::B3.Entrypoint.Fixp.Sbe.V6.Boolean.FALSE_VALUE;
+        msg.ClOrdID = new SbeClOrdID(request.ClOrdID.Value);
+        msg.SetAccount(request.Account is null ? null : checked((uint)request.Account.Value));
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 32, 10), options.SenderLocation);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 42, 5), options.EnteringTrader);
+        msg.SecurityID = new SecurityID(request.SecurityId);
+        msg.Side = (SbeSide)(byte)request.Side;
+        msg.OrdType = (SbeOrdType)(byte)request.OrderType;
+        msg.SetTimeInForce((SbeTimeInForce)(byte)request.TimeInForce);
+        msg.OrderQty = new Quantity(request.OrderQty);
+        if (request.Price.HasValue)
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 68, 8), PriceMantissa(request.Price.Value));
+        else
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 68, 8), long.MinValue);
+        msg.SetOrigClOrdID(request.OrigClOrdID.Value);
+        if (request.StopPrice.HasValue)
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 84, 8), PriceMantissa(request.StopPrice.Value));
+        else
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 84, 8), long.MinValue);
+        if (request.MinQty.HasValue)
+            BinaryPrimitives.WriteUInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 92, 8), request.MinQty.Value);
+        if (request.MaxFloor.HasValue)
+            BinaryPrimitives.WriteUInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 100, 8), request.MaxFloor.Value);
+        MemoryMarshalAsBytes(ref msg, 113, 1)[0] = (byte)request.AccountType;
+        if (request.ExpireDate.HasValue)
+            BinaryPrimitives.WriteUInt16LittleEndian(MemoryMarshalAsBytes(ref msg, 114, 2),
+                (ushort)((request.ExpireDate.Value - DateTimeOffset.UnixEpoch).Days));
+
+        if (!OrderCancelReplaceRequestData.TryEncode(msg, buffer.Slice(SofhSize + SbeHeaderSize),
+                ReadOnlySpan<byte>.Empty, memoBytes, out _))
+            throw new InvalidOperationException("Failed to encode OrderCancelReplaceRequestData.");
+        return totalSize;
+    }
+
+    /// <summary>Encodes an OrderMassActionRequest (template id 701). Returns total bytes written.</summary>
+    public static int EncodeOrderMassAction(
+        Span<byte> buffer,
+        MassActionRequest request,
+        EntryPointClientOptions options,
+        ulong msgSeqNum)
+    {
+        var totalSize = SofhSize + SbeHeaderSize + OrderMassActionRequestData.MESSAGE_SIZE;
+        WriteHeaders(buffer.Slice(0, totalSize), totalSize, p => OrderMassActionRequestData.WriteHeader(p));
+
+        var msg = default(OrderMassActionRequestData);
+        msg.BusinessHeader = BuildBusinessHeader(options, msgSeqNum);
+        msg.MassActionType = (SbeMassActionType)(byte)request.ActionType;
+        msg.SetMassActionScope((SbeMassActionScope?)(byte?)request.Scope);
+        msg.ClOrdID = new SbeClOrdID(request.ClOrdID.Value);
+        if (request.Side.HasValue)
+            msg.SetSide((SbeSide?)(byte?)request.Side.Value);
+        if (request.SecurityId.HasValue)
+            msg.SetSecurityID(request.SecurityId.Value);
+
+        if (!msg.TryEncode(buffer.Slice(SofhSize + SbeHeaderSize), out _))
+            throw new InvalidOperationException("Failed to encode OrderMassActionRequestData.");
+        return totalSize;
+    }
+
+    private static ReadOnlySpan<byte> MemoBytes(string? memo) =>
+        string.IsNullOrEmpty(memo) ? ReadOnlySpan<byte>.Empty : Encoding.UTF8.GetBytes(memo);
+
+    /// <summary>
+    /// Hands out a <see cref="Span{Byte}"/> view over a fixed offset/length within a struct
+    /// for the few cases where the SBE-generated surface lacks public setters
+    /// (e.g. <c>InlineArray</c>-backed text fields, <c>PriceOptional.Mantissa</c>).
+    /// </summary>
+    private static Span<byte> MemoryMarshalAsBytes<T>(ref T value, int offset, int length) where T : unmanaged
+    {
+        var span = System.Runtime.InteropServices.MemoryMarshal.CreateSpan(ref value, 1);
+        return System.Runtime.InteropServices.MemoryMarshal.AsBytes(span).Slice(offset, length);
+    }
+}

--- a/src/B3.EntryPoint.Client/Models/ClOrdID.cs
+++ b/src/B3.EntryPoint.Client/Models/ClOrdID.cs
@@ -1,26 +1,30 @@
 namespace B3.EntryPoint.Client.Models;
 
 /// <summary>
-/// Client order ID (FIX <c>ClOrdID</c>). Strongly-typed wrapper to keep the
-/// public API distinct from arbitrary strings. Max 20 characters per spec.
+/// Client order ID (FIX <c>ClOrdID</c>). Wraps the wire <c>uint64</c>
+/// (per schema <c>&lt;type name="ClOrdID" primitiveType="uint64"/&gt;</c>).
 /// </summary>
 public readonly record struct ClOrdID
 {
-    public const int MaxLength = 20;
-
-    public ClOrdID(string value)
+    public ClOrdID(ulong value)
     {
-        ArgumentException.ThrowIfNullOrEmpty(value);
-        if (value.Length > MaxLength)
-            throw new ArgumentException(
-                $"ClOrdID must be at most {MaxLength} characters (got {value.Length}).",
-                nameof(value));
+        if (value == 0)
+            throw new ArgumentException("ClOrdID cannot be zero (reserved as null sentinel).", nameof(value));
         Value = value;
     }
 
-    public string Value { get; }
+    public ulong Value { get; }
 
-    public override string ToString() => Value;
+    /// <summary>Parses a numeric string into a ClOrdID.</summary>
+    public static ClOrdID Parse(string value)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(value);
+        return new ClOrdID(ulong.Parse(value, System.Globalization.CultureInfo.InvariantCulture));
+    }
 
-    public static implicit operator string(ClOrdID id) => id.Value;
+    public override string ToString() => Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    public static implicit operator ulong(ClOrdID id) => id.Value;
+    public static explicit operator ClOrdID(ulong value) => new(value);
 }
+

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
@@ -1,0 +1,147 @@
+using System.Buffers.Binary;
+using System.Net;
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client.Tests.Fixp;
+
+public class OrderEntryEncoderTests
+{
+    private static EntryPointClientOptions Opts() => new()
+    {
+        Endpoint = new IPEndPoint(IPAddress.Loopback, 1),
+        SessionId = 42,
+        SessionVerId = 7,
+        EnteringFirm = 100,
+        Credentials = Credentials.FromUtf8("k"),
+        SenderLocation = "SP-001",
+        EnteringTrader = "T0001",
+        DefaultMarketSegmentId = 1,
+    };
+
+    // Wire layout: SOFH (4 bytes: msgLen[2] LE + encoding-type[2] LE) + SBE MessageHeader (8 bytes) + payload.
+    // SBE header: blockLength(uint16)|templateId(uint16)|...
+    private static (ushort sofhLen, ushort templateId) ReadFrameHeader(byte[] buffer)
+    {
+        var sofhLen = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(0, 2));
+        var templateId = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(4 + 2, 2));
+        return (sofhLen, templateId);
+    }
+
+    [Fact]
+    public void EncodeSimpleNewOrder_WritesTemplateId_100_AndExpectedLength()
+    {
+        var req = new SimpleNewOrderRequest
+        {
+            ClOrdID = new ClOrdID(12345UL),
+            SecurityId = 7,
+            Side = Side.Buy,
+            OrderType = SimpleOrderType.Limit,
+            OrderQty = 100,
+            Price = 12.34m,
+            Account = 555,
+        };
+        var buffer = new byte[256];
+        var len = OrderEntryEncoder.EncodeSimpleNewOrder(buffer, req, Opts(), msgSeqNum: 1);
+        var (sofhLen, tid) = ReadFrameHeader(buffer);
+        Assert.Equal(len, sofhLen);
+        Assert.Equal((ushort)100, tid);
+    }
+
+    [Fact]
+    public void EncodeOrderCancel_WritesTemplateId_105()
+    {
+        var req = new CancelOrderRequest
+        {
+            ClOrdID = new ClOrdID(2UL),
+            OrigClOrdID = new ClOrdID(1UL),
+            SecurityId = 7,
+            Side = Side.Sell,
+        };
+        var buffer = new byte[256];
+        var len = OrderEntryEncoder.EncodeOrderCancel(buffer, req, Opts(), msgSeqNum: 2);
+        var (_, tid) = ReadFrameHeader(buffer);
+        Assert.True(len > 0);
+        Assert.Equal((ushort)105, tid);
+    }
+
+    [Fact]
+    public void EncodeNewOrderSingle_WritesTemplateId_102()
+    {
+        var req = new NewOrderRequest
+        {
+            ClOrdID = new ClOrdID(99UL),
+            SecurityId = 1,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            OrderQty = 10,
+            Price = 0.05m,
+            Account = 1,
+        };
+        var buffer = new byte[512];
+        var len = OrderEntryEncoder.EncodeNewOrderSingle(buffer, req, Opts(), msgSeqNum: 3);
+        var (_, tid) = ReadFrameHeader(buffer);
+        Assert.True(len > 0);
+        Assert.Equal((ushort)102, tid);
+    }
+
+    [Fact]
+    public void EncodeOrderCancelReplace_WritesTemplateId_104()
+    {
+        var req = new ReplaceOrderRequest
+        {
+            ClOrdID = new ClOrdID(2UL),
+            OrigClOrdID = new ClOrdID(1UL),
+            SecurityId = 1,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            OrderQty = 20,
+            Price = 0.10m,
+        };
+        var buffer = new byte[512];
+        var len = OrderEntryEncoder.EncodeOrderCancelReplace(buffer, req, Opts(), msgSeqNum: 4);
+        var (_, tid) = ReadFrameHeader(buffer);
+        Assert.True(len > 0);
+        Assert.Equal((ushort)104, tid);
+    }
+
+    [Fact]
+    public void EncodeSimpleModifyOrder_WritesTemplateId_101()
+    {
+        var req = new SimpleModifyRequest
+        {
+            ClOrdID = new ClOrdID(2UL),
+            OrigClOrdID = new ClOrdID(1UL),
+            SecurityId = 1,
+            Side = Side.Buy,
+            OrderType = SimpleOrderType.Limit,
+            OrderQty = 15,
+            Price = 1.0m,
+        };
+        var buffer = new byte[256];
+        var len = OrderEntryEncoder.EncodeSimpleModifyOrder(buffer, req, Opts(), msgSeqNum: 5);
+        var (_, tid) = ReadFrameHeader(buffer);
+        Assert.True(len > 0);
+        Assert.Equal((ushort)101, tid);
+    }
+
+    [Fact]
+    public void EncodeOrderMassAction_WritesTemplateId_701_FixedLength()
+    {
+        var req = new MassActionRequest
+        {
+            ClOrdID = new ClOrdID(7UL),
+            ActionType = MassActionType.CancelOrders,
+            Scope = MassActionScope.AllOrdersForATradingSession,
+            SecurityId = 1,
+            Side = Side.Buy,
+        };
+        var buffer = new byte[128];
+        var len = OrderEntryEncoder.EncodeOrderMassAction(buffer, req, Opts(), msgSeqNum: 6);
+        var (sofhLen, tid) = ReadFrameHeader(buffer);
+        Assert.Equal(len, sofhLen);
+        Assert.Equal((ushort)701, tid);
+    }
+}

--- a/tests/B3.EntryPoint.Client.Tests/Models/CancelOrderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Models/CancelOrderTests.cs
@@ -12,12 +12,13 @@ public class CancelOrderTests
     {
         var req = new CancelOrderRequest
         {
-            ClOrdID = new ClOrdID("C1"),
-            OrigClOrdID = new ClOrdID("O1"),
+            ClOrdID = new ClOrdID(2UL),
+            OrigClOrdID = new ClOrdID(3UL),
             SecurityId = 1,
             Side = Side.Buy,
         };
-        Assert.Equal("C1", req.ClOrdID.Value);
+        Assert.Equal(2UL, req.ClOrdID.Value);
+        Assert.Equal(3UL, req.OrigClOrdID.Value);
     }
 
     [Fact]
@@ -25,7 +26,7 @@ public class CancelOrderTests
     {
         var req = new MassActionRequest
         {
-            ClOrdID = new ClOrdID("M1"),
+            ClOrdID = new ClOrdID(4UL),
             ActionType = MassActionType.CancelOrders,
         };
         Assert.Equal(MassActionScope.AllOrdersForATradingSession, req.Scope);
@@ -36,7 +37,7 @@ public class CancelOrderTests
     {
         var rpt = new MassActionReport
         {
-            ClOrdID = new ClOrdID("M1"),
+            ClOrdID = new ClOrdID(5UL),
             Response = MassActionResponse.Accepted,
             ActionType = MassActionType.CancelOrders,
             Scope = MassActionScope.AllOrdersForATradingSession,
@@ -60,8 +61,8 @@ public class CancelOrderTests
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             client.CancelAsync(new CancelOrderRequest
             {
-                ClOrdID = new ClOrdID("C"),
-                OrigClOrdID = new ClOrdID("O"),
+                ClOrdID = new ClOrdID(6UL),
+                OrigClOrdID = new ClOrdID(7UL),
                 SecurityId = 1,
                 Side = Side.Buy,
             }));

--- a/tests/B3.EntryPoint.Client.Tests/Models/EntryPointEventsTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Models/EntryPointEventsTests.cs
@@ -11,7 +11,7 @@ public class EntryPointEventsTests
         {
             SeqNum = 1,
             SendingTime = DateTimeOffset.UnixEpoch,
-            ClOrdID = new ClOrdID("X"),
+            ClOrdID = new ClOrdID(2UL),
             OrderId = 100,
             OrderStatus = OrderStatus.New,
             SecurityId = 1,
@@ -27,7 +27,7 @@ public class EntryPointEventsTests
         {
             SeqNum = 2,
             SendingTime = DateTimeOffset.UnixEpoch,
-            ClOrdID = new ClOrdID("X"),
+            ClOrdID = new ClOrdID(3UL),
             OrderId = 100,
             TradeId = 200,
             OrderStatus = OrderStatus.PartiallyFilled,
@@ -58,8 +58,8 @@ public class EntryPointEventsTests
         {
             SeqNum = 4,
             SendingTime = DateTimeOffset.UnixEpoch,
-            ClOrdID = new ClOrdID("X"),
-            OrigClOrdID = new ClOrdID("O"),
+            ClOrdID = new ClOrdID(4UL),
+            OrigClOrdID = new ClOrdID(5UL),
             OrderId = 1,
             OrderStatus = OrderStatus.Cancelled,
             RestatementReason = ExecRestatementReason.CancelOnTerminate,

--- a/tests/B3.EntryPoint.Client.Tests/Models/OrderModelsTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Models/OrderModelsTests.cs
@@ -6,20 +6,23 @@ namespace B3.EntryPoint.Client.Tests.Models;
 public class OrderModelsTests
 {
     [Fact]
-    public void ClOrdID_RejectsEmpty() =>
-        Assert.Throws<ArgumentException>(() => new ClOrdID(""));
+    public void ClOrdID_RejectsZero() =>
+        Assert.Throws<ArgumentException>(() => new ClOrdID(0UL));
 
     [Fact]
-    public void ClOrdID_RejectsTooLong() =>
-        Assert.Throws<ArgumentException>(() => new ClOrdID(new string('A', 21)));
-
-    [Fact]
-    public void ClOrdID_AcceptsUpToMax()
+    public void ClOrdID_Parse_RoundTrips()
     {
-        var id = new ClOrdID(new string('A', 20));
-        Assert.Equal(20, id.Value.Length);
-        string s = id;
-        Assert.Equal(id.Value, s);
+        var id = ClOrdID.Parse("12345");
+        Assert.Equal(12345UL, id.Value);
+        Assert.Equal("12345", id.ToString());
+    }
+
+    [Fact]
+    public void ClOrdID_AcceptsArbitraryUlong()
+    {
+        var id = new ClOrdID(ulong.MaxValue);
+        ulong raw = id;
+        Assert.Equal(ulong.MaxValue, raw);
     }
 
     [Fact]
@@ -27,14 +30,14 @@ public class OrderModelsTests
     {
         var req = new NewOrderRequest
         {
-            ClOrdID = new ClOrdID("ORD-1"),
+            ClOrdID = new ClOrdID(3UL),
             SecurityId = 12345,
             Side = Side.Buy,
             OrderType = OrderType.Limit,
             OrderQty = 100,
             Price = 12.34m,
         };
-        Assert.Equal("ORD-1", req.ClOrdID.Value);
+        Assert.Equal(3UL, req.ClOrdID.Value);
         Assert.Equal(TimeInForce.Day, req.TimeInForce);
         Assert.Equal(AccountType.RegularAccount, req.AccountType);
     }
@@ -44,7 +47,7 @@ public class OrderModelsTests
     {
         var req = new SimpleNewOrderRequest
         {
-            ClOrdID = new ClOrdID("S1"),
+            ClOrdID = new ClOrdID(4UL),
             SecurityId = 1,
             Side = Side.Sell,
             OrderType = SimpleOrderType.Market,
@@ -60,7 +63,7 @@ public class OrderModelsTests
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             client.SubmitAsync(new NewOrderRequest
             {
-                ClOrdID = new ClOrdID("X"),
+                ClOrdID = new ClOrdID(5UL),
                 SecurityId = 1,
                 Side = Side.Buy,
                 OrderType = OrderType.Market,

--- a/tests/B3.EntryPoint.Client.Tests/Models/ReplaceOrderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Models/ReplaceOrderTests.cs
@@ -12,16 +12,16 @@ public class ReplaceOrderTests
     {
         var req = new ReplaceOrderRequest
         {
-            ClOrdID = new ClOrdID("R1"),
-            OrigClOrdID = new ClOrdID("O1"),
+            ClOrdID = new ClOrdID(2UL),
+            OrigClOrdID = new ClOrdID(3UL),
             SecurityId = 1,
             Side = Side.Buy,
             OrderType = OrderType.Limit,
             OrderQty = 10,
             Price = 5.0m,
         };
-        Assert.Equal("R1", req.ClOrdID.Value);
-        Assert.Equal("O1", req.OrigClOrdID.Value);
+        Assert.Equal(2UL, req.ClOrdID.Value);
+        Assert.Equal(3UL, req.OrigClOrdID.Value);
     }
 
     [Fact]
@@ -29,8 +29,8 @@ public class ReplaceOrderTests
     {
         var req = new SimpleModifyRequest
         {
-            ClOrdID = new ClOrdID("R1"),
-            OrigClOrdID = new ClOrdID("O1"),
+            ClOrdID = new ClOrdID(4UL),
+            OrigClOrdID = new ClOrdID(5UL),
             SecurityId = 1,
             Side = Side.Sell,
             OrderType = SimpleOrderType.Limit,
@@ -55,8 +55,8 @@ public class ReplaceOrderTests
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             client.ReplaceAsync(new ReplaceOrderRequest
             {
-                ClOrdID = new ClOrdID("R"),
-                OrigClOrdID = new ClOrdID("O"),
+                ClOrdID = new ClOrdID(6UL),
+                OrigClOrdID = new ClOrdID(7UL),
                 SecurityId = 1,
                 Side = Side.Buy,
                 OrderType = OrderType.Limit,

--- a/tests/B3.EntryPoint.Conformance/OrderEntry_Cancel/CancelHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/OrderEntry_Cancel/CancelHappyPathTests.cs
@@ -24,8 +24,8 @@ public class CancelHappyPathTests
         await client.ConnectAsync();
         await client.CancelAsync(new CancelOrderRequest
         {
-            ClOrdID = new ClOrdID($"C-{Guid.NewGuid():N}".Substring(0, 20)),
-            OrigClOrdID = new ClOrdID("ORIG"),
+            ClOrdID = new ClOrdID((ulong)(uint)Guid.NewGuid().GetHashCode() | 1UL),
+            OrigClOrdID = new ClOrdID(2UL),
             SecurityId = 1,
             Side = Side.Buy,
         });

--- a/tests/B3.EntryPoint.Conformance/OrderEntry_NewOrder/NewOrderHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/OrderEntry_NewOrder/NewOrderHappyPathTests.cs
@@ -24,7 +24,7 @@ public class NewOrderHappyPathTests
 
         await client.ConnectAsync();
 
-        var clOrdId = new ClOrdID($"CONF-{Guid.NewGuid():N}".Substring(0, 20));
+        var clOrdId = new ClOrdID((ulong)(uint)Guid.NewGuid().GetHashCode() | 1UL);
         await client.SubmitAsync(new NewOrderRequest
         {
             ClOrdID = clOrdId,

--- a/tests/B3.EntryPoint.Conformance/OrderEntry_Replace/ReplaceHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/OrderEntry_Replace/ReplaceHappyPathTests.cs
@@ -24,8 +24,8 @@ public class ReplaceHappyPathTests
         await client.ConnectAsync();
         await client.ReplaceAsync(new ReplaceOrderRequest
         {
-            ClOrdID = new ClOrdID($"R-{Guid.NewGuid():N}".Substring(0, 20)),
-            OrigClOrdID = new ClOrdID("ORIG"),
+            ClOrdID = new ClOrdID((ulong)(uint)Guid.NewGuid().GetHashCode() | 1UL),
+            OrigClOrdID = new ClOrdID(2UL),
             SecurityId = 1,
             Side = Side.Buy,
             OrderType = OrderType.Limit,


### PR DESCRIPTION
Wires Order Entry submission/replace/cancel/mass-action methods on `EntryPointClient` to real SBE encoders + framed sends.

## Changes
- `Models/ClOrdID`: refactored to `readonly record struct(ulong)` matching schema (uint64). Public API breaking; `Parse(string)` provided for ergonomics.
- `EntryPointClientOptions`: new wire-up options `SenderLocation`, `EnteringTrader`, `DefaultMarketSegmentId`.
- `Fixp/OrderEntryEncoder`: NEW. Internal static encoder for SimpleNewOrder (100), SimpleModifyOrder (101), NewOrderSingle (102), OrderCancelReplaceRequest (104), OrderCancelRequest (105), OrderMassActionRequest (701). Builds SOFH + SBE message header + payload.
- `Fixp/FixpClientSession`: adds `SendApplicationFrameAsync` + `NextOutboundSeqNum` (Interlocked counter).
- `EntryPointClient`: replaces `NotImplementedException` stubs in Submit/SubmitSimple/Replace/ReplaceSimple/Cancel/MassAction with encoder + send.

## Tests
- New `OrderEntryEncoderTests` (6 cases) verify SOFH length + SBE templateId per message family.
- All existing tests refactored for ulong ClOrdID.
- 61 unit tests passing; 8 conformance still skip-by-default.

## Out of scope (follow-ups)
- Inbound dispatch of ExecutionReports / MassActionReport (#23).
- Outbound MsgSeqNum is currently a session-local Interlocked counter; full §4.6 KeepAlive/Sequence integration in #24.