### PR TITLE
feat(wire): inbound dispatcher decodes ER family + BMR into typed events (#23)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -1,5 +1,6 @@
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using B3.Entrypoint.Fixp.Sbe.V6;
 using B3.EntryPoint.Client.Fixp;
 using B3.EntryPoint.Client.Models;
@@ -17,6 +18,12 @@ namespace B3.EntryPoint.Client;
 public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceOrder, ICancelOrder
 {
     private readonly EntryPointClientOptions _options;
+    private readonly Channel<EntryPointEvent> _events =
+        Channel.CreateUnbounded<EntryPointEvent>(new UnboundedChannelOptions
+        {
+            SingleReader = false,
+            SingleWriter = true,
+        });
     private TcpClient? _tcp;
     private FixpClientSession? _session;
 
@@ -60,6 +67,7 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
 
         await _session.NegotiateAsync(ct).ConfigureAwait(false);
         await _session.EstablishAsync(ct).ConfigureAwait(false);
+        _session.StartInboundLoop(_events.Writer);
     }
 
     /// <inheritdoc />
@@ -184,8 +192,8 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     public async IAsyncEnumerable<EntryPointEvent> Events([EnumeratorCancellation] CancellationToken ct = default)
     {
         EnsureEstablished();
-        await Task.CompletedTask.ConfigureAwait(false);
-        yield break;
+        await foreach (var evt in _events.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            yield return evt;
     }
 
     public async ValueTask DisposeAsync()

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -1,9 +1,11 @@
 using System.Buffers.Binary;
 using System.Net;
 using System.Text;
+using System.Threading.Channels;
 using B3.Entrypoint.Fixp.Sbe.V6;
 using B3.EntryPoint.Client.Auth;
 using B3.EntryPoint.Client.Framing;
+using B3.EntryPoint.Client.Models;
 using SbeTerminationCode = B3.Entrypoint.Fixp.Sbe.V6.TerminationCode;
 
 namespace B3.EntryPoint.Client.Fixp;
@@ -116,11 +118,52 @@ internal sealed class FixpClientSession : IAsyncDisposable
     }
 
     private long _outboundSeqNum;
+    private Task? _inboundLoop;
+    private CancellationTokenSource? _inboundCts;
+    private ChannelWriter<EntryPointEvent>? _eventWriter;
 
     /// <summary>
-    /// Sends an Order Entry application frame previously encoded into <paramref name="buffer"/>
-    /// via <see cref="OrderEntryEncoder"/>. The first <paramref name="length"/> bytes are flushed.
+    /// Starts the inbound dispatch loop. Decoded application events are written to
+    /// <paramref name="writer"/>; session-layer messages (Sequence/NotApplied/etc.)
+    /// are silently consumed for now (#24/#25 will surface them).
+    /// Must be called after <see cref="EstablishAsync"/>.
     /// </summary>
+    public void StartInboundLoop(ChannelWriter<EntryPointEvent> writer)
+    {
+        if (_inboundLoop is not null)
+            throw new InvalidOperationException("Inbound loop already running.");
+        _eventWriter = writer;
+        _inboundCts = new CancellationTokenSource();
+        _inboundLoop = Task.Run(() => RunInboundLoopAsync(_inboundCts.Token));
+    }
+
+    private async Task RunInboundLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var frame = await SofhFrameReader.ReadFrameAsync(_stream, ct).ConfigureAwait(false);
+                if (frame.Length < SofhSize + SbeHeaderSize) continue;
+                if (InboundDecoder.TryDecode(frame, out var evt) && evt is not null)
+                {
+                    await _eventWriter!.WriteAsync(evt, ct).ConfigureAwait(false);
+                }
+                // else: session-layer (Sequence/NotApplied/Terminate/...) — handled in #24-#26.
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+        catch (EndOfStreamException) { /* peer closed */ }
+        catch (IOException) { /* peer closed */ }
+        catch (Exception ex)
+        {
+            _eventWriter?.TryComplete(ex);
+            return;
+        }
+        _eventWriter?.TryComplete();
+    }
+
+    /// <summary>Sends an Order Entry application frame previously encoded via <see cref="OrderEntryEncoder"/>.</summary>
     public async Task SendApplicationFrameAsync(byte[] buffer, int length, CancellationToken ct)
     {
         if (_machine.State != FixpClientState.Established)
@@ -135,6 +178,12 @@ internal sealed class FixpClientSession : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        try { _inboundCts?.Cancel(); } catch { /* ignore */ }
+        if (_inboundLoop is not null)
+        {
+            try { await _inboundLoop.ConfigureAwait(false); } catch { /* ignore */ }
+        }
+        _inboundCts?.Dispose();
         try { await TerminateAsync(SbeTerminationCode.FINISHED, CancellationToken.None).ConfigureAwait(false); }
         catch { /* best-effort */ }
         await _stream.DisposeAsync().ConfigureAwait(false);

--- a/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
@@ -1,0 +1,202 @@
+using System.Runtime.InteropServices;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.EntryPoint.Client.Models;
+using ClientCancelled = B3.EntryPoint.Client.Models.OrderCancelled;
+using ClientEvent = B3.EntryPoint.Client.Models.EntryPointEvent;
+using ClientForwarded = B3.EntryPoint.Client.Models.OrderForwarded;
+using ClientModified = B3.EntryPoint.Client.Models.OrderModified;
+using ClientReject = B3.EntryPoint.Client.Models.OrderRejected;
+using ClientTrade = B3.EntryPoint.Client.Models.OrderTrade;
+using ClientAccepted = B3.EntryPoint.Client.Models.OrderAccepted;
+using ClientBusinessReject = B3.EntryPoint.Client.Models.BusinessReject;
+using SbeBmr = B3.Entrypoint.Fixp.Sbe.V6.BusinessMessageRejectData;
+using SbeErCancel = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_CancelData;
+using SbeErForward = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_ForwardData;
+using SbeErModify = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_ModifyData;
+using SbeErNew = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_NewData;
+using SbeErReject = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_RejectData;
+using SbeErTrade = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_TradeData;
+using ClientClOrdID = B3.EntryPoint.Client.Models.ClOrdID;
+
+namespace B3.EntryPoint.Client.Fixp;
+
+/// <summary>
+/// Decodes inbound application messages (ExecutionReport family + BusinessMessageReject)
+/// into the typed <see cref="EntryPointEvent"/> records exposed via
+/// <see cref="EntryPointClient.Events"/>.
+/// </summary>
+internal static class InboundDecoder
+{
+    private const int SofhSize = 4;
+    private const int SbeHeaderSize = 8;
+
+    /// <summary>Reads templateId (uint16 LE at SOFH+2) from a SOFH-framed SBE message.</summary>
+    public static ushort ReadTemplateId(ReadOnlySpan<byte> frame) =>
+        System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(frame.Slice(SofhSize + 2, 2));
+
+    /// <summary>
+    /// Decodes a SOFH-framed inbound message into an <see cref="EntryPointEvent"/>, if it
+    /// belongs to a known application template. Returns false for session-layer messages
+    /// (Sequence, NotApplied, Retransmission, Terminate, etc.) which the caller handles.
+    /// </summary>
+    public static bool TryDecode(ReadOnlySpan<byte> frame, out ClientEvent? evt)
+    {
+        evt = null;
+        if (frame.Length < SofhSize + SbeHeaderSize)
+            return false;
+        var templateId = ReadTemplateId(frame);
+        var payload = frame[(SofhSize + SbeHeaderSize)..];
+
+        switch (templateId)
+        {
+            case SbeErNew.MESSAGE_ID:
+                evt = DecodeNew(payload);
+                return true;
+            case SbeErModify.MESSAGE_ID:
+                evt = DecodeModify(payload);
+                return true;
+            case SbeErCancel.MESSAGE_ID:
+                evt = DecodeCancel(payload);
+                return true;
+            case SbeErTrade.MESSAGE_ID:
+                evt = DecodeTrade(payload);
+                return true;
+            case SbeErReject.MESSAGE_ID:
+                evt = DecodeReject(payload);
+                return true;
+            case SbeErForward.MESSAGE_ID:
+                evt = DecodeForward(payload);
+                return true;
+            case SbeBmr.MESSAGE_ID:
+                evt = DecodeBmr(payload);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    // -- private decoders ----------------------------------------------------
+
+    private static ClientAccepted DecodeNew(ReadOnlySpan<byte> payload)
+    {
+        ref readonly var msg = ref MemoryMarshal.AsRef<SbeErNew>(payload);
+        return new ClientAccepted
+        {
+            SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
+            SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
+            ClOrdID = new ClientClOrdID(msg.ClOrdID.Value),
+            OrderId = msg.OrderID.Value,
+            OrderStatus = (OrderStatus)(byte)msg.OrdStatus,
+            SecurityId = msg.SecurityID.Value,
+            Side = (Models.Side)(byte)msg.Side,
+            TransactTime = ToDateTime(msg.TransactTime.Time),
+        };
+    }
+
+    private static ClientModified DecodeModify(ReadOnlySpan<byte> payload)
+    {
+        ref readonly var msg = ref MemoryMarshal.AsRef<SbeErModify>(payload);
+        return new ClientModified
+        {
+            SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
+            SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
+            ClOrdID = new ClientClOrdID(msg.ClOrdID.Value),
+            OrigClOrdID = new ClientClOrdID(msg.OrigClOrdID ?? 0UL),
+            OrderId = msg.OrderID.Value,
+            OrderStatus = (OrderStatus)(byte)msg.OrdStatus,
+            LeavesQty = msg.LeavesQty.Value,
+            CumQty = msg.CumQty.Value,
+            TransactTime = ToDateTime(msg.TransactTime.Time),
+        };
+    }
+
+    private static ClientCancelled DecodeCancel(ReadOnlySpan<byte> payload)
+    {
+        ref readonly var msg = ref MemoryMarshal.AsRef<SbeErCancel>(payload);
+        return new ClientCancelled
+        {
+            SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
+            SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
+            ClOrdID = new ClientClOrdID(msg.ClOrdID.Value),
+            OrigClOrdID = null,
+            OrderId = msg.OrderID.Value,
+            OrderStatus = (OrderStatus)(byte)msg.OrdStatus,
+            TransactTime = ToDateTime(msg.TransactTime.Time),
+        };
+    }
+
+    private static ClientTrade DecodeTrade(ReadOnlySpan<byte> payload)
+    {
+        ref readonly var msg = ref MemoryMarshal.AsRef<SbeErTrade>(payload);
+        return new ClientTrade
+        {
+            SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
+            SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
+            ClOrdID = new ClientClOrdID(msg.ClOrdID ?? 0UL),
+            OrderId = msg.OrderID.Value,
+            TradeId = msg.TradeID.Value,
+            OrderStatus = (OrderStatus)(byte)msg.OrdStatus,
+            LastPx = MantissaToDecimal(msg.LastPx.Mantissa),
+            LastQty = msg.LastQty.Value,
+            LeavesQty = msg.LeavesQty.Value,
+            CumQty = msg.CumQty.Value,
+            TransactTime = ToDateTime(msg.TransactTime.Time),
+        };
+    }
+
+    private static ClientReject DecodeReject(ReadOnlySpan<byte> payload)
+    {
+        ref readonly var msg = ref MemoryMarshal.AsRef<SbeErReject>(payload);
+        return new ClientReject
+        {
+            SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
+            SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
+            ClOrdID = new ClientClOrdID(msg.ClOrdID.Value),
+            OrderId = 0UL,
+            RejectCode = (ushort)msg.OrdRejReason.Value,
+            TransactTime = ToDateTime(msg.TransactTime.Time),
+        };
+    }
+
+    private static ClientForwarded DecodeForward(ReadOnlySpan<byte> payload)
+    {
+        ref readonly var msg = ref MemoryMarshal.AsRef<SbeErForward>(payload);
+        // Forward doesn't carry a top-level ClOrdID; use SecondaryOrderID as the order id.
+        return new ClientForwarded
+        {
+            SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
+            SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
+            ClOrdID = new ClientClOrdID(msg.SecondaryOrderID.Value),
+            OrderId = msg.SecondaryOrderID.Value,
+            TransactTime = ToDateTime(msg.TransactTime.Time),
+        };
+    }
+
+    private static ClientBusinessReject DecodeBmr(ReadOnlySpan<byte> payload)
+    {
+        ref readonly var msg = ref MemoryMarshal.AsRef<SbeBmr>(payload);
+        return new ClientBusinessReject
+        {
+            SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
+            SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
+            RefSeqNum = msg.RefSeqNum.Value,
+            RejectReason = (ushort)msg.BusinessRejectReason.Value,
+        };
+    }
+
+    private static DateTimeOffset ToDateTime(ulong unixNanos)
+    {
+        if (unixNanos == 0UL) return DateTimeOffset.MinValue;
+        var ticks = (long)(unixNanos / 100UL);
+        return DateTimeOffset.UnixEpoch.AddTicks(ticks);
+    }
+
+    private static DateTimeOffset ToDateTime(ulong? unixNanos) =>
+        unixNanos.HasValue ? ToDateTime(unixNanos.Value) : DateTimeOffset.MinValue;
+
+    private static decimal MantissaToDecimal(long mantissa)
+    {
+        // Schema fixes Exponent at -4 for prices.
+        return mantissa / 10_000m;
+    }
+}

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/InboundDecoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/InboundDecoderTests.cs
@@ -1,0 +1,94 @@
+using System.Buffers.Binary;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Framing;
+using B3.EntryPoint.Client.Models;
+using ClientAccepted = B3.EntryPoint.Client.Models.OrderAccepted;
+using ClientReject = B3.EntryPoint.Client.Models.BusinessReject;
+
+namespace B3.EntryPoint.Client.Tests.Fixp;
+
+public class InboundDecoderTests
+{
+    private const int SofhSize = SofhFrameWriter.HeaderSize;
+    private const int SbeHeaderSize = MessageHeader.MESSAGE_SIZE;
+
+    private static byte[] BuildFrame(ushort templateId, int payloadSize, Action<Span<byte>> writePayload)
+    {
+        // Allocate generous trailing room for encoders that write var-data sections.
+        var total = SofhSize + SbeHeaderSize + payloadSize + 16;
+        var buffer = new byte[total];
+        SofhFrameWriter.WriteHeader(buffer, checked((ushort)total));
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(SofhSize, 2), (ushort)payloadSize);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(SofhSize + 2, 2), templateId);
+        writePayload(buffer.AsSpan(SofhSize + SbeHeaderSize));
+        return buffer;
+    }
+
+    [Fact]
+    public void TryDecode_ExecutionReportNew_ReturnsOrderAccepted()
+    {
+        var msg = new ExecutionReport_NewData
+        {
+            BusinessHeader = new OutboundBusinessHeader
+            {
+                SessionID = 1,
+                MsgSeqNum = new SeqNum(42),
+            },
+            Side = B3.Entrypoint.Fixp.Sbe.V6.Side.BUY,
+            OrdStatus = OrdStatus.NEW,
+            ClOrdID = new B3.Entrypoint.Fixp.Sbe.V6.ClOrdID(7777UL),
+            OrderID = new OrderID(123456UL),
+            SecurityID = new SecurityID(9UL),
+            TransactTime = new UTCTimestampNanos { Time = 1_700_000_000_000_000_000UL },
+        };
+
+        var frame = BuildFrame(ExecutionReport_NewData.MESSAGE_ID, ExecutionReport_NewData.MESSAGE_SIZE, span =>
+        {
+            if (!ExecutionReport_NewData.TryEncode(msg, span, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, out _))
+                throw new InvalidOperationException("encode failed");
+        });
+
+        Assert.True(InboundDecoder.TryDecode(frame, out var evt));
+        var accepted = Assert.IsType<ClientAccepted>(evt);
+        Assert.Equal(42UL, accepted.SeqNum);
+        Assert.Equal(7777UL, accepted.ClOrdID.Value);
+        Assert.Equal(123456UL, accepted.OrderId);
+    }
+
+    [Fact]
+    public void TryDecode_BusinessMessageReject_ReturnsBusinessReject()
+    {
+        var msg = new BusinessMessageRejectData
+        {
+            BusinessHeader = new OutboundBusinessHeader
+            {
+                SessionID = 1,
+                MsgSeqNum = new SeqNum(99),
+            },
+            RefMsgType = MessageType.NewOrderSingle,
+            RefSeqNum = new SeqNum(7),
+            BusinessRejectReason = new RejReason(11),
+        };
+
+        var frame = BuildFrame(BusinessMessageRejectData.MESSAGE_ID, BusinessMessageRejectData.MESSAGE_SIZE, span =>
+        {
+            if (!msg.TryEncode(span, out _))
+                throw new InvalidOperationException("encode failed");
+        });
+
+        Assert.True(InboundDecoder.TryDecode(frame, out var evt));
+        var reject = Assert.IsType<ClientReject>(evt);
+        Assert.Equal(99UL, reject.SeqNum);
+        Assert.Equal(7UL, reject.RefSeqNum);
+        Assert.Equal((ushort)11, reject.RejectReason);
+    }
+
+    [Fact]
+    public void TryDecode_UnknownTemplate_ReturnsFalse()
+    {
+        var frame = BuildFrame(9999, 0, _ => { });
+        Assert.False(InboundDecoder.TryDecode(frame, out var evt));
+        Assert.Null(evt);
+    }
+}


### PR DESCRIPTION
Decodes inbound application messages and pushes them through the public `EntryPointClient.Events()` async stream.

## Changes
- `Fixp/InboundDecoder`: NEW. Static `TryDecode(frame, out EntryPointEvent?)` that recognises ExecutionReport_New/Modify/Cancel/Trade/Reject/Forward + BusinessMessageReject and overlays the SBE struct via `MemoryMarshal.AsRef`.
- `FixpClientSession.StartInboundLoop(ChannelWriter<EntryPointEvent>)`: NEW. Background loop reads SOFH frames, decodes, writes to channel; session-layer messages (Sequence/NotApplied/Terminate) are silently consumed for #24-#26.
- `EntryPointClient`: owns an unbounded `Channel<EntryPointEvent>`; wires it to the session after Establish; `Events()` now drains the channel via `ReadAllAsync`.

## Tests
- New `InboundDecoderTests` (3 cases): ER_New round-trip, BusinessMessageReject round-trip, unknown templateId returns false.
- 64 unit tests passing; 8 conformance still skip-by-default.

## Out of scope
- Sequence/NotApplied handling (#24).
- Retransmission gap detection (#25).
- Terminate-driven shutdown of the loop (#26).