### PR TITLE
feat(wire): KeepAlive scheduler sends/receives Sequence frames (#24)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -26,6 +26,10 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
         });
     private TcpClient? _tcp;
     private FixpClientSession? _session;
+    private KeepAliveScheduler? _keepAlive;
+
+    /// <summary>Keep-alive scheduler for this client. Bound after <see cref="ConnectAsync"/>.</summary>
+    public IKeepAliveScheduler? KeepAlive => _keepAlive;
 
     public EntryPointClient(EntryPointClientOptions options)
     {
@@ -68,6 +72,13 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
         await _session.NegotiateAsync(ct).ConfigureAwait(false);
         await _session.EstablishAsync(ct).ConfigureAwait(false);
         _session.StartInboundLoop(_events.Writer);
+
+        _keepAlive = new KeepAliveScheduler(
+            _options.KeepAliveInterval,
+            sendSequence: (seq, token) => _session.SendSequenceAsync(seq, token),
+            nextSeqNo: () => _session.NextOutboundSeqNum());
+        _session.OnInboundSequence = nextSeq => _keepAlive.RaiseFrameReceived(nextSeq, DateTimeOffset.UtcNow);
+        _keepAlive.Start();
     }
 
     /// <inheritdoc />
@@ -198,6 +209,8 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
 
     public async ValueTask DisposeAsync()
     {
+        _keepAlive?.Dispose();
+        _keepAlive = null;
         if (_session is not null)
             await _session.DisposeAsync().ConfigureAwait(false);
         _tcp?.Dispose();

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -149,7 +149,17 @@ internal sealed class FixpClientSession : IAsyncDisposable
                 {
                     await _eventWriter!.WriteAsync(evt, ct).ConfigureAwait(false);
                 }
-                // else: session-layer (Sequence/NotApplied/Terminate/...) — handled in #24-#26.
+                else
+                {
+                    var templateId = InboundDecoder.ReadTemplateId(frame);
+                    if (templateId == SequenceData.MESSAGE_ID && OnInboundSequence is not null)
+                    {
+                        var payload = frame.AsSpan(SofhSize + SbeHeaderSize);
+                        var seq = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload);
+                        OnInboundSequence(seq);
+                    }
+                    // else: NotApplied/Retransmission/Terminate — handled in #25/#26.
+                }
             }
         }
         catch (OperationCanceledException) { /* shutdown */ }
@@ -175,6 +185,27 @@ internal sealed class FixpClientSession : IAsyncDisposable
     /// <summary>Returns the next outbound MsgSeqNum and increments the counter.</summary>
     public ulong NextOutboundSeqNum() =>
         (ulong)System.Threading.Interlocked.Increment(ref _outboundSeqNum);
+
+    /// <summary>Sends a single FIXP <c>Sequence</c> frame announcing <paramref name="nextSeqNo"/>.</summary>
+    public async Task SendSequenceAsync(ulong nextSeqNo, CancellationToken ct)
+    {
+        var totalSize = SofhSize + SbeHeaderSize + SequenceData.MESSAGE_SIZE;
+        var buffer = new byte[totalSize];
+        SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
+        SequenceData.WriteHeader(buffer.AsSpan(SofhSize));
+        var payload = new SequenceData
+        {
+            NextSeqNo = new SeqNum(checked((uint)nextSeqNo)),
+        };
+        if (!payload.TryEncode(buffer.AsSpan(SofhSize + SbeHeaderSize), out _))
+            throw new InvalidOperationException("Failed to encode Sequence payload.");
+
+        await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
+        await _stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Optional hook: invoked by the inbound loop when a peer Sequence frame arrives.</summary>
+    internal Action<ulong>? OnInboundSequence { get; set; }
 
     public async ValueTask DisposeAsync()
     {

--- a/src/B3.EntryPoint.Client/Fixp/KeepAliveScheduler.cs
+++ b/src/B3.EntryPoint.Client/Fixp/KeepAliveScheduler.cs
@@ -1,18 +1,38 @@
 namespace B3.EntryPoint.Client.Fixp;
 
 /// <summary>
-/// Default <see cref="IKeepAliveScheduler"/>. API-surface stub — events and
-/// <see cref="KeepAliveInterval"/> are wired, but the periodic Sequence-frame
-/// send/receive loop is intentionally not implemented in this PR (issue #3).
+/// Default <see cref="IKeepAliveScheduler"/>. Sends a periodic <c>Sequence</c>
+/// frame on the bound transport every <see cref="KeepAliveInterval"/> and
+/// surfaces inbound peer <c>Sequence</c> frames through
+/// <see cref="SequenceFrameReceived"/> (spec §4.6).
 /// </summary>
-public sealed class KeepAliveScheduler : IKeepAliveScheduler
+public sealed class KeepAliveScheduler : IKeepAliveScheduler, IDisposable
 {
+    private readonly Func<ulong, CancellationToken, Task>? _sendSequence;
+    private readonly Func<ulong>? _nextSeqNo;
+    private CancellationTokenSource? _cts;
+    private Task? _loop;
+
+    /// <summary>
+    /// Public constructor — produces a scheduler with no transport bound.
+    /// Calling <see cref="Start"/> on such an instance throws; bind a
+    /// transport via <see cref="EntryPointClient"/> instead.
+    /// </summary>
     public KeepAliveScheduler(TimeSpan keepAliveInterval)
+        : this(keepAliveInterval, sendSequence: null, nextSeqNo: null)
+    { }
+
+    internal KeepAliveScheduler(
+        TimeSpan keepAliveInterval,
+        Func<ulong, CancellationToken, Task>? sendSequence,
+        Func<ulong>? nextSeqNo)
     {
         if (keepAliveInterval <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(keepAliveInterval),
                 "Keep-alive interval must be positive.");
         KeepAliveInterval = keepAliveInterval;
+        _sendSequence = sendSequence;
+        _nextSeqNo = nextSeqNo;
     }
 
     public TimeSpan KeepAliveInterval { get; }
@@ -21,26 +41,58 @@ public sealed class KeepAliveScheduler : IKeepAliveScheduler
 
     public event EventHandler<SequenceFrameEventArgs>? SequenceFrameReceived;
 
-    public void Start() => throw new NotImplementedException(
-        "KeepAliveScheduler.Start is not yet wired to the FIXP transport. Tracked by issue #3.");
+    public void Start()
+    {
+        if (_sendSequence is null || _nextSeqNo is null)
+            throw new InvalidOperationException(
+                "KeepAliveScheduler was constructed without a bound transport. " +
+                "Use EntryPointClient.ConnectAsync, which wires a scheduler internally.");
+        if (_loop is not null) return;
+        _cts = new CancellationTokenSource();
+        _loop = Task.Run(() => RunAsync(_cts.Token));
+    }
 
     public void Stop()
     {
-        // Idempotent no-op until Start is wired.
+        try { _cts?.Cancel(); } catch { /* ignore */ }
     }
 
-    /// <summary>
-    /// Test/internal hook that lets callers surface a synthetic outbound
-    /// Sequence frame through the public event. Will be replaced by the real
-    /// send loop in the follow-up implementation PR.
-    /// </summary>
+    public void Dispose()
+    {
+        Stop();
+        _cts?.Dispose();
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        using var timer = new PeriodicTimer(KeepAliveInterval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+            {
+                var seq = _nextSeqNo!();
+                try
+                {
+                    await _sendSequence!(seq, ct).ConfigureAwait(false);
+                    RaiseFrameSent(seq, DateTimeOffset.UtcNow);
+                }
+                catch (OperationCanceledException) { return; }
+                catch
+                {
+                    // Send failed (peer closed, IO error). Stop quietly; the
+                    // session-level error handling surfaces the disconnect.
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+    }
+
+    /// <summary>Internal hook used by tests and by the inbound dispatcher.</summary>
     internal void RaiseFrameSent(ulong nextSeqNo, DateTimeOffset at) =>
         SequenceFrameSent?.Invoke(this, new SequenceFrameEventArgs(nextSeqNo, at));
 
-    /// <summary>
-    /// Test/internal hook that lets the receive loop surface inbound Sequence
-    /// frames through the public event.
-    /// </summary>
+    /// <summary>Internal hook used by the inbound dispatcher when a Sequence frame arrives.</summary>
     internal void RaiseFrameReceived(ulong nextSeqNo, DateTimeOffset at) =>
         SequenceFrameReceived?.Invoke(this, new SequenceFrameEventArgs(nextSeqNo, at));
 }

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/KeepAliveSchedulerTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/KeepAliveSchedulerTests.cs
@@ -21,11 +21,11 @@ public class KeepAliveSchedulerTests
     }
 
     [Fact]
-    public void Start_ThrowsNotImplemented_PerIssue3()
+    public void Start_WithoutBoundTransport_Throws()
     {
         var s = new KeepAliveScheduler(TimeSpan.FromSeconds(1));
-        var ex = Assert.Throws<NotImplementedException>(s.Start);
-        Assert.Contains("issue #3", ex.Message);
+        var ex = Assert.Throws<InvalidOperationException>(s.Start);
+        Assert.Contains("transport", ex.Message);
     }
 
     [Fact]
@@ -65,5 +65,34 @@ public class KeepAliveSchedulerTests
     {
         IKeepAliveScheduler s = new KeepAliveScheduler(TimeSpan.FromMilliseconds(500));
         Assert.Equal(TimeSpan.FromMilliseconds(500), s.KeepAliveInterval);
+    }
+}
+
+public class KeepAliveSchedulerPeriodicTests
+{
+    [Fact]
+    public async Task Start_WithBoundTransport_InvokesSendCallbackPeriodically()
+    {
+        var ticks = new List<ulong>();
+        ulong nextSeq = 0;
+        Task SendAsync(ulong seq, CancellationToken ct)
+        {
+            lock (ticks) ticks.Add(seq);
+            return Task.CompletedTask;
+        }
+        var ctorInfo = typeof(B3.EntryPoint.Client.Fixp.KeepAliveScheduler).GetConstructors(
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .Single(c => c.GetParameters().Length == 3);
+        var scheduler = (B3.EntryPoint.Client.Fixp.KeepAliveScheduler)ctorInfo.Invoke(new object?[]
+        {
+            TimeSpan.FromMilliseconds(40),
+            (Func<ulong, CancellationToken, Task>)SendAsync,
+            (Func<ulong>)(() => System.Threading.Interlocked.Increment(ref nextSeq)),
+        });
+        scheduler.Start();
+        await Task.Delay(180);
+        scheduler.Stop();
+        scheduler.Dispose();
+        Assert.True(ticks.Count >= 2, $"expected >=2 ticks, got {ticks.Count}");
     }
 }


### PR DESCRIPTION
Implements §4.6 Sequence/Heartbeat: periodic outbound `Sequence` send via PeriodicTimer and inbound `Sequence` recognition.

## Changes
- `Fixp/KeepAliveScheduler`: rewritten. Adds internal ctor binding (sendSequenceCallback, nextSeqNo). `Start()` runs a PeriodicTimer loop on `KeepAliveInterval`; on each tick fetches next outbound seq, sends Sequence, raises `SequenceFrameSent`. Public ctor still allowed; `Start()` on an unbound instance throws `InvalidOperationException` (was `NotImplementedException` referencing #3 stub). Implements `IDisposable`.
- `Fixp/FixpClientSession.SendSequenceAsync(nextSeqNo)`: NEW. SOFH+SBE-frames a `SequenceData` and writes to stream.
- `Fixp/FixpClientSession` inbound loop: now recognises template-id 9 (Sequence) and invokes optional `OnInboundSequence` callback (used by scheduler to surface `SequenceFrameReceived`).
- `EntryPointClient`: wires a `KeepAliveScheduler` after Establish; exposes it via `KeepAlive` property. Disposes scheduler on shutdown.

## Tests
- Existing `Start_ThrowsNotImplemented_PerIssue3` updated to assert the new `InvalidOperationException`.
- New `Start_WithBoundTransport_InvokesSendCallbackPeriodically` exercises the full periodic loop with a fake send callback (40ms interval, asserts ≥2 ticks within 180ms).
- 65 unit tests pass; 8 conformance still skip-by-default.

## Out of scope
- Peer-watchdog (close session if no inbound for 3×interval) — left for #25/#26 wiring.