### PR TITLE
feat(wire): retransmit/notapplied wired (#25)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -27,9 +27,13 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     private TcpClient? _tcp;
     private FixpClientSession? _session;
     private KeepAliveScheduler? _keepAlive;
+    private RetransmitRequestHandler? _retransmit;
 
     /// <summary>Keep-alive scheduler for this client. Bound after <see cref="ConnectAsync"/>.</summary>
     public IKeepAliveScheduler? KeepAlive => _keepAlive;
+
+    /// <summary>Retransmit handler for this client. Bound after <see cref="ConnectAsync"/>.</summary>
+    public IRetransmitRequestHandler? Retransmit => _retransmit;
 
     public EntryPointClient(EntryPointClientOptions options)
     {
@@ -79,7 +83,20 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
             nextSeqNo: () => _session.NextOutboundSeqNum());
         _session.OnInboundSequence = nextSeq => _keepAlive.RaiseFrameReceived(nextSeq, DateTimeOffset.UtcNow);
         _keepAlive.Start();
+
+        _retransmit = new RetransmitRequestHandler(
+            sendRequest: (from, count, token) => _session.SendRetransmitRequestAsync(from, count, token));
+        _session.OnInboundRetransmission = (nextSeq, count, reqNanos) =>
+            _retransmit.RaiseRetransmissionReceived(nextSeq, count, NanosToOffset(reqNanos));
+        _session.OnInboundRetransmitReject = (code, reqNanos) =>
+            _retransmit.RaiseRetransmitRejected((B3.EntryPoint.Client.Fixp.RetransmitRejectCode)(byte)code, NanosToOffset(reqNanos));
+        _session.OnInboundNotApplied = (from, count) =>
+            _retransmit.RaiseNotAppliedReceived(from, count);
     }
+
+    private static DateTimeOffset NanosToOffset(ulong unixNanos) =>
+        unixNanos == 0UL ? DateTimeOffset.MinValue
+                         : DateTimeOffset.UnixEpoch.AddTicks((long)(unixNanos / 100UL));
 
     /// <inheritdoc />
     public async Task<ClOrdID> SubmitAsync(NewOrderRequest request, CancellationToken ct = default)

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -152,13 +152,42 @@ internal sealed class FixpClientSession : IAsyncDisposable
                 else
                 {
                     var templateId = InboundDecoder.ReadTemplateId(frame);
-                    if (templateId == SequenceData.MESSAGE_ID && OnInboundSequence is not null)
+                    var payload = frame.AsSpan(SofhSize + SbeHeaderSize);
+                    switch (templateId)
                     {
-                        var payload = frame.AsSpan(SofhSize + SbeHeaderSize);
-                        var seq = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload);
-                        OnInboundSequence(seq);
+                        case SequenceData.MESSAGE_ID:
+                            OnInboundSequence?.Invoke(System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload));
+                            break;
+                        case RetransmissionData.MESSAGE_ID:
+                            // SessionID(8) + RequestTimestamp(8) + NextSeqNo(4) + Count(4) = 24 bytes
+                            if (payload.Length >= RetransmissionData.MESSAGE_SIZE)
+                            {
+                                var reqTs = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload.Slice(8, 8));
+                                var nextSeq = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(16, 4));
+                                var cnt = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(20, 4));
+                                OnInboundRetransmission?.Invoke(nextSeq, cnt, reqTs);
+                            }
+                            break;
+                        case RetransmitRejectData.MESSAGE_ID:
+                            // SessionID(8) + RequestTimestamp(8) + Code(1)
+                            if (payload.Length >= RetransmitRejectData.MESSAGE_SIZE)
+                            {
+                                var reqTs = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload.Slice(8, 8));
+                                var code = (uint)payload[16];
+                                OnInboundRetransmitReject?.Invoke(code, reqTs);
+                            }
+                            break;
+                        case NotAppliedData.MESSAGE_ID:
+                            // FromSeqNo(4) + Count(4) = 8 bytes
+                            if (payload.Length >= NotAppliedData.MESSAGE_SIZE)
+                            {
+                                var fromSeq = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(0, 4));
+                                var cnt = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(4, 4));
+                                OnInboundNotApplied?.Invoke(fromSeq, cnt);
+                            }
+                            break;
+                        // Terminate handled in #26.
                     }
-                    // else: NotApplied/Retransmission/Terminate — handled in #25/#26.
                 }
             }
         }
@@ -204,8 +233,37 @@ internal sealed class FixpClientSession : IAsyncDisposable
         await _stream.FlushAsync(ct).ConfigureAwait(false);
     }
 
+    /// <summary>Sends a §4.7 RetransmitRequest covering [fromSeqNo, fromSeqNo+count).</summary>
+    public async Task SendRetransmitRequestAsync(ulong fromSeqNo, uint count, CancellationToken ct)
+    {
+        var totalSize = SofhSize + SbeHeaderSize + RetransmitRequestData.MESSAGE_SIZE;
+        var buffer = new byte[totalSize];
+        SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
+        RetransmitRequestData.WriteHeader(buffer.AsSpan(SofhSize));
+        var payload = new RetransmitRequestData
+        {
+            SessionID = _options.SessionId,
+            Timestamp = new UTCTimestampNanos { Time = (ulong)NowUnixNanos() },
+            FromSeqNo = new SeqNum(checked((uint)fromSeqNo)),
+            Count = new MessageCounter(count),
+        };
+        if (!payload.TryEncode(buffer.AsSpan(SofhSize + SbeHeaderSize), out _))
+            throw new InvalidOperationException("Failed to encode RetransmitRequest payload.");
+        await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
+        await _stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+
     /// <summary>Optional hook: invoked by the inbound loop when a peer Sequence frame arrives.</summary>
     internal Action<ulong>? OnInboundSequence { get; set; }
+
+    /// <summary>Optional hook: invoked when a Retransmission frame arrives. Args: (nextSeqNo, count, requestTimestampNanos).</summary>
+    internal Action<ulong, uint, ulong>? OnInboundRetransmission { get; set; }
+
+    /// <summary>Optional hook: invoked when a RetransmitReject frame arrives. Arg: rejectCode (uint).</summary>
+    internal Action<uint, ulong>? OnInboundRetransmitReject { get; set; }
+
+    /// <summary>Optional hook: invoked when a NotApplied frame arrives. Args: (fromSeqNo, count).</summary>
+    internal Action<ulong, uint>? OnInboundNotApplied { get; set; }
 
     public async ValueTask DisposeAsync()
     {

--- a/src/B3.EntryPoint.Client/Fixp/RetransmitRequestHandler.cs
+++ b/src/B3.EntryPoint.Client/Fixp/RetransmitRequestHandler.cs
@@ -1,30 +1,46 @@
 namespace B3.EntryPoint.Client.Fixp;
 
 /// <summary>
-/// Default <see cref="IRetransmitRequestHandler"/>. API-surface stub — events
-/// are wired and <see cref="RequestRetransmitAsync"/> validates the range, but
-/// the wire-level send loop is intentionally not implemented in this PR
-/// (issue #5).
+/// Default <see cref="IRetransmitRequestHandler"/>. Sends FIXP §4.7 RetransmitRequest
+/// frames and surfaces inbound Retransmission/RetransmitReject/NotApplied notifications.
 /// </summary>
 public sealed class RetransmitRequestHandler : IRetransmitRequestHandler
 {
     /// <summary>Maximum messages per <c>RetransmitRequest</c> (spec §4.7).</summary>
     public const uint MaxCountPerRequest = 1000;
 
+    private readonly Func<ulong, uint, CancellationToken, Task>? _sendRequest;
+
+    /// <summary>
+    /// Public constructor — produces an unbound handler.
+    /// <see cref="RequestRetransmitAsync"/> on such an instance throws; bind via
+    /// <see cref="EntryPointClient"/> instead.
+    /// </summary>
+    public RetransmitRequestHandler() : this(sendRequest: null) { }
+
+    internal RetransmitRequestHandler(Func<ulong, uint, CancellationToken, Task>? sendRequest)
+    {
+        _sendRequest = sendRequest;
+    }
+
     public event EventHandler<RetransmitRequestedEventArgs>? RetransmitRequested;
     public event EventHandler<RetransmissionEventArgs>? RetransmissionReceived;
     public event EventHandler<RetransmitRejectedEventArgs>? RetransmitRejected;
     public event EventHandler<NotAppliedEventArgs>? NotAppliedReceived;
 
-    public Task RequestRetransmitAsync(ulong fromSeqNo, uint count, CancellationToken ct = default)
+    public async Task RequestRetransmitAsync(ulong fromSeqNo, uint count, CancellationToken ct = default)
     {
         if (count is 0 or > MaxCountPerRequest)
             throw new ArgumentOutOfRangeException(nameof(count),
                 $"count must be in [1, {MaxCountPerRequest}].");
         if (fromSeqNo == 0)
             throw new ArgumentOutOfRangeException(nameof(fromSeqNo), "fromSeqNo must be > 0.");
-        throw new NotImplementedException(
-            "RequestRetransmitAsync is not yet wired to the FIXP transport. Tracked by issue #5.");
+        if (_sendRequest is null)
+            throw new InvalidOperationException(
+                "RetransmitRequestHandler was constructed without a bound transport. " +
+                "Use EntryPointClient.ConnectAsync, which wires a handler internally.");
+        await _sendRequest(fromSeqNo, count, ct).ConfigureAwait(false);
+        RaiseRetransmitRequested(fromSeqNo, count, DateTimeOffset.UtcNow);
     }
 
     internal void RaiseRetransmitRequested(ulong fromSeqNo, uint count, DateTimeOffset at) =>

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/RetransmitRequestHandlerTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/RetransmitRequestHandlerTests.cs
@@ -29,12 +29,38 @@ public class RetransmitRequestHandlerTests
     }
 
     [Fact]
-    public async Task Request_ValidRange_ThrowsNotImplemented()
+    public async Task Request_WithoutBoundTransport_Throws()
     {
         var h = new RetransmitRequestHandler();
-        var ex = await Assert.ThrowsAsync<NotImplementedException>(() =>
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             h.RequestRetransmitAsync(1, 1));
-        Assert.Contains("issue #5", ex.Message);
+        Assert.Contains("transport", ex.Message);
+    }
+
+    [Fact]
+    public async Task Request_BoundTransport_InvokesSendAndRaisesEvent()
+    {
+        var calls = new List<(ulong from, uint count)>();
+        Task SendAsync(ulong from, uint count, CancellationToken ct)
+        {
+            calls.Add((from, count));
+            return Task.CompletedTask;
+        }
+        var ctorInfo = typeof(RetransmitRequestHandler).GetConstructors(
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .Single(c => c.GetParameters().Length == 1);
+        var h = (RetransmitRequestHandler)ctorInfo.Invoke(new object?[]
+        {
+            (Func<ulong, uint, CancellationToken, Task>)SendAsync,
+        });
+        RetransmitRequestedEventArgs? raised = null;
+        h.RetransmitRequested += (_, e) => raised = e;
+        await h.RequestRetransmitAsync(7, 3);
+        Assert.Single(calls);
+        Assert.Equal(7UL, calls[0].from);
+        Assert.Equal(3u, calls[0].count);
+        Assert.NotNull(raised);
+        Assert.Equal(7UL, raised!.FromSeqNo);
     }
 
     [Fact]


### PR DESCRIPTION
Wires RetransmitRequestHandler to FixpClientSession transport. Sends RetransmitRequest frames, dispatches inbound Retransmission/RetransmitReject/NotApplied to handler events. 66 unit tests passing.