### PR TITLE
feat(wire): terminate/reconnect wired (#26)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -92,6 +92,8 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
             _retransmit.RaiseRetransmitRejected((B3.EntryPoint.Client.Fixp.RetransmitRejectCode)(byte)code, NanosToOffset(reqNanos));
         _session.OnInboundNotApplied = (from, count) =>
             _retransmit.RaiseNotAppliedReceived(from, count);
+        _session.OnInboundTerminate = code =>
+            RaiseTerminated((TerminationCode)code, reason: null, initiatedByClient: false);
     }
 
     private static DateTimeOffset NanosToOffset(ulong unixNanos) =>
@@ -188,12 +190,12 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     /// Send a graceful <c>Terminate</c> to the peer and tear down the session.
     /// API surface only — the wire-level encode lands in a follow-up PR (issue #6).
     /// </summary>
-    public Task TerminateAsync(TerminationCode code, CancellationToken ct = default)
+    public async Task TerminateAsync(TerminationCode code, CancellationToken ct = default)
     {
         if (_session is null)
             throw new InvalidOperationException("Client is not connected.");
-        throw new NotImplementedException(
-            "TerminateAsync(code) is not yet wired to the FIXP transport. Tracked by issue #6.");
+        await _session.TerminateAsync((B3.Entrypoint.Fixp.Sbe.V6.TerminationCode)(byte)code, ct).ConfigureAwait(false);
+        RaiseTerminated(code, reason: null, initiatedByClient: true);
     }
 
     /// <summary>
@@ -203,13 +205,30 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     /// otherwise the gateway terminates with
     /// <see cref="TerminationCode.InvalidSessionVerId"/>.
     /// </summary>
-    public Task ReconnectAsync(uint nextSessionVerId, CancellationToken ct = default)
+    public async Task ReconnectAsync(uint nextSessionVerId, CancellationToken ct = default)
     {
         if (nextSessionVerId <= _options.SessionVerId)
             throw new ArgumentOutOfRangeException(nameof(nextSessionVerId),
                 "Next SessionVerID must be strictly greater than the current one.");
-        throw new NotImplementedException(
-            "ReconnectAsync is not yet implemented. Tracked by issue #6.");
+
+        // Tear down current session/socket if any, then bump SessionVerID and re-handshake.
+        try
+        {
+            if (_session is not null)
+                await _session.TerminateAsync(B3.Entrypoint.Fixp.Sbe.V6.TerminationCode.FINISHED, ct).ConfigureAwait(false);
+        }
+        catch { /* best-effort */ }
+        _keepAlive?.Dispose();
+        _keepAlive = null;
+        _retransmit = null;
+        if (_session is not null)
+            await _session.DisposeAsync().ConfigureAwait(false);
+        _tcp?.Dispose();
+        _session = null;
+        _tcp = null;
+
+        _options.SessionVerId = nextSessionVerId;
+        await ConnectAsync(ct).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -11,7 +11,7 @@ public sealed class EntryPointClientOptions
     public required uint SessionId { get; init; }
 
     /// <summary>Session version identification — must increase on each new Negotiate.</summary>
-    public required uint SessionVerId { get; init; }
+    public required uint SessionVerId { get; set; }
 
     /// <summary>Identifies the broker firm that will enter orders.</summary>
     public required uint EnteringFirm { get; init; }

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -186,7 +186,16 @@ internal sealed class FixpClientSession : IAsyncDisposable
                                 OnInboundNotApplied?.Invoke(fromSeq, cnt);
                             }
                             break;
-                        // Terminate handled in #26.
+                        case TerminateData.MESSAGE_ID:
+                            // SessionID(4) + SessionVerID(8) + TerminationCode(1) = 13 bytes
+                            if (payload.Length >= TerminateData.MESSAGE_SIZE)
+                            {
+                                var code = payload[12];
+                                OnInboundTerminate?.Invoke(code);
+                            }
+                            // peer is shutting us down — exit loop
+                            _eventWriter?.TryComplete();
+                            return;
                     }
                 }
             }
@@ -264,6 +273,9 @@ internal sealed class FixpClientSession : IAsyncDisposable
 
     /// <summary>Optional hook: invoked when a NotApplied frame arrives. Args: (fromSeqNo, count).</summary>
     internal Action<ulong, uint>? OnInboundNotApplied { get; set; }
+
+    /// <summary>Optional hook: invoked when a Terminate frame arrives. Arg: terminationCode (byte).</summary>
+    internal Action<byte>? OnInboundTerminate { get; set; }
 
     public async ValueTask DisposeAsync()
     {

--- a/tests/B3.EntryPoint.Client.Tests/TerminateApiTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/TerminateApiTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using B3.EntryPoint.Client;
 using B3.EntryPoint.Client.Auth;
 
@@ -25,12 +26,12 @@ public class TerminateApiTests
     }
 
     [Fact]
-    public async Task ReconnectAsync_AcceptsIncreasingVerId_ButNotImplemented()
+    public async Task ReconnectAsync_AcceptsIncreasingVerId_AttemptsTcpConnect()
     {
         await using var c = MakeClient(sessionVerId: 5);
-        var ex = await Assert.ThrowsAsync<NotImplementedException>(() =>
-            c.ReconnectAsync(6));
-        Assert.Contains("issue #6", ex.Message);
+        // No socket listening on port 9999 → TCP connect must fail. The point is
+        // that the version check passes and ReconnectAsync proceeds to ConnectAsync.
+        await Assert.ThrowsAnyAsync<SocketException>(() => c.ReconnectAsync(6));
     }
 
     [Fact]


### PR DESCRIPTION
Wires EntryPointClient.TerminateAsync to FixpClientSession.TerminateAsync. Inbound Terminate frame is dispatched to Terminated event (initiatedByClient=false). ReconnectAsync tears down current session, bumps SessionVerId, then re-establishes via ConnectAsync.