### PR TITLE
feat(wire): drop copy ConnectAsync wired (#27)

### DIFF
--- a/src/B3.EntryPoint.Client/DropCopy/DropCopyClient.cs
+++ b/src/B3.EntryPoint.Client/DropCopy/DropCopyClient.cs
@@ -25,10 +25,11 @@ public sealed class DropCopyClient : IAsyncDisposable
         _inner = new EntryPointClient(options);
     }
 
-    /// <summary>Establishes the Drop Copy FIXP session.</summary>
+    /// <summary>Establishes the Drop Copy FIXP session (TCP + Negotiate + Establish, reusing
+    /// the underlying <see cref="EntryPointClient"/>). The Drop Copy entitlement is enforced
+    /// by the gateway against the firm; this client does not encode any submission frames.</summary>
     public Task ConnectAsync(CancellationToken cancellationToken = default)
-        => throw new NotImplementedException(
-            "Drop Copy session establishment is part of the wire-up. Tracked by issue #10.");
+        => _inner.ConnectAsync(cancellationToken);
 
     /// <summary>Read-only event stream — same shape as <see cref="EntryPointClient.Events"/>.</summary>
     public IAsyncEnumerable<EntryPointEvent> Events(CancellationToken cancellationToken = default)

--- a/tests/B3.EntryPoint.Client.Tests/DropCopy/DropCopyClientTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/DropCopy/DropCopyClientTests.cs
@@ -25,10 +25,11 @@ public class DropCopyClientTests
     }
 
     [Fact]
-    public async Task ConnectAsync_Throws_With_Issue_Citation()
+    public async Task ConnectAsync_AttemptsTcpConnect()
     {
         await using var c = new DropCopyClient(Opts(SessionProfile.DropCopy));
-        var ex = await Assert.ThrowsAsync<NotImplementedException>(() => c.ConnectAsync());
-        Assert.Contains("issue #10", ex.Message);
+        // No socket listening on port 9999 → TCP connect must fail. Confirms the
+        // delegating wire-up to EntryPointClient.ConnectAsync is in place.
+        await Assert.ThrowsAnyAsync<System.Net.Sockets.SocketException>(() => c.ConnectAsync());
     }
 }


### PR DESCRIPTION
DropCopyClient.ConnectAsync now delegates to inner EntryPointClient.ConnectAsync (TCP + Negotiate + Establish). Profile=DropCopy enforced at construction. Read-only Events stream + Terminate already in place.