### PR TITLE
feat(cli): submit/replace/cancel/dropcopy tail commands (#28)

### DIFF
--- a/src/B3.EntryPoint.Cli/Program.cs
+++ b/src/B3.EntryPoint.Cli/Program.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using B3.EntryPoint.Client;
 using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.DropCopy;
+using B3.EntryPoint.Client.Models;
 
 if (args.Length == 0 || args[0] is "-h" or "--help" or "help")
 {
@@ -10,51 +12,139 @@ if (args.Length == 0 || args[0] is "-h" or "--help" or "help")
 
 return args[0] switch
 {
-    "connect" => await ConnectAsync(args[1..]),
+    "connect"  => await ConnectAsync(args[1..]),
+    "submit"   => await SubmitAsync(args[1..]),
+    "replace"  => await ReplaceAsync(args[1..]),
+    "cancel"   => await CancelAsync(args[1..]),
+    "dropcopy" => await DropCopyAsync(args[1..]),
     _ => UnknownCommand(args[0]),
 };
 
-static async Task<int> ConnectAsync(string[] args)
+static EntryPointClientOptions BuildOptions(Dictionary<string, string> flags, SessionProfile profile = SessionProfile.OrderEntry)
 {
-    string? endpoint = null;
-    string? sessionIdRaw = null;
-    string? sessionVerIdRaw = null;
-    string? firmRaw = null;
-    string? accessKey = null;
-
-    for (var i = 0; i < args.Length; i++)
-    {
-        switch (args[i])
-        {
-            case "--endpoint": endpoint = args[++i]; break;
-            case "--session-id": sessionIdRaw = args[++i]; break;
-            case "--session-ver-id": sessionVerIdRaw = args[++i]; break;
-            case "--firm": firmRaw = args[++i]; break;
-            case "--access-key": accessKey = args[++i]; break;
-            default: Console.Error.WriteLine($"Unknown flag: {args[i]}"); return 2;
-        }
-    }
-
-    if (endpoint is null || sessionIdRaw is null || sessionVerIdRaw is null || firmRaw is null || accessKey is null)
-    {
-        PrintUsage();
-        return 2;
-    }
-
-    var ep = ParseEndpoint(endpoint);
-    var options = new EntryPointClientOptions
+    var ep = ParseEndpoint(flags["--endpoint"]);
+    return new EntryPointClientOptions
     {
         Endpoint = ep,
-        SessionId = uint.Parse(sessionIdRaw),
-        SessionVerId = uint.Parse(sessionVerIdRaw),
-        EnteringFirm = uint.Parse(firmRaw),
-        Credentials = Credentials.FromUtf8(accessKey),
+        SessionId = uint.Parse(flags["--session-id"]),
+        SessionVerId = uint.Parse(flags["--session-ver-id"]),
+        EnteringFirm = uint.Parse(flags["--firm"]),
+        Credentials = Credentials.FromUtf8(flags["--access-key"]),
+        Profile = profile,
     };
+}
 
+static Dictionary<string, string> ParseFlags(string[] args, params string[] required)
+{
+    var map = new Dictionary<string, string>();
+    for (var i = 0; i < args.Length; i++)
+    {
+        if (!args[i].StartsWith("--"))
+            throw new ArgumentException($"Unknown positional arg: {args[i]}");
+        if (i + 1 >= args.Length)
+            throw new ArgumentException($"Missing value for {args[i]}");
+        map[args[i]] = args[++i];
+    }
+    foreach (var r in required)
+        if (!map.ContainsKey(r))
+            throw new ArgumentException($"Missing required flag: {r}");
+    return map;
+}
+
+static async Task<int> ConnectAsync(string[] args)
+{
+    var flags = ParseFlags(args, "--endpoint", "--session-id", "--session-ver-id", "--firm", "--access-key");
+    var options = BuildOptions(flags);
     await using var client = new EntryPointClient(options);
-    Console.WriteLine($"Connecting to {ep} ...");
+    Console.WriteLine($"Connecting to {options.Endpoint} ...");
     await client.ConnectAsync();
     Console.WriteLine($"Connected. State = {client.State}");
+    return 0;
+}
+
+static async Task<int> SubmitAsync(string[] args)
+{
+    var flags = ParseFlags(args, "--endpoint", "--session-id", "--session-ver-id", "--firm", "--access-key",
+        "--clordid", "--security-id", "--side", "--ord-type", "--qty");
+    var options = BuildOptions(flags);
+    await using var client = new EntryPointClient(options);
+    await client.ConnectAsync();
+    var req = new NewOrderRequest
+    {
+        ClOrdID = ClOrdID.Parse(flags["--clordid"]),
+        SecurityId = ulong.Parse(flags["--security-id"]),
+        Side = Enum.Parse<Side>(flags["--side"], ignoreCase: true),
+        OrderType = Enum.Parse<OrderType>(flags["--ord-type"], ignoreCase: true),
+        OrderQty = ulong.Parse(flags["--qty"]),
+        Price = flags.TryGetValue("--price", out var p) ? decimal.Parse(p) : null,
+    };
+    var id = await client.SubmitAsync(req);
+    Console.WriteLine($"Submitted ClOrdID={id}");
+    return 0;
+}
+
+static async Task<int> ReplaceAsync(string[] args)
+{
+    var flags = ParseFlags(args, "--endpoint", "--session-id", "--session-ver-id", "--firm", "--access-key",
+        "--clordid", "--orig-clordid", "--security-id", "--side", "--ord-type", "--qty");
+    var options = BuildOptions(flags);
+    await using var client = new EntryPointClient(options);
+    await client.ConnectAsync();
+    var req = new ReplaceOrderRequest
+    {
+        ClOrdID = ClOrdID.Parse(flags["--clordid"]),
+        OrigClOrdID = ClOrdID.Parse(flags["--orig-clordid"]),
+        SecurityId = ulong.Parse(flags["--security-id"]),
+        Side = Enum.Parse<Side>(flags["--side"], ignoreCase: true),
+        OrderType = Enum.Parse<OrderType>(flags["--ord-type"], ignoreCase: true),
+        OrderQty = ulong.Parse(flags["--qty"]),
+        Price = flags.TryGetValue("--price", out var p) ? decimal.Parse(p) : null,
+    };
+    var id = await client.ReplaceAsync(req);
+    Console.WriteLine($"Replaced ClOrdID={id}");
+    return 0;
+}
+
+static async Task<int> CancelAsync(string[] args)
+{
+    var flags = ParseFlags(args, "--endpoint", "--session-id", "--session-ver-id", "--firm", "--access-key",
+        "--clordid", "--orig-clordid", "--security-id", "--side");
+    var options = BuildOptions(flags);
+    await using var client = new EntryPointClient(options);
+    await client.ConnectAsync();
+    var req = new CancelOrderRequest
+    {
+        ClOrdID = ClOrdID.Parse(flags["--clordid"]),
+        OrigClOrdID = ClOrdID.Parse(flags["--orig-clordid"]),
+        SecurityId = ulong.Parse(flags["--security-id"]),
+        Side = Enum.Parse<Side>(flags["--side"], ignoreCase: true),
+    };
+    await client.CancelAsync(req);
+    Console.WriteLine("Cancel sent");
+    return 0;
+}
+
+static async Task<int> DropCopyAsync(string[] args)
+{
+    if (args.Length == 0 || args[0] != "tail")
+    {
+        Console.Error.WriteLine("Usage: dropcopy tail --endpoint ... --session-id ... --session-ver-id ... --firm ... --access-key ...");
+        return 2;
+    }
+    var flags = ParseFlags(args[1..], "--endpoint", "--session-id", "--session-ver-id", "--firm", "--access-key");
+    var options = BuildOptions(flags, SessionProfile.DropCopy);
+    await using var client = new DropCopyClient(options);
+    Console.WriteLine($"Connecting drop-copy to {options.Endpoint} ...");
+    await client.ConnectAsync();
+    Console.WriteLine("Tailing events. Ctrl+C to stop.");
+    using var cts = new CancellationTokenSource();
+    Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
+    try
+    {
+        await foreach (var evt in client.Events(cts.Token))
+            Console.WriteLine(evt);
+    }
+    catch (OperationCanceledException) { }
     return 0;
 }
 
@@ -70,12 +160,24 @@ static void PrintUsage()
     Console.WriteLine("""
         b3-entrypoint-cli — manual smoke tool for B3.EntryPoint.Client.
 
-        Usage:
-          b3-entrypoint-cli connect --endpoint HOST:PORT --session-id N --session-ver-id N --firm N --access-key KEY
+        Common flags (all commands except `help`):
+          --endpoint HOST:PORT --session-id N --session-ver-id N --firm N --access-key KEY
 
-        Bootstrap scope: connect performs TCP + Negotiate + Establish, prints the
-        resulting state, and disconnects (Terminate). Order submission lands in a
-        follow-up milestone.
+        Commands:
+          connect
+              TCP + Negotiate + Establish, prints state, then disconnects (Terminate).
+
+          submit  --clordid X --security-id N --side BUY|SELL --ord-type Limit|Market|... --qty N [--price D]
+              Submit a NewOrderSingle.
+
+          replace --clordid X --orig-clordid Y --security-id N --side BUY|SELL --ord-type ... --qty N [--price D]
+              Submit an OrderCancelReplaceRequest.
+
+          cancel  --clordid X --orig-clordid Y --security-id N --side BUY|SELL
+              Submit an OrderCancelRequest.
+
+          dropcopy tail
+              Open a DropCopy session and stream EntryPointEvents to stdout until Ctrl+C.
         """);
 }
 


### PR DESCRIPTION
Extends b3-entrypoint-cli with submit, replace, cancel, and `dropcopy tail` subcommands. Help text updated. Common connection flags shared across all commands.