### PR TITLE
feat(wire): connect retry / idle timeout / structured logger (#29)

### DIFF
--- a/src/B3.EntryPoint.Client/B3.EntryPoint.Client.csproj
+++ b/src/B3.EntryPoint.Client/B3.EntryPoint.Client.csproj
@@ -16,4 +16,8 @@
     <InternalsVisibleTo Include="B3.EntryPoint.Client.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+  </ItemGroup>
+
 </Project>

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -4,6 +4,7 @@ using System.Threading.Channels;
 using B3.Entrypoint.Fixp.Sbe.V6;
 using B3.EntryPoint.Client.Fixp;
 using B3.EntryPoint.Client.Models;
+using Microsoft.Extensions.Logging;
 using ClOrdID = B3.EntryPoint.Client.Models.ClOrdID;
 
 namespace B3.EntryPoint.Client;
@@ -28,6 +29,9 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     private FixpClientSession? _session;
     private KeepAliveScheduler? _keepAlive;
     private RetransmitRequestHandler? _retransmit;
+    private DateTime _lastInboundUtc;
+    private CancellationTokenSource? _idleCts;
+    private Task? _idleWatchdog;
 
     /// <summary>Keep-alive scheduler for this client. Bound after <see cref="ConnectAsync"/>.</summary>
     public IKeepAliveScheduler? KeepAlive => _keepAlive;
@@ -56,6 +60,33 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
         if (_session is not null)
             throw new InvalidOperationException("Client is already connected.");
 
+        var attempts = Math.Max(1, _options.ConnectMaxAttempts);
+        Exception? lastError = null;
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                await ConnectOnceAsync(ct).ConfigureAwait(false);
+                _options.Logger.LogInformation("EntryPointClient connected on attempt {Attempt}/{Max} to {Endpoint}",
+                    attempt, attempts, _options.Endpoint);
+                StartIdleWatchdog();
+                return;
+            }
+            catch (Exception ex) when (attempt < attempts && !ct.IsCancellationRequested)
+            {
+                lastError = ex;
+                var delay = ComputeBackoff(attempt);
+                _options.Logger.LogWarning(ex, "ConnectAsync attempt {Attempt}/{Max} failed; retrying in {DelayMs} ms",
+                    attempt, attempts, (int)delay.TotalMilliseconds);
+                await Task.Delay(delay, ct).ConfigureAwait(false);
+            }
+        }
+        throw lastError ?? new InvalidOperationException("ConnectAsync failed without exception.");
+    }
+
+    private async Task ConnectOnceAsync(CancellationToken ct)
+    {
         var tcp = new TcpClient();
         try
         {
@@ -74,26 +105,79 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
         _session = new FixpClientSession(tcp.GetStream(), _options);
 
         await _session.NegotiateAsync(ct).ConfigureAwait(false);
+        _options.Logger.LogDebug("FIXP Negotiated with {Endpoint}", _options.Endpoint);
         await _session.EstablishAsync(ct).ConfigureAwait(false);
+        _options.Logger.LogDebug("FIXP Established with {Endpoint}", _options.Endpoint);
         _session.StartInboundLoop(_events.Writer);
 
         _keepAlive = new KeepAliveScheduler(
             _options.KeepAliveInterval,
             sendSequence: (seq, token) => _session.SendSequenceAsync(seq, token),
             nextSeqNo: () => _session.NextOutboundSeqNum());
-        _session.OnInboundSequence = nextSeq => _keepAlive.RaiseFrameReceived(nextSeq, DateTimeOffset.UtcNow);
+        _session.OnInboundSequence = nextSeq =>
+        {
+            _lastInboundUtc = DateTime.UtcNow;
+            _keepAlive!.RaiseFrameReceived(nextSeq, DateTimeOffset.UtcNow);
+        };
         _keepAlive.Start();
 
         _retransmit = new RetransmitRequestHandler(
             sendRequest: (from, count, token) => _session.SendRetransmitRequestAsync(from, count, token));
         _session.OnInboundRetransmission = (nextSeq, count, reqNanos) =>
-            _retransmit.RaiseRetransmissionReceived(nextSeq, count, NanosToOffset(reqNanos));
+        {
+            _lastInboundUtc = DateTime.UtcNow;
+            _retransmit!.RaiseRetransmissionReceived(nextSeq, count, NanosToOffset(reqNanos));
+        };
         _session.OnInboundRetransmitReject = (code, reqNanos) =>
-            _retransmit.RaiseRetransmitRejected((B3.EntryPoint.Client.Fixp.RetransmitRejectCode)(byte)code, NanosToOffset(reqNanos));
+        {
+            _lastInboundUtc = DateTime.UtcNow;
+            _retransmit!.RaiseRetransmitRejected((B3.EntryPoint.Client.Fixp.RetransmitRejectCode)(byte)code, NanosToOffset(reqNanos));
+        };
         _session.OnInboundNotApplied = (from, count) =>
-            _retransmit.RaiseNotAppliedReceived(from, count);
+        {
+            _lastInboundUtc = DateTime.UtcNow;
+            _retransmit!.RaiseNotAppliedReceived(from, count);
+        };
         _session.OnInboundTerminate = code =>
+        {
+            _lastInboundUtc = DateTime.UtcNow;
+            _options.Logger.LogInformation("Inbound Terminate received: code={Code}", code);
             RaiseTerminated((TerminationCode)code, reason: null, initiatedByClient: false);
+        };
+        _lastInboundUtc = DateTime.UtcNow;
+    }
+
+    private TimeSpan ComputeBackoff(int attempt)
+    {
+        var baseMs = _options.ConnectBaseDelay.TotalMilliseconds;
+        var raw = baseMs * Math.Pow(2, attempt - 1);
+        var capped = Math.Min(raw, _options.ConnectMaxDelay.TotalMilliseconds);
+        var jitter = Random.Shared.NextDouble() * 0.25 * capped;
+        return TimeSpan.FromMilliseconds(capped + jitter);
+    }
+
+    private void StartIdleWatchdog()
+    {
+        if (_options.IdleTimeout <= TimeSpan.Zero) return;
+        _idleCts = new CancellationTokenSource();
+        var token = _idleCts.Token;
+        _idleWatchdog = Task.Run(async () =>
+        {
+            var period = TimeSpan.FromMilliseconds(Math.Max(50, _options.IdleTimeout.TotalMilliseconds / 4));
+            using var timer = new PeriodicTimer(period);
+            while (!token.IsCancellationRequested && await timer.WaitForNextTickAsync(token).ConfigureAwait(false))
+            {
+                var idleFor = DateTime.UtcNow - _lastInboundUtc;
+                if (idleFor > _options.IdleTimeout)
+                {
+                    _options.Logger.LogWarning("Idle timeout exceeded ({Idle} > {Threshold}); closing session",
+                        idleFor, _options.IdleTimeout);
+                    try { await TerminateAsync(TerminationCode.KeepaliveIntervalLapsed, CancellationToken.None).ConfigureAwait(false); }
+                    catch { /* best-effort */ }
+                    return;
+                }
+            }
+        }, token);
     }
 
     private static DateTimeOffset NanosToOffset(ulong unixNanos) =>
@@ -245,6 +329,14 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
 
     public async ValueTask DisposeAsync()
     {
+        try { _idleCts?.Cancel(); } catch { }
+        if (_idleWatchdog is not null)
+        {
+            try { await _idleWatchdog.ConfigureAwait(false); } catch { }
+        }
+        _idleCts?.Dispose();
+        _idleCts = null;
+        _idleWatchdog = null;
         _keepAlive?.Dispose();
         _keepAlive = null;
         if (_session is not null)

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -1,5 +1,7 @@
 using System.Net;
 using B3.EntryPoint.Client.Auth;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace B3.EntryPoint.Client;
 
@@ -75,6 +77,25 @@ public sealed class EntryPointClientOptions
 
     /// <summary>Time to wait for <c>NegotiateResponse</c> / <c>EstablishmentAck</c>.</summary>
     public TimeSpan HandshakeTimeout { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>Maximum number of <c>ConnectAsync</c> attempts (TCP+Negotiate+Establish) before
+    /// surfacing the underlying exception. <c>1</c> disables retry. Defaults to 1 to preserve
+    /// fail-fast semantics in the unit tests.</summary>
+    public int ConnectMaxAttempts { get; init; } = 1;
+
+    /// <summary>Base delay for exponential backoff between connect attempts.</summary>
+    public TimeSpan ConnectBaseDelay { get; init; } = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>Maximum delay between connect attempts (caps the exponential growth).</summary>
+    public TimeSpan ConnectMaxDelay { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>Idle timeout — if no inbound frame is observed for this duration the client
+    /// closes the session. Defaults to <see cref="TimeSpan.Zero"/> (disabled).</summary>
+    public TimeSpan IdleTimeout { get; init; } = TimeSpan.Zero;
+
+    /// <summary>Optional <see cref="ILogger"/> used by the client for structured events.
+    /// Defaults to <see cref="NullLogger.Instance"/> so existing tests are unaffected.</summary>
+    public ILogger Logger { get; init; } = NullLogger.Instance;
 
     private static string ThisAssemblyVersion() =>
         typeof(EntryPointClientOptions).Assembly.GetName().Version?.ToString() ?? "0.0.0";

--- a/tests/B3.EntryPoint.Client.Tests/ResiliencyTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/ResiliencyTests.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+
+namespace B3.EntryPoint.Client.Tests;
+
+public class ResiliencyTests
+{
+    [Fact]
+    public async Task ConnectAsync_RetriesUpToConfiguredAttempts_WhenTcpFails()
+    {
+        var opts = new EntryPointClientOptions
+        {
+            Endpoint = new IPEndPoint(IPAddress.Loopback, 9), // discard port — no listener
+            SessionId = 1,
+            SessionVerId = 1,
+            EnteringFirm = 1,
+            Credentials = Credentials.FromUtf8("k"),
+            ConnectMaxAttempts = 3,
+            ConnectBaseDelay = TimeSpan.FromMilliseconds(5),
+            ConnectMaxDelay = TimeSpan.FromMilliseconds(20),
+            ConnectTimeout = TimeSpan.FromMilliseconds(200),
+        };
+        await using var c = new EntryPointClient(opts);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await Assert.ThrowsAnyAsync<SocketException>(() => c.ConnectAsync());
+        sw.Stop();
+
+        // 2 backoffs occurred between 3 attempts; lower bound ≈ 2 * baseDelay.
+        Assert.True(sw.Elapsed >= TimeSpan.FromMilliseconds(8),
+            $"Expected at least one backoff delay; elapsed={sw.ElapsedMilliseconds}ms");
+    }
+
+    [Fact]
+    public void Options_DefaultRetryAndIdle_AreFailFastSafe()
+    {
+        var o = new EntryPointClientOptions
+        {
+            Endpoint = new IPEndPoint(IPAddress.Loopback, 1),
+            SessionId = 1,
+            SessionVerId = 1,
+            EnteringFirm = 1,
+            Credentials = Credentials.FromUtf8("k"),
+        };
+        Assert.Equal(1, o.ConnectMaxAttempts);
+        Assert.Equal(TimeSpan.Zero, o.IdleTimeout);
+        Assert.NotNull(o.Logger);
+    }
+}


### PR DESCRIPTION
Adds operational resilience to EntryPointClient: ConnectAsync retries with exponential backoff + jitter (configurable via ConnectMaxAttempts/ConnectBaseDelay/ConnectMaxDelay), optional IdleTimeout watchdog that terminates the session when inbound traffic stalls, and an ILogger hook (NullLogger by default) that emits structured events at Connect/Negotiated/Established/Terminate boundaries.