### PR TITLE
feat(risk): pre-trade gates + throttles (#39)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -4,6 +4,7 @@ using System.Threading.Channels;
 using B3.Entrypoint.Fixp.Sbe.V6;
 using B3.EntryPoint.Client.Fixp;
 using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Client.Risk;
 using Microsoft.Extensions.Logging;
 using ClOrdID = B3.EntryPoint.Client.Models.ClOrdID;
 
@@ -38,6 +39,13 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
 
     /// <summary>Retransmit handler for this client. Bound after <see cref="ConnectAsync"/>.</summary>
     public IRetransmitRequestHandler? Retransmit => _retransmit;
+
+    /// <summary>
+    /// Pre-trade risk gates. Evaluated in registration order before any order
+    /// entry frame leaves the client. The first non-Allow decision throws
+    /// <see cref="RiskRejectedException"/>.
+    /// </summary>
+    public IList<IPreTradeGate> RiskGates { get; } = new List<IPreTradeGate>();
 
     public EntryPointClient(EntryPointClientOptions options)
     {
@@ -184,11 +192,27 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
         unixNanos == 0UL ? DateTimeOffset.MinValue
                          : DateTimeOffset.UnixEpoch.AddTicks((long)(unixNanos / 100UL));
 
+    private async ValueTask EvaluateRiskAsync(OutboundRequestKind kind, object req, ulong securityId, string clordid, CancellationToken ct)
+    {
+        if (RiskGates.Count == 0) return;
+        var snapshot = new OutboundRequest(kind, req, securityId, clordid);
+        foreach (var gate in RiskGates)
+        {
+            var decision = await gate.EvaluateAsync(snapshot, ct).ConfigureAwait(false);
+            if (decision.Kind != RiskDecisionKind.Allow)
+            {
+                _options.Logger.LogWarning("Risk gate {Gate} {Kind}: {Reason}", gate.GetType().Name, decision.Kind, decision.Reason);
+                throw new RiskRejectedException(decision);
+            }
+        }
+    }
+
     /// <inheritdoc />
     public async Task<ClOrdID> SubmitAsync(NewOrderRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
+        await EvaluateRiskAsync(OutboundRequestKind.NewOrder, request, request.SecurityId, request.ClOrdID.Value.ToString(), ct).ConfigureAwait(false);
         var seq = _session!.NextOutboundSeqNum();
         var buffer = new byte[NewOrderSingleData.MESSAGE_SIZE + 256];
         var len = OrderEntryEncoder.EncodeNewOrderSingle(buffer, request, _options, seq);
@@ -201,6 +225,7 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
+        await EvaluateRiskAsync(OutboundRequestKind.SimpleNewOrder, request, request.SecurityId, request.ClOrdID.Value.ToString(), ct).ConfigureAwait(false);
         var seq = _session!.NextOutboundSeqNum();
         var buffer = new byte[SimpleNewOrderData.MESSAGE_SIZE + 64];
         var len = OrderEntryEncoder.EncodeSimpleNewOrder(buffer, request, _options, seq);
@@ -213,6 +238,7 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
+        await EvaluateRiskAsync(OutboundRequestKind.Replace, request, request.SecurityId, request.ClOrdID.Value.ToString(), ct).ConfigureAwait(false);
         var seq = _session!.NextOutboundSeqNum();
         var buffer = new byte[OrderCancelReplaceRequestData.MESSAGE_SIZE + 256];
         var len = OrderEntryEncoder.EncodeOrderCancelReplace(buffer, request, _options, seq);
@@ -225,6 +251,7 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
+        await EvaluateRiskAsync(OutboundRequestKind.SimpleReplace, request, request.SecurityId, request.ClOrdID.Value.ToString(), ct).ConfigureAwait(false);
         var seq = _session!.NextOutboundSeqNum();
         var buffer = new byte[SimpleModifyOrderData.MESSAGE_SIZE + 64];
         var len = OrderEntryEncoder.EncodeSimpleModifyOrder(buffer, request, _options, seq);
@@ -237,6 +264,7 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
+        await EvaluateRiskAsync(OutboundRequestKind.Cancel, request, request.SecurityId, request.ClOrdID.Value.ToString(), ct).ConfigureAwait(false);
         var seq = _session!.NextOutboundSeqNum();
         var buffer = new byte[OrderCancelRequestData.MESSAGE_SIZE + 256];
         var len = OrderEntryEncoder.EncodeOrderCancel(buffer, request, _options, seq);
@@ -248,17 +276,15 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
-        var seq = _session!.NextOutboundSeqNum();
-        var buffer = new byte[OrderMassActionRequestData.MESSAGE_SIZE + 32];
-        var len = OrderEntryEncoder.EncodeOrderMassAction(buffer, request, _options, seq);
-        // Fire-and-forget the request; the matching MassActionReport will be
-        // surfaced through the inbound dispatcher (issue #23) — until then,
-        // we encode+send and return a synthetic Acknowledged report.
-        return SendMassActionAsync(buffer, len, request, ct);
+        return SendMassActionWithRiskAsync(request, ct);
 
-        async Task<MassActionReport> SendMassActionAsync(byte[] buf, int length, MassActionRequest req, CancellationToken token)
+        async Task<MassActionReport> SendMassActionWithRiskAsync(MassActionRequest req, CancellationToken token)
         {
-            await _session.SendApplicationFrameAsync(buf, length, token).ConfigureAwait(false);
+            await EvaluateRiskAsync(OutboundRequestKind.MassAction, req, req.SecurityId ?? 0UL, req.ClOrdID.Value.ToString(), token).ConfigureAwait(false);
+            var seq = _session!.NextOutboundSeqNum();
+            var buffer = new byte[OrderMassActionRequestData.MESSAGE_SIZE + 32];
+            var len = OrderEntryEncoder.EncodeOrderMassAction(buffer, req, _options, seq);
+            await _session.SendApplicationFrameAsync(buffer, len, token).ConfigureAwait(false);
             return new MassActionReport
             {
                 ClOrdID = req.ClOrdID,

--- a/src/B3.EntryPoint.Client/Risk/IPreTradeGate.cs
+++ b/src/B3.EntryPoint.Client/Risk/IPreTradeGate.cs
@@ -1,0 +1,62 @@
+namespace B3.EntryPoint.Client.Risk;
+
+/// <summary>Outcome of a pre-trade risk evaluation.</summary>
+public enum RiskDecisionKind : byte
+{
+    Allow = 0,
+    Reject = 1,
+    Throttle = 2,
+}
+
+/// <summary>Result returned by an <see cref="IPreTradeGate"/>.</summary>
+public readonly struct RiskDecision
+{
+    public RiskDecisionKind Kind { get; init; }
+    public string? Reason { get; init; }
+
+    public static RiskDecision Allow() => new() { Kind = RiskDecisionKind.Allow };
+    public static RiskDecision Reject(string reason) => new() { Kind = RiskDecisionKind.Reject, Reason = reason };
+    public static RiskDecision Throttle(string reason) => new() { Kind = RiskDecisionKind.Throttle, Reason = reason };
+}
+
+public enum OutboundRequestKind : byte
+{
+    NewOrder,
+    SimpleNewOrder,
+    Replace,
+    SimpleReplace,
+    Cancel,
+    MassAction,
+}
+
+/// <summary>
+/// Snapshot of an outbound request fed to <see cref="IPreTradeGate"/>. Variants
+/// other than NewOrder are normalized through the same shape so a single gate
+/// can apply uniform throttles across kinds.
+/// </summary>
+public readonly record struct OutboundRequest(
+    OutboundRequestKind Kind,
+    object Request,
+    ulong SecurityId,
+    string ClOrdID);
+
+/// <summary>
+/// Pre-trade risk gate. Implementations are invoked sequentially before any
+/// order entry frame leaves the client. The first non-Allow decision aborts
+/// the request and surfaces a <see cref="RiskRejectedException"/>.
+/// </summary>
+public interface IPreTradeGate
+{
+    ValueTask<RiskDecision> EvaluateAsync(OutboundRequest request, CancellationToken ct);
+}
+
+/// <summary>Thrown when a pre-trade gate rejects or throttles an outbound request.</summary>
+public sealed class RiskRejectedException : Exception
+{
+    public RiskDecisionKind Kind { get; }
+    public RiskRejectedException(RiskDecision decision)
+        : base($"Pre-trade gate {decision.Kind}: {decision.Reason ?? "(no reason)"}")
+    {
+        Kind = decision.Kind;
+    }
+}

--- a/src/B3.EntryPoint.Client/Risk/Throttles.cs
+++ b/src/B3.EntryPoint.Client/Risk/Throttles.cs
@@ -1,0 +1,92 @@
+using System.Collections.Concurrent;
+
+namespace B3.EntryPoint.Client.Risk;
+
+/// <summary>
+/// Sliding-window throttle that limits outbound order entry requests per
+/// <c>ClOrdID</c> prefix. A request is throttled when more than
+/// <see cref="MaxPerWindow"/> have been observed within
+/// <see cref="WindowDuration"/> for the same prefix.
+/// </summary>
+public sealed class ClOrdIdPrefixThrottle : IPreTradeGate
+{
+    private readonly int _prefixLength;
+    private readonly ConcurrentDictionary<string, Window> _windows = new();
+    public int MaxPerWindow { get; }
+    public TimeSpan WindowDuration { get; }
+
+    public ClOrdIdPrefixThrottle(int prefixLength, int maxPerWindow, TimeSpan windowDuration)
+    {
+        if (prefixLength <= 0) throw new ArgumentOutOfRangeException(nameof(prefixLength));
+        if (maxPerWindow <= 0) throw new ArgumentOutOfRangeException(nameof(maxPerWindow));
+        if (windowDuration <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(windowDuration));
+        _prefixLength = prefixLength;
+        MaxPerWindow = maxPerWindow;
+        WindowDuration = windowDuration;
+    }
+
+    public ValueTask<RiskDecision> EvaluateAsync(OutboundRequest request, CancellationToken ct)
+    {
+        var clordid = request.ClOrdID ?? string.Empty;
+        var prefix = clordid.Length >= _prefixLength
+            ? clordid.Substring(0, _prefixLength)
+            : clordid;
+        var now = DateTime.UtcNow;
+        var window = _windows.GetOrAdd(prefix, _ => new Window());
+        lock (window)
+        {
+            if (now - window.Start > WindowDuration)
+            {
+                window.Start = now;
+                window.Count = 0;
+            }
+            window.Count++;
+            if (window.Count > MaxPerWindow)
+                return ValueTask.FromResult(RiskDecision.Throttle(
+                    $"ClOrdID prefix '{prefix}' exceeded {MaxPerWindow} requests / {WindowDuration.TotalMilliseconds}ms"));
+        }
+        return ValueTask.FromResult(RiskDecision.Allow());
+    }
+
+    private sealed class Window { public DateTime Start; public int Count; }
+}
+
+/// <summary>
+/// Sliding-window throttle that limits outbound order entry requests per
+/// <c>SecurityID</c>. Same semantics as <see cref="ClOrdIdPrefixThrottle"/>.
+/// </summary>
+public sealed class SecurityIdRateThrottle : IPreTradeGate
+{
+    private readonly ConcurrentDictionary<ulong, Window> _windows = new();
+    public int MaxPerWindow { get; }
+    public TimeSpan WindowDuration { get; }
+
+    public SecurityIdRateThrottle(int maxPerWindow, TimeSpan windowDuration)
+    {
+        if (maxPerWindow <= 0) throw new ArgumentOutOfRangeException(nameof(maxPerWindow));
+        if (windowDuration <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(windowDuration));
+        MaxPerWindow = maxPerWindow;
+        WindowDuration = windowDuration;
+    }
+
+    public ValueTask<RiskDecision> EvaluateAsync(OutboundRequest request, CancellationToken ct)
+    {
+        var now = DateTime.UtcNow;
+        var window = _windows.GetOrAdd(request.SecurityId, _ => new Window());
+        lock (window)
+        {
+            if (now - window.Start > WindowDuration)
+            {
+                window.Start = now;
+                window.Count = 0;
+            }
+            window.Count++;
+            if (window.Count > MaxPerWindow)
+                return ValueTask.FromResult(RiskDecision.Throttle(
+                    $"SecurityId={request.SecurityId} exceeded {MaxPerWindow} requests / {WindowDuration.TotalMilliseconds}ms"));
+        }
+        return ValueTask.FromResult(RiskDecision.Allow());
+    }
+
+    private sealed class Window { public DateTime Start; public int Count; }
+}

--- a/tests/B3.EntryPoint.Client.Tests/Risk/ThrottleTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Risk/ThrottleTests.cs
@@ -1,0 +1,37 @@
+using B3.EntryPoint.Client.Risk;
+
+namespace B3.EntryPoint.Client.Tests.Risk;
+
+public class ThrottleTests
+{
+    [Fact]
+    public async Task ClOrdIdPrefixThrottle_AllowsUpToLimit_ThenThrottles()
+    {
+        var t = new ClOrdIdPrefixThrottle(prefixLength: 3, maxPerWindow: 2, windowDuration: TimeSpan.FromSeconds(10));
+        var req = new OutboundRequest(OutboundRequestKind.NewOrder, new object(), 1UL, "ABC123");
+        Assert.Equal(RiskDecisionKind.Allow, (await t.EvaluateAsync(req, default)).Kind);
+        Assert.Equal(RiskDecisionKind.Allow, (await t.EvaluateAsync(req, default)).Kind);
+        Assert.Equal(RiskDecisionKind.Throttle, (await t.EvaluateAsync(req, default)).Kind);
+        var other = req with { ClOrdID = "XYZ999" };
+        Assert.Equal(RiskDecisionKind.Allow, (await t.EvaluateAsync(other, default)).Kind);
+    }
+
+    [Fact]
+    public async Task SecurityIdRateThrottle_LimitsPerSecurity()
+    {
+        var t = new SecurityIdRateThrottle(maxPerWindow: 1, windowDuration: TimeSpan.FromSeconds(10));
+        var r1 = new OutboundRequest(OutboundRequestKind.NewOrder, new object(), 100UL, "A");
+        var r2 = new OutboundRequest(OutboundRequestKind.NewOrder, new object(), 200UL, "B");
+        Assert.Equal(RiskDecisionKind.Allow, (await t.EvaluateAsync(r1, default)).Kind);
+        Assert.Equal(RiskDecisionKind.Throttle, (await t.EvaluateAsync(r1, default)).Kind);
+        Assert.Equal(RiskDecisionKind.Allow, (await t.EvaluateAsync(r2, default)).Kind);
+    }
+
+    [Fact]
+    public void RiskRejectedException_Carries_Decision()
+    {
+        var ex = new RiskRejectedException(RiskDecision.Reject("nope"));
+        Assert.Equal(RiskDecisionKind.Reject, ex.Kind);
+        Assert.Contains("nope", ex.Message);
+    }
+}


### PR DESCRIPTION
Adds B3.EntryPoint.Client.Risk namespace: IPreTradeGate / RiskDecision / OutboundRequest. EntryPointClient evaluates registered gates in order before every Submit/Replace/Cancel/MassAction; first non-Allow decision throws RiskRejectedException. Built-in throttles: ClOrdIdPrefixThrottle, SecurityIdRateThrottle.