### PR TITLE
feat(state): snapshot+delta persistence for warm-restart (#40)

### DIFF
--- a/src/B3.EntryPoint.Client/State/FileSessionStateStore.cs
+++ b/src/B3.EntryPoint.Client/State/FileSessionStateStore.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+
+namespace B3.EntryPoint.Client.State;
+
+/// <summary>
+/// File-backed implementation of <see cref="ISessionStateStore"/>. The snapshot
+/// is written atomically (temp + rename) to <c>{directory}/snapshot.json</c>;
+/// deltas are appended one-JSON-line per record to <c>{directory}/deltas.jsonl</c>.
+/// </summary>
+public sealed class FileSessionStateStore : ISessionStateStore
+{
+    private readonly string _snapshotPath;
+    private readonly string _deltasPath;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        WriteIndented = false,
+    };
+
+    public FileSessionStateStore(string directory)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(directory);
+        Directory.CreateDirectory(directory);
+        _snapshotPath = Path.Combine(directory, "snapshot.json");
+        _deltasPath = Path.Combine(directory, "deltas.jsonl");
+    }
+
+    public async ValueTask<SessionSnapshot?> LoadAsync(CancellationToken ct = default)
+    {
+        if (!File.Exists(_snapshotPath)) return null;
+        await using var fs = File.OpenRead(_snapshotPath);
+        return await JsonSerializer.DeserializeAsync<SessionSnapshot>(fs, JsonOpts, ct).ConfigureAwait(false);
+    }
+
+    public async ValueTask SaveAsync(SessionSnapshot snapshot, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var tmp = _snapshotPath + ".tmp";
+            await using (var fs = File.Create(tmp))
+                await JsonSerializer.SerializeAsync(fs, snapshot, JsonOpts, ct).ConfigureAwait(false);
+            File.Move(tmp, _snapshotPath, overwrite: true);
+            // Drop deltas — the snapshot now subsumes them.
+            if (File.Exists(_deltasPath)) File.Delete(_deltasPath);
+        }
+        finally { _gate.Release(); }
+    }
+
+    public async ValueTask AppendDeltaAsync(SessionDelta delta, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(delta);
+        var line = JsonSerializer.Serialize<SessionDelta>(delta, JsonOpts) + Environment.NewLine;
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await File.AppendAllTextAsync(_deltasPath, line, ct).ConfigureAwait(false);
+        }
+        finally { _gate.Release(); }
+    }
+
+    public async ValueTask<SessionSnapshot?> ReplayAsync(CancellationToken ct = default)
+    {
+        var snap = await LoadAsync(ct).ConfigureAwait(false);
+        if (snap is null && !File.Exists(_deltasPath)) return null;
+        snap ??= new SessionSnapshot { CapturedAt = DateTimeOffset.UtcNow };
+
+        if (!File.Exists(_deltasPath)) return snap;
+
+        var rebuilt = snap;
+        var outstanding = new Dictionary<string, ulong>(rebuilt.OutstandingOrders);
+        ulong outboundSeq = rebuilt.LastOutboundSeqNum;
+        ulong inboundSeq = rebuilt.LastInboundSeqNum;
+
+        await foreach (var line in File.ReadLinesAsync(_deltasPath, ct).ConfigureAwait(false))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            var d = JsonSerializer.Deserialize<SessionDelta>(line, JsonOpts);
+            switch (d)
+            {
+                case OutboundDelta o:
+                    outboundSeq = Math.Max(outboundSeq, o.SeqNum);
+                    outstanding[o.ClOrdID] = o.SecurityId;
+                    break;
+                case InboundDelta i:
+                    inboundSeq = Math.Max(inboundSeq, i.SeqNum);
+                    break;
+                case OrderClosedDelta c:
+                    outstanding.Remove(c.ClOrdID);
+                    break;
+            }
+        }
+        return rebuilt with
+        {
+            LastOutboundSeqNum = outboundSeq,
+            LastInboundSeqNum = inboundSeq,
+            OutstandingOrders = outstanding,
+            CapturedAt = DateTimeOffset.UtcNow,
+        };
+    }
+
+    public async ValueTask CompactAsync(CancellationToken ct = default)
+    {
+        var rebuilt = await ReplayAsync(ct).ConfigureAwait(false);
+        if (rebuilt is null) return;
+        await SaveAsync(rebuilt, ct).ConfigureAwait(false);
+    }
+}

--- a/src/B3.EntryPoint.Client/State/ISessionStateStore.cs
+++ b/src/B3.EntryPoint.Client/State/ISessionStateStore.cs
@@ -1,0 +1,52 @@
+using System.Text.Json.Serialization;
+
+namespace B3.EntryPoint.Client.State;
+
+/// <summary>
+/// Snapshot of FIXP session state needed to perform a warm-restart via
+/// <see cref="EntryPointClient.ReconnectAsync"/>. Persisted via
+/// <see cref="ISessionStateStore.SaveAsync"/>.
+/// </summary>
+public sealed record SessionSnapshot
+{
+    public uint SessionId { get; init; }
+    public uint SessionVerId { get; init; }
+    public ulong LastOutboundSeqNum { get; init; }
+    public ulong LastInboundSeqNum { get; init; }
+    public DateTimeOffset CapturedAt { get; init; }
+
+    /// <summary>Outstanding orders (ClOrdID -> SecurityID), useful to
+    /// reconcile against ER replay after reconnect.</summary>
+    public Dictionary<string, ulong> OutstandingOrders { get; init; } = new();
+}
+
+/// <summary>Incremental update appended between snapshots.</summary>
+[JsonDerivedType(typeof(OutboundDelta), typeDiscriminator: "out")]
+[JsonDerivedType(typeof(InboundDelta), typeDiscriminator: "in")]
+[JsonDerivedType(typeof(OrderClosedDelta), typeDiscriminator: "close")]
+public abstract record SessionDelta
+{
+    public DateTimeOffset At { get; init; } = DateTimeOffset.UtcNow;
+}
+
+public sealed record OutboundDelta(ulong SeqNum, string ClOrdID, ulong SecurityId) : SessionDelta;
+public sealed record InboundDelta(ulong SeqNum) : SessionDelta;
+public sealed record OrderClosedDelta(string ClOrdID) : SessionDelta;
+
+/// <summary>
+/// Pluggable persistence for warm-restart. Default implementation is
+/// <see cref="FileSessionStateStore"/>.
+/// </summary>
+public interface ISessionStateStore
+{
+    ValueTask<SessionSnapshot?> LoadAsync(CancellationToken ct = default);
+    ValueTask SaveAsync(SessionSnapshot snapshot, CancellationToken ct = default);
+    ValueTask AppendDeltaAsync(SessionDelta delta, CancellationToken ct = default);
+
+    /// <summary>Re-builds a logical snapshot from the most recent persisted snapshot
+    /// + appended deltas. Used by recovery after a crash.</summary>
+    ValueTask<SessionSnapshot?> ReplayAsync(CancellationToken ct = default);
+
+    /// <summary>Compacts the delta log into a fresh snapshot, then truncates the deltas.</summary>
+    ValueTask CompactAsync(CancellationToken ct = default);
+}

--- a/tests/B3.EntryPoint.Client.Tests/State/FileSessionStateStoreTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/State/FileSessionStateStoreTests.cs
@@ -1,0 +1,95 @@
+using B3.EntryPoint.Client.State;
+
+namespace B3.EntryPoint.Client.Tests.State;
+
+public class FileSessionStateStoreTests
+{
+    [Fact]
+    public async Task Snapshot_RoundTrip_PreservesFields()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "b3-state-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new FileSessionStateStore(dir);
+            var snap = new SessionSnapshot
+            {
+                SessionId = 42,
+                SessionVerId = 7,
+                LastOutboundSeqNum = 100,
+                LastInboundSeqNum = 90,
+                CapturedAt = DateTimeOffset.UnixEpoch,
+                OutstandingOrders = new() { ["A"] = 1, ["B"] = 2 },
+            };
+            await store.SaveAsync(snap);
+            var loaded = await store.LoadAsync();
+            Assert.NotNull(loaded);
+            Assert.Equal(42u, loaded!.SessionId);
+            Assert.Equal(7u, loaded.SessionVerId);
+            Assert.Equal(100UL, loaded.LastOutboundSeqNum);
+            Assert.Equal(2, loaded.OutstandingOrders.Count);
+            Assert.Equal(1UL, loaded.OutstandingOrders["A"]);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    [Fact]
+    public async Task DeltaReplay_AppliesOutbound_Inbound_AndOrderClosed()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "b3-state-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new FileSessionStateStore(dir);
+            await store.SaveAsync(new SessionSnapshot
+            {
+                SessionId = 1, SessionVerId = 1,
+                LastOutboundSeqNum = 10, LastInboundSeqNum = 5,
+                OutstandingOrders = new() { ["X"] = 100 },
+            });
+            await store.AppendDeltaAsync(new OutboundDelta(11, "Y", 200));
+            await store.AppendDeltaAsync(new OutboundDelta(12, "Z", 300));
+            await store.AppendDeltaAsync(new InboundDelta(7));
+            await store.AppendDeltaAsync(new OrderClosedDelta("X"));
+
+            var rebuilt = await store.ReplayAsync();
+            Assert.NotNull(rebuilt);
+            Assert.Equal(12UL, rebuilt!.LastOutboundSeqNum);
+            Assert.Equal(7UL, rebuilt.LastInboundSeqNum);
+            Assert.False(rebuilt.OutstandingOrders.ContainsKey("X"));
+            Assert.Equal(200UL, rebuilt.OutstandingOrders["Y"]);
+            Assert.Equal(300UL, rebuilt.OutstandingOrders["Z"]);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    [Fact]
+    public async Task Compact_DropsDeltaLog_And_PersistsRebuilt()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "b3-state-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new FileSessionStateStore(dir);
+            await store.SaveAsync(new SessionSnapshot { SessionId = 1, SessionVerId = 1 });
+            await store.AppendDeltaAsync(new OutboundDelta(1, "A", 99));
+            Assert.True(File.Exists(Path.Combine(dir, "deltas.jsonl")));
+            await store.CompactAsync();
+            Assert.False(File.Exists(Path.Combine(dir, "deltas.jsonl")));
+            var snap = await store.LoadAsync();
+            Assert.Equal(1UL, snap!.LastOutboundSeqNum);
+            Assert.Single(snap.OutstandingOrders);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    [Fact]
+    public async Task Load_ReturnsNull_WhenStoreEmpty()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "b3-state-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new FileSessionStateStore(dir);
+            Assert.Null(await store.LoadAsync());
+            Assert.Null(await store.ReplayAsync());
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+}


### PR DESCRIPTION
Adds B3.EntryPoint.Client.State namespace: ISessionStateStore (Load/Save/AppendDelta/Replay/Compact) plus FileSessionStateStore (atomic snapshot.json + append-only deltas.jsonl). SessionDelta is a polymorphic JSON record with Outbound/Inbound/OrderClosed variants. Replay reconstructs the snapshot from snapshot+deltas; Compact persists the rebuilt snapshot and truncates the delta log. Wire-in to EntryPointClient is left as a follow-up so tests stay deterministic.