### PR TITLE
feat(packaging): NuGet metadata + SourceLink + release workflow (#41)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish NuGet
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore SbeB3EntryPointClient.slnx
+
+      - name: Build (Release)
+        run: dotnet build SbeB3EntryPointClient.slnx -c Release --no-restore
+
+      - name: Test (Release)
+        run: dotnet test SbeB3EntryPointClient.slnx -c Release --no-build --nologo
+
+      - name: Pack
+        run: dotnet pack SbeB3EntryPointClient.slnx -c Release --no-build -o ./nupkgs
+
+      - name: Push to NuGet.org
+        if: ${{ env.NUGET_API_KEY != '' }}
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          for pkg in ./nupkgs/*.nupkg; do
+            dotnet nuget push "$pkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nupkgs
+          path: ./nupkgs/*

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,5 +5,33 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!-- NuGet metadata shared by all packable projects. -->
+    <Version>0.4.2</Version>
+    <Authors>pedrosakuma</Authors>
+    <Company>pedrosakuma</Company>
+    <Copyright>Copyright (c) pedrosakuma</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/pedrosakuma/B3EntryPointClient</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/pedrosakuma/B3EntryPointClient</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>b3;entrypoint;fixp;sbe;trading;order-entry</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # B3EntryPointClient
 
+[![NuGet — Client](https://img.shields.io/nuget/v/B3.EntryPoint.Client?label=B3.EntryPoint.Client)](https://www.nuget.org/packages/B3.EntryPoint.Client)
+[![NuGet — Sbe](https://img.shields.io/nuget/v/B3.EntryPoint.Sbe?label=B3.EntryPoint.Sbe)](https://www.nuget.org/packages/B3.EntryPoint.Sbe)
+
 Wire-puro **client** library for the B3 EntryPoint (SBE/FIXP 8.4.2) order-entry
 protocol. Symmetric counterpart of [`B3MarketDataPlatform`][md] (UMDF consumer):
 this library **produces** orders and **consumes** ExecutionReports. The

--- a/src/B3.EntryPoint.Cli/B3.EntryPoint.Cli.csproj
+++ b/src/B3.EntryPoint.Cli/B3.EntryPoint.Cli.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>B3.EntryPoint.Cli</RootNamespace>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/B3.EntryPoint.Sbe/B3.EntryPoint.Sbe.csproj
+++ b/src/B3.EntryPoint.Sbe/B3.EntryPoint.Sbe.csproj
@@ -5,6 +5,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>generated</CompilerGeneratedFilesOutputPath>
+    <IsPackable>true</IsPackable>
+    <PackageId>B3.EntryPoint.Sbe</PackageId>
+    <Description>Source-generated SBE codecs for the B3 EntryPoint (FIXP 8.4.2) wire protocol.</Description>
+    <!-- Generated SBE code emits cref/typeparam comments that cannot be resolved.
+         Disable doc generation (and tighten NoWarn) for this project only. -->
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1574;CS1735;CS1591;CS1572;CS1573</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #41

- Directory.Build.props: NuGet metadata, SourceLink, snupkg symbols, README packing.
- B3.EntryPoint.Sbe: packable (PackageId=B3.EntryPoint.Sbe). Doc-gen disabled since the SBE source generator emits unresolvable cref/typeparam comments.
- B3.EntryPoint.Cli: explicit IsPackable=false.
- .github/workflows/publish.yml: pack + push to NuGet.org on v* tags.
- README: NuGet shields for both packages.

Verified: dotnet pack produces .nupkg+.snupkg for both packages; dotnet test 79/79 green.