### PR TITLE
feat(bench): BenchmarkDotNet harness for hot paths (#42)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,28 @@
+name: Benchmarks
+
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: "BenchmarkDotNet filter (e.g. *Risk*)"
+        required: false
+        default: "*"
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: Run benchmarks
+        run: dotnet run -c Release --project benchmarks/B3.EntryPoint.Benchmarks/B3.EntryPoint.Benchmarks.csproj -- --filter "${{ github.event.inputs.filter }}" --exporters json github
+      - uses: actions/upload-artifact@v4
+        with:
+          name: BenchmarkDotNet.Artifacts
+          path: BenchmarkDotNet.Artifacts/**
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ integração com `B3MatchingPlatform` antes da fiação SBE/FIXP completa.
 Cross / Quote / Position / Allocation / SecurityDefinition messages estão fora
 de escopo nesta fase.
 
+## Benchmarks
+
+Micro-benchmarks live in [`benchmarks/B3.EntryPoint.Benchmarks`](benchmarks/B3.EntryPoint.Benchmarks)
+and exercise the hot paths the matching platform pays for on every order
+(DTO construction, pre-trade risk gates, polymorphic session-state delta
+serialization). Run locally:
+
+```bash
+dotnet run -c Release --project benchmarks/B3.EntryPoint.Benchmarks -- --filter '*'
+```
+
+Or trigger the [`Benchmarks`](.github/workflows/bench.yml) workflow via
+`workflow_dispatch` to run on CI and download the artifacts.
+
 ## License
 
 MIT — see [`LICENSE`](LICENSE).

--- a/SbeB3EntryPointClient.slnx
+++ b/SbeB3EntryPointClient.slnx
@@ -8,4 +8,7 @@
     <Project Path="tests/B3.EntryPoint.Client.Tests/B3.EntryPoint.Client.Tests.csproj" />
     <Project Path="tests/B3.EntryPoint.Conformance/B3.EntryPoint.Conformance.csproj" />
   </Folder>
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/B3.EntryPoint.Benchmarks/B3.EntryPoint.Benchmarks.csproj" />
+  </Folder>
 </Solution>

--- a/benchmarks/B3.EntryPoint.Benchmarks/B3.EntryPoint.Benchmarks.csproj
+++ b/benchmarks/B3.EntryPoint.Benchmarks/B3.EntryPoint.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>B3.EntryPoint.Benchmarks</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <TieredCompilation>true</TieredCompilation>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.EntryPoint.Client\B3.EntryPoint.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/B3.EntryPoint.Benchmarks/DtoConstructionBenchmarks.cs
+++ b/benchmarks/B3.EntryPoint.Benchmarks/DtoConstructionBenchmarks.cs
@@ -1,0 +1,42 @@
+using BenchmarkDotNet.Attributes;
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Benchmarks;
+
+/// <summary>
+/// Allocation/throughput baseline for constructing the public DTOs the
+/// matching platform will hand to the client. Tracks regressions in record
+/// initialization, default values, and ClOrdID parsing.
+/// </summary>
+[MemoryDiagnoser]
+public class DtoConstructionBenchmarks
+{
+    [Benchmark]
+    public NewOrderRequest NewOrderSingle()
+        => new()
+        {
+            ClOrdID = new ClOrdID(123456789UL),
+            SecurityId = 5_900_000UL,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            Price = 42.55m,
+            OrderQty = 100UL,
+            TimeInForce = TimeInForce.Day,
+        };
+
+    [Benchmark]
+    public SimpleNewOrderRequest SimpleNewOrder()
+        => new()
+        {
+            ClOrdID = new ClOrdID(987654321UL),
+            SecurityId = 5_900_000UL,
+            Side = Side.Sell,
+            OrderType = SimpleOrderType.Limit,
+            Price = 42.55m,
+            OrderQty = 100UL,
+            TimeInForce = SimpleTimeInForce.Day,
+        };
+
+    [Benchmark]
+    public ClOrdID ClOrdIdParse() => ClOrdID.Parse("1234567890");
+}

--- a/benchmarks/B3.EntryPoint.Benchmarks/Program.cs
+++ b/benchmarks/B3.EntryPoint.Benchmarks/Program.cs
@@ -1,0 +1,9 @@
+using BenchmarkDotNet.Running;
+
+namespace B3.EntryPoint.Benchmarks;
+
+public static class Program
+{
+    public static void Main(string[] args)
+        => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+}

--- a/benchmarks/B3.EntryPoint.Benchmarks/RiskGateBenchmarks.cs
+++ b/benchmarks/B3.EntryPoint.Benchmarks/RiskGateBenchmarks.cs
@@ -1,0 +1,30 @@
+using BenchmarkDotNet.Attributes;
+using B3.EntryPoint.Client.Risk;
+
+namespace B3.EntryPoint.Benchmarks;
+
+/// <summary>
+/// Hot-path latency for the pre-trade risk gate. Every order entry call
+/// pays this cost, so regressions here directly hit end-to-end p99.
+/// </summary>
+[MemoryDiagnoser]
+public class RiskGateBenchmarks
+{
+    private ClOrdIdPrefixThrottle _prefix = null!;
+    private SecurityIdRateThrottle _security = null!;
+    private OutboundRequest _request;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _prefix = new ClOrdIdPrefixThrottle(prefixLength: 4, maxPerWindow: 1_000_000, windowDuration: TimeSpan.FromSeconds(1));
+        _security = new SecurityIdRateThrottle(maxPerWindow: 1_000_000, windowDuration: TimeSpan.FromSeconds(1));
+        _request = new OutboundRequest(OutboundRequestKind.NewOrder, new object(), SecurityId: 5_900_000UL, ClOrdID: "ACME0000001");
+    }
+
+    [Benchmark]
+    public async ValueTask<RiskDecision> ClOrdIdPrefix() => await _prefix.EvaluateAsync(_request, CancellationToken.None);
+
+    [Benchmark]
+    public async ValueTask<RiskDecision> SecurityIdRate() => await _security.EvaluateAsync(_request, CancellationToken.None);
+}

--- a/benchmarks/B3.EntryPoint.Benchmarks/SessionDeltaSerializationBenchmarks.cs
+++ b/benchmarks/B3.EntryPoint.Benchmarks/SessionDeltaSerializationBenchmarks.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using B3.EntryPoint.Client.State;
+
+namespace B3.EntryPoint.Benchmarks;
+
+/// <summary>
+/// Cost of serializing the polymorphic <see cref="SessionDelta"/> wire envelope.
+/// AppendDeltaAsync calls this on every order entry frame, so allocations
+/// here directly bloat the GC pause budget.
+/// </summary>
+[MemoryDiagnoser]
+public class SessionDeltaSerializationBenchmarks
+{
+    private SessionDelta _outbound = null!;
+    private SessionDelta _inbound = null!;
+    private SessionSnapshot _snapshot = null!;
+    private static readonly JsonSerializerOptions Options = new() { WriteIndented = false };
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _outbound = new OutboundDelta(SeqNum: 12345UL, ClOrdID: "ACME0000001", SecurityId: 5_900_000UL);
+        _inbound = new InboundDelta(SeqNum: 67890UL);
+        _snapshot = new SessionSnapshot
+        {
+            SessionId = 42u,
+            SessionVerId = 1u,
+            LastOutboundSeqNum = 100_000UL,
+            LastInboundSeqNum = 99_000UL,
+            CapturedAt = DateTimeOffset.UtcNow,
+            OutstandingOrders = Enumerable.Range(0, 100)
+                .ToDictionary(i => $"ACME{i:D7}", i => 5_900_000UL + (ulong)i),
+        };
+    }
+
+    [Benchmark] public string OutboundDelta() => JsonSerializer.Serialize<SessionDelta>(_outbound, Options);
+    [Benchmark] public string InboundDelta() => JsonSerializer.Serialize<SessionDelta>(_inbound, Options);
+    [Benchmark] public string Snapshot100Orders() => JsonSerializer.Serialize(_snapshot, Options);
+}


### PR DESCRIPTION
Closes #42

- benchmarks/B3.EntryPoint.Benchmarks: BenchmarkDotNet 0.14.0, OutputType=Exe, IsPackable=false. References B3.EntryPoint.Client.
- DtoConstructionBenchmarks: NewOrderRequest/SimpleNewOrderRequest init + ClOrdID.Parse.
- RiskGateBenchmarks: ClOrdIdPrefixThrottle and SecurityIdRateThrottle hot path (paid by every order).
- SessionDeltaSerializationBenchmarks: polymorphic SessionDelta + 100-order snapshot serialization.
- .github/workflows/bench.yml: workflow_dispatch with optional --filter input; uploads BenchmarkDotNet.Artifacts.
- README: Benchmarks section.

Verified: dotnet test still 79/79 green; dotnet run --list flat enumerates all 8 benchmarks.