### PR TITLE
test(conformance): in-memory FIXP peer + CI conformance job (#49)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,16 @@ jobs:
           --collect:"XPlat Code Coverage"
           --results-directory ./TestResults
 
+      - name: Conformance (in-process FIXP peer)
+        env:
+          ENTRYPOINT_TESTPEER: "1"
+        run: >
+          dotnet test tests/B3.EntryPoint.Conformance/B3.EntryPoint.Conformance.csproj
+          --no-build -c Release
+          --logger "trx;LogFileName=conformance-results.trx"
+          --logger "console;verbosity=normal"
+          --results-directory ./TestResults
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7

--- a/SbeB3EntryPointClient.slnx
+++ b/SbeB3EntryPointClient.slnx
@@ -7,6 +7,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/B3.EntryPoint.Client.Tests/B3.EntryPoint.Client.Tests.csproj" />
     <Project Path="tests/B3.EntryPoint.Conformance/B3.EntryPoint.Conformance.csproj" />
+    <Project Path="tests/B3.EntryPoint.TestPeer/B3.EntryPoint.TestPeer.csproj" />
   </Folder>
   <Folder Name="/benchmarks/">
     <Project Path="benchmarks/B3.EntryPoint.Benchmarks/B3.EntryPoint.Benchmarks.csproj" />

--- a/src/B3.EntryPoint.Cli/Program.cs
+++ b/src/B3.EntryPoint.Cli/Program.cs
@@ -12,10 +12,10 @@ if (args.Length == 0 || args[0] is "-h" or "--help" or "help")
 
 return args[0] switch
 {
-    "connect"  => await ConnectAsync(args[1..]),
-    "submit"   => await SubmitAsync(args[1..]),
-    "replace"  => await ReplaceAsync(args[1..]),
-    "cancel"   => await CancelAsync(args[1..]),
+    "connect" => await ConnectAsync(args[1..]),
+    "submit" => await SubmitAsync(args[1..]),
+    "replace" => await ReplaceAsync(args[1..]),
+    "cancel" => await CancelAsync(args[1..]),
     "dropcopy" => await DropCopyAsync(args[1..]),
     _ => UnknownCommand(args[0]),
 };

--- a/tests/B3.EntryPoint.Client.Tests/State/FileSessionStateStoreTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/State/FileSessionStateStoreTests.cs
@@ -41,8 +41,10 @@ public class FileSessionStateStoreTests
             var store = new FileSessionStateStore(dir);
             await store.SaveAsync(new SessionSnapshot
             {
-                SessionId = 1, SessionVerId = 1,
-                LastOutboundSeqNum = 10, LastInboundSeqNum = 5,
+                SessionId = 1,
+                SessionVerId = 1,
+                LastOutboundSeqNum = 10,
+                LastInboundSeqNum = 5,
                 OutstandingOrders = new() { ["X"] = 100 },
             });
             await store.AppendDeltaAsync(new OutboundDelta(11, "Y", 200));

--- a/tests/B3.EntryPoint.Conformance/B3.EntryPoint.Conformance.csproj
+++ b/tests/B3.EntryPoint.Conformance/B3.EntryPoint.Conformance.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\B3.EntryPoint.Client\B3.EntryPoint.Client.csproj" />
+    <ProjectReference Include="..\B3.EntryPoint.TestPeer\B3.EntryPoint.TestPeer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/B3.EntryPoint.Conformance/Infrastructure/PeerEndpoint.cs
+++ b/tests/B3.EntryPoint.Conformance/Infrastructure/PeerEndpoint.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using B3.EntryPoint.TestPeer;
 
 namespace B3.EntryPoint.Conformance.Infrastructure;
 
@@ -8,10 +9,17 @@ namespace B3.EntryPoint.Conformance.Infrastructure;
 /// <c>B3MatchingPlatform</c> instance or B3 UAT — only env values change.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Scenarios that require a peer must call <see cref="TryResolve"/> and
 /// <c>Skip</c> when <c>null</c>, so CI is green even without a peer
 /// configured. This is the "expected to fail until B3MatchingPlatform#42 lands"
 /// behavior described in the bootstrap issue.
+/// </para>
+/// <para>
+/// Set <c>ENTRYPOINT_TESTPEER=1</c> to spin up an in-process
+/// <see cref="InMemoryFixpPeer"/> instead. This makes the conformance suite
+/// runnable in CI without an external endpoint.
+/// </para>
 /// </remarks>
 public sealed record PeerEndpoint(IPEndPoint Endpoint, uint SessionId, uint SessionVerId, uint EnteringFirm, string AccessKey)
 {
@@ -20,9 +28,31 @@ public sealed record PeerEndpoint(IPEndPoint Endpoint, uint SessionId, uint Sess
     public const string EnvSessionVerId = "B3EP_SESSION_VER_ID";
     public const string EnvFirm = "B3EP_FIRM";
     public const string EnvAccessKey = "B3EP_ACCESS_KEY";
+    public const string EnvUseTestPeer = "ENTRYPOINT_TESTPEER";
+
+    private static readonly Lazy<InMemoryFixpPeer?> SharedTestPeer = new(() =>
+    {
+        if (!IsTestPeerEnabled()) return null;
+        var peer = new InMemoryFixpPeer();
+        peer.Start();
+        AppDomain.CurrentDomain.ProcessExit += async (_, _) => await peer.DisposeAsync();
+        return peer;
+    });
+
+    public static bool IsTestPeerEnabled()
+    {
+        var v = Environment.GetEnvironmentVariable(EnvUseTestPeer);
+        return string.Equals(v, "1", StringComparison.Ordinal)
+            || string.Equals(v, "true", StringComparison.OrdinalIgnoreCase);
+    }
 
     public static PeerEndpoint? TryResolve()
     {
+        if (IsTestPeerEnabled() && SharedTestPeer.Value is { } peer)
+        {
+            return new PeerEndpoint(peer.Endpoint, SessionId: 1u, SessionVerId: 1u, EnteringFirm: 1u, AccessKey: "TESTPEER");
+        }
+
         var endpoint = Environment.GetEnvironmentVariable(EnvEndpoint);
         var sessionId = Environment.GetEnvironmentVariable(EnvSessionId);
         var sessionVerId = Environment.GetEnvironmentVariable(EnvSessionVerId);
@@ -48,5 +78,5 @@ public sealed record PeerEndpoint(IPEndPoint Endpoint, uint SessionId, uint Sess
     }
 
     public const string SkipReason =
-        "Conformance peer not configured. Set B3EP_PEER, B3EP_SESSION_ID, B3EP_SESSION_VER_ID, B3EP_FIRM, B3EP_ACCESS_KEY to run.";
+        "Conformance peer not configured. Set ENTRYPOINT_TESTPEER=1 for the in-process peer, or B3EP_PEER + credentials for an external one.";
 }

--- a/tests/B3.EntryPoint.TestPeer/B3.EntryPoint.TestPeer.csproj
+++ b/tests/B3.EntryPoint.TestPeer/B3.EntryPoint.TestPeer.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>B3.EntryPoint.TestPeer</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.EntryPoint.Sbe\B3.EntryPoint.Sbe.csproj" />
+    <ProjectReference Include="..\..\src\B3.EntryPoint.Client\B3.EntryPoint.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/B3.EntryPoint.TestPeer/InMemoryFixpPeer.cs
+++ b/tests/B3.EntryPoint.TestPeer/InMemoryFixpPeer.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.EntryPoint.Client.Framing;
+
+namespace B3.EntryPoint.TestPeer;
+
+/// <summary>
+/// Minimal in-process FIXP gateway for conformance tests. Accepts TCP
+/// connections, reads SOFH-framed SBE messages, and replies to the FIXP
+/// session-layer handshake (Negotiate/Establish/Terminate). Application
+/// messages are silently consumed so the client's send paths exercise their
+/// full encode/flush cycle.
+///
+/// Not a complete B3 simulator — just enough to drive the conformance tests
+/// without an external endpoint. Application response messages
+/// (ExecutionReport*) are out of scope here.
+/// </summary>
+public sealed class InMemoryFixpPeer : IAsyncDisposable
+{
+    private readonly TcpListener _listener;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly List<Task> _connections = new();
+    private Task? _acceptLoop;
+
+    public InMemoryFixpPeer()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+    }
+
+    public IPEndPoint Endpoint => (IPEndPoint)_listener.LocalEndpoint;
+
+    public void Start()
+    {
+        _listener.Start();
+        _acceptLoop = AcceptLoopAsync(_cts.Token);
+    }
+
+    private async Task AcceptLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var tcp = await _listener.AcceptTcpClientAsync(ct).ConfigureAwait(false);
+                lock (_connections)
+                    _connections.Add(HandleConnectionAsync(tcp, ct));
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+        catch (SocketException) { }
+    }
+
+    private static async Task HandleConnectionAsync(TcpClient tcp, CancellationToken ct)
+    {
+        try
+        {
+            using (tcp)
+            await using (var stream = tcp.GetStream())
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    byte[] frame;
+                    try
+                    {
+                        frame = await SofhFrameReader.ReadFrameAsync(stream, ct).ConfigureAwait(false);
+                    }
+                    catch (EndOfStreamException) { return; }
+                    catch (IOException) { return; }
+
+                    var templateId = ReadTemplateId(frame);
+                    switch (templateId)
+                    {
+                        case NegotiateData.MESSAGE_ID:
+                            await SendNegotiateResponseAsync(stream, frame, ct).ConfigureAwait(false);
+                            break;
+                        case EstablishData.MESSAGE_ID:
+                            await SendEstablishAckAsync(stream, frame, ct).ConfigureAwait(false);
+                            break;
+                        case TerminateData.MESSAGE_ID:
+                            await SendTerminateEchoAsync(stream, frame, ct).ConfigureAwait(false);
+                            return;
+                        default:
+                            // Application or session-layer messages we don't model — swallow.
+                            break;
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (IOException) { }
+        catch (ObjectDisposedException) { }
+    }
+
+    private static async Task SendNegotiateResponseAsync(Stream stream, byte[] requestFrame, CancellationToken ct)
+    {
+        if (!NegotiateData.TryParse(requestFrame.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out var reader))
+            return;
+        ref readonly var req = ref reader.Data;
+
+        var totalSize = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + NegotiateResponseData.MESSAGE_SIZE;
+        var buffer = new byte[totalSize];
+        SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
+        NegotiateResponseData.WriteHeader(buffer.AsSpan(SofhFrameReader.HeaderSize));
+
+        var resp = new NegotiateResponseData
+        {
+            SessionID = req.SessionID,
+            SessionVerID = req.SessionVerID,
+            RequestTimestamp = req.Timestamp,
+            EnteringFirm = req.EnteringFirm,
+        };
+        if (!resp.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
+            return;
+
+        await stream.WriteAsync(buffer, ct).ConfigureAwait(false);
+        await stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    private static async Task SendEstablishAckAsync(Stream stream, byte[] requestFrame, CancellationToken ct)
+    {
+        if (!EstablishData.TryParse(requestFrame.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out var reader))
+            return;
+        ref readonly var req = ref reader.Data;
+
+        var totalSize = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + EstablishAckData.MESSAGE_SIZE;
+        var buffer = new byte[totalSize];
+        SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
+        EstablishAckData.WriteHeader(buffer.AsSpan(SofhFrameReader.HeaderSize));
+
+        var ack = new EstablishAckData
+        {
+            SessionID = req.SessionID,
+            SessionVerID = req.SessionVerID,
+            RequestTimestamp = req.Timestamp,
+            KeepAliveInterval = req.KeepAliveInterval,
+            NextSeqNo = new SeqNum(1u),
+            LastIncomingSeqNo = new SeqNum(req.NextSeqNo.Value > 0u ? req.NextSeqNo.Value - 1u : 0u),
+        };
+        if (!ack.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
+            return;
+
+        await stream.WriteAsync(buffer, ct).ConfigureAwait(false);
+        await stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    private static async Task SendTerminateEchoAsync(Stream stream, byte[] requestFrame, CancellationToken ct)
+    {
+        if (!TerminateData.TryParse(requestFrame.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out var reader))
+            return;
+        ref readonly var req = ref reader.Data;
+
+        var totalSize = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + TerminateData.MESSAGE_SIZE;
+        var buffer = new byte[totalSize];
+        SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
+        TerminateData.WriteHeader(buffer.AsSpan(SofhFrameReader.HeaderSize));
+
+        var echo = new TerminateData
+        {
+            SessionID = req.SessionID,
+            SessionVerID = req.SessionVerID,
+            TerminationCode = TerminationCode.FINISHED,
+        };
+        if (!echo.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
+            return;
+
+        try
+        {
+            await stream.WriteAsync(buffer, ct).ConfigureAwait(false);
+            await stream.FlushAsync(ct).ConfigureAwait(false);
+        }
+        catch (IOException) { }
+    }
+
+    private static ushort ReadTemplateId(byte[] frame) =>
+        System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(
+            frame.AsSpan(SofhFrameReader.HeaderSize + 2, 2));
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        try { _listener.Stop(); } catch { }
+        Task[] tasks;
+        lock (_connections) tasks = _connections.ToArray();
+        try { await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false); } catch { }
+        if (_acceptLoop is not null)
+            try { await _acceptLoop.WaitAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false); } catch { }
+        _cts.Dispose();
+    }
+}


### PR DESCRIPTION
Closes #49

New tests/B3.EntryPoint.TestPeer assembly with an InMemoryFixpPeer that handles the FIXP session-layer handshake (Negotiate / Establish / Terminate) on a dynamic loopback TCP port. Application messages are silently consumed, which is sufficient for the current 8 conformance tests since none of them assert on inbound application traffic.

PeerEndpoint.TryResolve now spins up a shared peer when ENTRYPOINT_TESTPEER=1 is exported. Default behavior (no env vars) still skips the suite. ci.yml gets a new step that exports the var so all 8 tests run on every push and PR.

Verified: ENTRYPOINT_TESTPEER=1 dotnet test -> 8/8 conformance pass; default unit run still 82/82 + 8 skipped.