### PR TITLE
Wire ISessionStateStore into EntryPointClient (#50)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
@@ -6,6 +7,7 @@ using B3.Entrypoint.Fixp.Sbe.V6;
 using B3.EntryPoint.Client.Fixp;
 using B3.EntryPoint.Client.Models;
 using B3.EntryPoint.Client.Risk;
+using B3.EntryPoint.Client.State;
 using B3.EntryPoint.Client.Telemetry;
 using Microsoft.Extensions.Logging;
 using ClOrdID = B3.EntryPoint.Client.Models.ClOrdID;
@@ -35,6 +37,10 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     private DateTime _lastInboundUtc;
     private CancellationTokenSource? _idleCts;
     private Task? _idleWatchdog;
+
+    private readonly ConcurrentDictionary<string, ulong> _outstandingOrders = new(StringComparer.Ordinal);
+    private long _deltasSinceCompact;
+    private ulong _lastInboundSeqNum;
 
     /// <summary>Keep-alive scheduler for this client. Bound after <see cref="ConnectAsync"/>.</summary>
     public IKeepAliveScheduler? KeepAlive => _keepAlive;
@@ -127,6 +133,11 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
             await _session.EstablishAsync(ct).ConfigureAwait(false);
             _options.Logger.LogDebug("FIXP Established with {Endpoint}", _options.Endpoint);
         }
+
+        await HydrateFromSnapshotAsync(ct).ConfigureAwait(false);
+
+        _session.OnInboundEvent = OnInboundEventForPersistence;
+
         _session.StartInboundLoop(_events.Writer);
 
         _keepAlive = new KeepAliveScheduler(
@@ -243,6 +254,103 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
             new KeyValuePair<string, object?>("kind", kind.ToString()));
     }
 
+    private async ValueTask HydrateFromSnapshotAsync(CancellationToken ct)
+    {
+        if (_options.SessionStateStore is null) return;
+        var snapshot = await _options.SessionStateStore.ReplayAsync(ct).ConfigureAwait(false);
+        if (snapshot is null) return;
+        if (snapshot.SessionId != _options.SessionId)
+        {
+            _options.Logger.LogInformation("Persisted snapshot SessionID={Persisted} != current {Current}; ignoring.",
+                snapshot.SessionId, _options.SessionId);
+            return;
+        }
+        _session!.ResumeOutboundSeqNum(snapshot.LastOutboundSeqNum + 1UL);
+        _lastInboundSeqNum = snapshot.LastInboundSeqNum;
+        _outstandingOrders.Clear();
+        foreach (var (clordid, secId) in snapshot.OutstandingOrders)
+            _outstandingOrders[clordid] = secId;
+        _options.Logger.LogInformation(
+            "Hydrated from snapshot: outboundSeq={Out} inboundSeq={In} outstanding={Count}",
+            snapshot.LastOutboundSeqNum, snapshot.LastInboundSeqNum, _outstandingOrders.Count);
+    }
+
+    private async ValueTask AppendOutboundDeltaAsync(ulong seq, string clordid, ulong securityId, CancellationToken ct)
+    {
+        var store = _options.SessionStateStore;
+        if (store is null) return;
+        _outstandingOrders[clordid] = securityId;
+        try
+        {
+            await store.AppendDeltaAsync(new OutboundDelta(seq, clordid, securityId), ct).ConfigureAwait(false);
+            await MaybeCompactAsync(store, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _options.Logger.LogWarning(ex, "Failed to append OutboundDelta for ClOrdID={ClOrdID}", clordid);
+        }
+    }
+
+    private async ValueTask MaybeCompactAsync(ISessionStateStore store, CancellationToken ct)
+    {
+        var threshold = _options.StateCompactEveryDeltas;
+        if (threshold <= 0) return;
+        if (System.Threading.Interlocked.Increment(ref _deltasSinceCompact) < threshold) return;
+        System.Threading.Interlocked.Exchange(ref _deltasSinceCompact, 0);
+        try
+        {
+            await store.SaveAsync(BuildSnapshot(), ct).ConfigureAwait(false);
+            await store.CompactAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _options.Logger.LogWarning(ex, "Failed periodic snapshot compaction");
+        }
+    }
+
+    private SessionSnapshot BuildSnapshot() => new()
+    {
+        SessionId = _options.SessionId,
+        SessionVerId = _options.SessionVerId,
+        LastOutboundSeqNum = _session is null ? 0UL : _session.NextOutboundSeqNum() - 1UL,
+        LastInboundSeqNum = _lastInboundSeqNum,
+        CapturedAt = DateTimeOffset.UtcNow,
+        OutstandingOrders = new Dictionary<string, ulong>(_outstandingOrders),
+    };
+
+    private void OnInboundEventForPersistence(EntryPointEvent evt)
+    {
+        if (evt.SeqNum > _lastInboundSeqNum) _lastInboundSeqNum = evt.SeqNum;
+        var store = _options.SessionStateStore;
+        if (store is null) return;
+
+        string? closedClOrdId = evt switch
+        {
+            OrderCancelled c => c.ClOrdID.Value.ToString(),
+            OrderRejected r => r.ClOrdID.Value.ToString(),
+            OrderTrade t when t.LeavesQty == 0UL => t.ClOrdID.Value.ToString(),
+            _ => null,
+        };
+
+        if (closedClOrdId is null) return;
+        _outstandingOrders.TryRemove(closedClOrdId, out _);
+
+        // Fire-and-forget so the inbound loop is never blocked by I/O.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await store.AppendDeltaAsync(new OrderClosedDelta(closedClOrdId)).ConfigureAwait(false);
+                await store.AppendDeltaAsync(new InboundDelta(evt.SeqNum)).ConfigureAwait(false);
+                await MaybeCompactAsync(store, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _options.Logger.LogWarning(ex, "Failed to persist OrderClosedDelta for {ClOrdID}", closedClOrdId);
+            }
+        });
+    }
+
     /// <inheritdoc />
     public async Task<ClOrdID> SubmitAsync(NewOrderRequest request, CancellationToken ct = default)
     {
@@ -256,6 +364,7 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
         var buffer = new byte[NewOrderSingleData.MESSAGE_SIZE + 256];
         var len = OrderEntryEncoder.EncodeNewOrderSingle(buffer, request, _options, seq);
         await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "NewOrder"));
         RecordLatency(startTs, OutboundRequestKind.NewOrder);
         return request.ClOrdID;
@@ -274,6 +383,7 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
         var buffer = new byte[SimpleNewOrderData.MESSAGE_SIZE + 64];
         var len = OrderEntryEncoder.EncodeSimpleNewOrder(buffer, request, _options, seq);
         await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "SimpleNewOrder"));
         RecordLatency(startTs, OutboundRequestKind.SimpleNewOrder);
         return request.ClOrdID;
@@ -292,6 +402,7 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
         var buffer = new byte[OrderCancelReplaceRequestData.MESSAGE_SIZE + 256];
         var len = OrderEntryEncoder.EncodeOrderCancelReplace(buffer, request, _options, seq);
         await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersReplaced.Add(1, new KeyValuePair<string, object?>("kind", "Replace"));
         RecordLatency(startTs, OutboundRequestKind.Replace);
         return request.ClOrdID;
@@ -310,6 +421,7 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
         var buffer = new byte[SimpleModifyOrderData.MESSAGE_SIZE + 64];
         var len = OrderEntryEncoder.EncodeSimpleModifyOrder(buffer, request, _options, seq);
         await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersReplaced.Add(1, new KeyValuePair<string, object?>("kind", "SimpleReplace"));
         RecordLatency(startTs, OutboundRequestKind.SimpleReplace);
         return request.ClOrdID;
@@ -328,6 +440,7 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
         var buffer = new byte[OrderCancelRequestData.MESSAGE_SIZE + 256];
         var len = OrderEntryEncoder.EncodeOrderCancel(buffer, request, _options, seq);
         await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersCancelled.Add(1);
         RecordLatency(startTs, OutboundRequestKind.Cancel);
     }
@@ -349,6 +462,7 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
             var buffer = new byte[OrderMassActionRequestData.MESSAGE_SIZE + 32];
             var len = OrderEntryEncoder.EncodeOrderMassAction(buffer, req, _options, seq);
             await _session.SendApplicationFrameAsync(buffer, len, token).ConfigureAwait(false);
+            await AppendOutboundDeltaAsync(seq, clordid, req.SecurityId ?? 0UL, token).ConfigureAwait(false);
             EntryPointTelemetry.MassActions.Add(1);
             RecordLatency(startTs, OutboundRequestKind.MassAction);
             return new MassActionReport

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -97,6 +97,20 @@ public sealed class EntryPointClientOptions
     /// Defaults to <see cref="NullLogger.Instance"/> so existing tests are unaffected.</summary>
     public ILogger Logger { get; init; } = NullLogger.Instance;
 
+    /// <summary>
+    /// Optional persistence for warm-restart. When provided, the client hydrates
+    /// outbound/inbound sequence numbers and outstanding orders from the snapshot
+    /// after Establish, appends an <see cref="State.OutboundDelta"/> per outbound
+    /// frame, an <see cref="State.OrderClosedDelta"/> per terminal ExecutionReport,
+    /// and triggers a snapshot+truncate after every
+    /// <see cref="StateCompactEveryDeltas"/> appends.
+    /// </summary>
+    public State.ISessionStateStore? SessionStateStore { get; init; }
+
+    /// <summary>How many appended deltas trigger a <see cref="State.ISessionStateStore.CompactAsync"/>.
+    /// Set to <c>0</c> to disable automatic compaction. Defaults to 1024.</summary>
+    public int StateCompactEveryDeltas { get; init; } = 1024;
+
     private static string ThisAssemblyVersion() =>
         typeof(EntryPointClientOptions).Assembly.GetName().Version?.ToString() ?? "0.0.0";
 }

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -123,6 +123,17 @@ internal sealed class FixpClientSession : IAsyncDisposable
     private ChannelWriter<EntryPointEvent>? _eventWriter;
 
     /// <summary>
+    /// Resumes the outbound counter from a persisted snapshot. Must be called
+    /// before any frame is sent (i.e. immediately after Establish completes).
+    /// </summary>
+    public void ResumeOutboundSeqNum(ulong nextOutboundSeqNum)
+    {
+        if (nextOutboundSeqNum == 0UL) return;
+        // NextOutboundSeqNum returns the post-increment, so seed with (next - 1).
+        System.Threading.Interlocked.Exchange(ref _outboundSeqNum, (long)(nextOutboundSeqNum - 1UL));
+    }
+
+    /// <summary>
     /// Starts the inbound dispatch loop. Decoded application events are written to
     /// <paramref name="writer"/>; session-layer messages (Sequence/NotApplied/etc.)
     /// are silently consumed for now (#24/#25 will surface them).
@@ -147,6 +158,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
                 if (frame.Length < SofhSize + SbeHeaderSize) continue;
                 if (InboundDecoder.TryDecode(frame, out var evt) && evt is not null)
                 {
+                    try { OnInboundEvent?.Invoke(evt); } catch { /* swallow — telemetry/persistence must not break the loop */ }
                     await _eventWriter!.WriteAsync(evt, ct).ConfigureAwait(false);
                 }
                 else
@@ -264,6 +276,11 @@ internal sealed class FixpClientSession : IAsyncDisposable
 
     /// <summary>Optional hook: invoked by the inbound loop when a peer Sequence frame arrives.</summary>
     internal Action<ulong>? OnInboundSequence { get; set; }
+
+    /// <summary>Optional hook: invoked for every decoded application
+    /// <see cref="EntryPointEvent"/> before it is published to the user channel.
+    /// Used internally to drive <see cref="EntryPointClient"/> persistence.</summary>
+    internal Action<Models.EntryPointEvent>? OnInboundEvent { get; set; }
 
     /// <summary>Optional hook: invoked when a Retransmission frame arrives. Args: (nextSeqNo, count, requestTimestampNanos).</summary>
     internal Action<ulong, uint, ulong>? OnInboundRetransmission { get; set; }

--- a/tests/B3.EntryPoint.Client.Tests/State/SessionStateStoreWiringTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/State/SessionStateStoreWiringTests.cs
@@ -1,0 +1,83 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.State;
+using Xunit;
+
+namespace B3.EntryPoint.Client.Tests.State;
+
+public class SessionStateStoreWiringTests
+{
+    [Fact]
+    public async Task Replay_AppliesOutboundAndClosedDeltas()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "b3epc-state-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var store = new FileSessionStateStore(dir);
+            await store.SaveAsync(new SessionSnapshot
+            {
+                SessionId = 42u,
+                SessionVerId = 1u,
+                LastOutboundSeqNum = 100UL,
+                LastInboundSeqNum = 50UL,
+                CapturedAt = DateTimeOffset.UtcNow,
+                OutstandingOrders = new() { ["CL-1"] = 7UL, ["CL-2"] = 9UL },
+            });
+            await store.AppendDeltaAsync(new OutboundDelta(101UL, "CL-3", 11UL));
+            await store.AppendDeltaAsync(new OutboundDelta(102UL, "CL-4", 12UL));
+            await store.AppendDeltaAsync(new OrderClosedDelta("CL-1"));
+            await store.AppendDeltaAsync(new InboundDelta(60UL));
+
+            var replay = await store.ReplayAsync();
+            Assert.NotNull(replay);
+            Assert.Equal(102UL, replay!.LastOutboundSeqNum);
+            Assert.Equal(60UL, replay.LastInboundSeqNum);
+            Assert.False(replay.OutstandingOrders.ContainsKey("CL-1"));
+            Assert.True(replay.OutstandingOrders.ContainsKey("CL-3"));
+            Assert.True(replay.OutstandingOrders.ContainsKey("CL-4"));
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void EntryPointClientOptions_ExposeStateStoreSlots()
+    {
+        var opts = new EntryPointClientOptions
+        {
+            Endpoint = new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 1),
+            SessionId = 1,
+            SessionVerId = 1,
+            EnteringFirm = 1,
+            Credentials = Credentials.FromUtf8("k"),
+        };
+        Assert.Null(opts.SessionStateStore);
+        Assert.True(opts.StateCompactEveryDeltas > 0);
+    }
+
+    [Fact]
+    public async Task Compact_TruncatesDeltas_AfterRebuild()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "b3epc-compact-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var store = new FileSessionStateStore(dir);
+            await store.SaveAsync(new SessionSnapshot { SessionId = 1u, SessionVerId = 1u, LastOutboundSeqNum = 10UL });
+            for (ulong i = 11UL; i <= 20UL; i++)
+                await store.AppendDeltaAsync(new OutboundDelta(i, $"X{i}", i));
+            await store.CompactAsync();
+            var replay = await store.ReplayAsync();
+            Assert.Equal(20UL, replay!.LastOutboundSeqNum);
+            Assert.Equal(10, replay.OutstandingOrders.Count);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+}
+


### PR DESCRIPTION
Closes #50.

Wires session state persistence end-to-end:

- **Hydrate after Establish** — `EntryPointClient` reads `SessionSnapshot` from the configured `ISessionStateStore` via `ReplayAsync`, validates `SessionId`, and seeds the FIXP outbound counter through `FixpClientSession.ResumeOutboundSeqNum`.
- **Append on send** — every Submit/Replace/Cancel/MassAction (6 paths) emits an `OutboundDelta(seq, ClOrdID, SecurityId)` after the frame is on the wire.
- **Terminal close tracking** — new internal `OnInboundEvent` hook on `FixpClientSession` is fed by `EntryPointClient` to persist `OrderClosedDelta` + `InboundDelta` on `OrderCancelled`, `OrderRejected`, and fully filled `OrderTrade` (`LeavesQty == 0`).
- **Periodic compact** — every `EntryPointClientOptions.StateCompactEveryDeltas` (default 1024) writes a fresh snapshot and truncates the delta log.
- Tests: snapshot replay applies outbound + closed deltas, options surface, compact-after-rebuild round-trip.

85/85 unit tests + 8/8 conformance under `ENTRYPOINT_TESTPEER=1`.