### PR TITLE
Add Cross + Quote API surface (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ integração com `B3MatchingPlatform` antes da fiação SBE/FIXP completa.
 | Drop Copy session profile | [#10](https://github.com/pedrosakuma/B3EntryPointClient/issues/10) |
 | Conformance §4.5..§4.8 + Order Entry + Drop Copy | [#11](https://github.com/pedrosakuma/B3EntryPointClient/issues/11) |
 
-Cross / Quote / Position / Allocation / SecurityDefinition messages estão fora
-de escopo nesta fase.
+Position / Allocation / SecurityDefinition messages estão fora de escopo
+nesta fase (não constam do schema atual). Cross / Quote possuem **interface
+estável** (`ISubmitCross`, `IQuoteFlow`) — wire-up SBE rastreado pela issue
+[#51](https://github.com/pedrosakuma/B3EntryPointClient/issues/51).
 
 ## Benchmarks
 

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -21,7 +21,7 @@ namespace B3.EntryPoint.Client;
 /// public API surface; their wire-level implementations land incrementally
 /// (see <c>docs/CONFORMANCE.md</c> and the issues tagged <c>area/api-surface</c>).
 /// </summary>
-public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceOrder, ICancelOrder
+public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceOrder, ICancelOrder, ISubmitCross, IQuoteFlow
 {
     private readonly EntryPointClientOptions _options;
     private readonly Channel<EntryPointEvent> _events =
@@ -474,6 +474,42 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
                 TotalAffectedOrders = 0,
             };
         }
+    }
+
+    /// <inheritdoc />
+    public Task<string> SubmitCrossAsync(NewOrderCrossRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureEstablished();
+        throw new NotImplementedException(
+            "NewOrderCross wire-up pending — tracked by issue #51 (interface exposed for early integration).");
+    }
+
+    /// <inheritdoc />
+    public Task SendQuoteRequestAsync(QuoteRequestMessage request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureEstablished();
+        throw new NotImplementedException(
+            "QuoteRequest wire-up pending — tracked by issue #51 (interface exposed for early integration).");
+    }
+
+    /// <inheritdoc />
+    public Task SendQuoteAsync(QuoteMessage quote, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(quote);
+        EnsureEstablished();
+        throw new NotImplementedException(
+            "Quote wire-up pending — tracked by issue #51 (interface exposed for early integration).");
+    }
+
+    /// <inheritdoc />
+    public Task CancelQuoteAsync(string quoteId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(quoteId);
+        EnsureEstablished();
+        throw new NotImplementedException(
+            "QuoteCancel wire-up pending — tracked by issue #51 (interface exposed for early integration).");
     }
 
     /// <summary>

--- a/src/B3.EntryPoint.Client/ICrossQuoteFlows.cs
+++ b/src/B3.EntryPoint.Client/ICrossQuoteFlows.cs
@@ -1,0 +1,31 @@
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client;
+
+/// <summary>
+/// Submits a <c>NewOrderCross</c> message (schema §9). Wire-up is tracked by
+/// issue #51; the current implementation throws <see cref="NotImplementedException"/>
+/// so consumers can integrate against the typed contract today.
+/// </summary>
+public interface ISubmitCross
+{
+    /// <summary>Submits a cross trade. Returns the <c>CrossID</c> echoed back.</summary>
+    Task<string> SubmitCrossAsync(NewOrderCrossRequest request, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Quote-side messaging (QuoteRequest, Quote, QuoteCancel). Wire-up tracked
+/// by issue #51 — interfaces are exposed today so dependent services can
+/// integrate against them while wiring lands incrementally.
+/// </summary>
+public interface IQuoteFlow
+{
+    /// <summary>Sends a <c>QuoteRequest</c>.</summary>
+    Task SendQuoteRequestAsync(QuoteRequestMessage request, CancellationToken ct = default);
+
+    /// <summary>Sends a <c>Quote</c> (market-maker quote).</summary>
+    Task SendQuoteAsync(QuoteMessage quote, CancellationToken ct = default);
+
+    /// <summary>Cancels a previously sent quote by <paramref name="quoteId"/>.</summary>
+    Task CancelQuoteAsync(string quoteId, CancellationToken ct = default);
+}

--- a/src/B3.EntryPoint.Client/Models/CrossQuoteModels.cs
+++ b/src/B3.EntryPoint.Client/Models/CrossQuoteModels.cs
@@ -1,0 +1,82 @@
+namespace B3.EntryPoint.Client.Models;
+
+/// <summary>Cross trade type for <c>NewOrderCross</c> (FIX <c>CrossType</c>).</summary>
+public enum CrossType : byte
+{
+    AllOrNone = 1,
+    Default = 2,
+}
+
+/// <summary>Cross prioritization (FIX <c>CrossPrioritization</c>).</summary>
+public enum CrossPrioritization : byte
+{
+    None = 0,
+    BuySidePrioritized = 1,
+    SellSidePrioritized = 2,
+}
+
+/// <summary>Side of a sub-order leg inside a cross.</summary>
+public sealed record CrossLeg
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required Side Side { get; init; }
+    public required ulong OrderQty { get; init; }
+    public AccountType AccountType { get; init; } = AccountType.RegularAccount;
+    public ulong? Account { get; init; }
+}
+
+/// <summary>Logical request shape for <c>NewOrderCross</c> (schema §9).</summary>
+public sealed record NewOrderCrossRequest
+{
+    public required string CrossId { get; init; }
+    public required ulong SecurityId { get; init; }
+    public required CrossType CrossType { get; init; }
+    public required CrossPrioritization Prioritization { get; init; }
+    public required decimal Price { get; init; }
+    public required IReadOnlyList<CrossLeg> Legs { get; init; }
+}
+
+/// <summary>Logical request shape for <c>QuoteRequest</c>.</summary>
+public sealed record QuoteRequestMessage
+{
+    public required string QuoteReqId { get; init; }
+    public required ulong SecurityId { get; init; }
+    public ulong? OrderQty { get; init; }
+    public Side? Side { get; init; }
+}
+
+/// <summary>Logical request shape for <c>Quote</c> (a market-maker quote).</summary>
+public sealed record QuoteMessage
+{
+    public required string QuoteId { get; init; }
+    public required ulong SecurityId { get; init; }
+    public decimal? BidPrice { get; init; }
+    public decimal? OfferPrice { get; init; }
+    public ulong? BidSize { get; init; }
+    public ulong? OfferSize { get; init; }
+    public string? QuoteReqId { get; init; }
+}
+
+/// <summary>Reason carried by <c>QuoteRequestReject</c> (FIX <c>QuoteRequestRejectReason</c>).</summary>
+public enum QuoteRequestRejectReason : byte
+{
+    UnknownSymbol = 1,
+    ExchangeClosed = 2,
+    QuoteRequestExceedsLimit = 3,
+    TooLateToEnter = 4,
+    InvalidPrice = 5,
+    NotAuthorizedToRequestQuote = 6,
+    Other = 99,
+}
+
+/// <summary>Status of an outstanding quote (FIX <c>QuoteStatus</c> subset).</summary>
+public enum QuoteStatus : byte
+{
+    Accepted = 0,
+    CanceledForSymbol = 1,
+    CanceledAll = 4,
+    Rejected = 5,
+    RemovedFromMarket = 6,
+    Expired = 7,
+    Active = 16,
+}

--- a/tests/B3.EntryPoint.Client.Tests/CrossQuoteApiSurfaceTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/CrossQuoteApiSurfaceTests.cs
@@ -1,0 +1,43 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Models;
+using Xunit;
+
+namespace B3.EntryPoint.Client.Tests;
+
+public class CrossQuoteApiSurfaceTests
+{
+    [Fact]
+    public void EntryPointClient_ImplementsCrossAndQuoteInterfaces()
+    {
+        Assert.True(typeof(ISubmitCross).IsAssignableFrom(typeof(EntryPointClient)));
+        Assert.True(typeof(IQuoteFlow).IsAssignableFrom(typeof(EntryPointClient)));
+    }
+
+    [Fact]
+    public void NewOrderCrossRequest_IsConstructible()
+    {
+        var req = new NewOrderCrossRequest
+        {
+            CrossId = "X-1",
+            SecurityId = 5,
+            CrossType = CrossType.Default,
+            Prioritization = CrossPrioritization.None,
+            Price = 12.34m,
+            Legs = new[]
+            {
+                new CrossLeg { ClOrdID = (ClOrdID)1UL, Side = Side.Buy, OrderQty = 10 },
+                new CrossLeg { ClOrdID = (ClOrdID)2UL, Side = Side.Sell, OrderQty = 10 },
+            },
+        };
+        Assert.Equal(2, req.Legs.Count);
+    }
+
+    [Fact]
+    public void QuoteAndQuoteRequest_AreConstructible()
+    {
+        var qr = new QuoteRequestMessage { QuoteReqId = "QR-1", SecurityId = 1 };
+        var q = new QuoteMessage { QuoteId = "Q-1", SecurityId = 1, BidPrice = 1m, OfferPrice = 2m };
+        Assert.Equal("QR-1", qr.QuoteReqId);
+        Assert.Equal("Q-1", q.QuoteId);
+    }
+}


### PR DESCRIPTION
Closes #51.

Adds the typed contract for the Cross / Quote message families that exist in the B3 SBE schema (Position / Allocation / SecurityDefinition are not in-schema and remain out of scope).

**API surface added (zero wire-up — stubs throw `NotImplementedException` citing this issue, mirroring the pattern used by the original API-surface PRs #3-#11):**

- `Models/CrossQuoteModels.cs` — `NewOrderCrossRequest`, `CrossLeg`, `QuoteRequestMessage`, `QuoteMessage` + enums `CrossType`, `CrossPrioritization`, `QuoteRequestRejectReason`, `QuoteStatus`.
- `ICrossQuoteFlows.cs` — `ISubmitCross.SubmitCrossAsync`, `IQuoteFlow.SendQuoteRequestAsync / SendQuoteAsync / CancelQuoteAsync`.
- `EntryPointClient` implements both; each method throws `NotImplementedException("... wire-up pending — tracked by issue #51")`.
- README: Cross/Quote moved out of the 'fora de escopo' bucket; positions/allocations/security-definition called out as not-in-schema.
- 3 surface tests verifying the interfaces are implemented and DTOs construct cleanly.

88/88 unit + 8/8 conformance under `ENTRYPOINT_TESTPEER=1`.