### PR TITLE
Add Quickstart sample + docs (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ wire-puro is so the same code can drive the simulator or B3 UAT.
   `Models/`, `EntryPointClient.cs` (high-level API).
 - **`B3.EntryPoint.Cli`** — thin CLI wrapper for manual smoke testing
   (`connect` only in the bootstrap).
+- **`samples/B3.EntryPoint.Quickstart`** — end-to-end console demo against
+  the in-memory FIXP peer. See [Quickstart](docs/QUICKSTART.md).
+
+## Quickstart
+
+```bash
+dotnet run --project samples/B3.EntryPoint.Quickstart
+```
+
+Full walkthrough: [docs/QUICKSTART.md](docs/QUICKSTART.md).
 
 ## Build & test
 

--- a/SbeB3EntryPointClient.slnx
+++ b/SbeB3EntryPointClient.slnx
@@ -12,4 +12,7 @@
   <Folder Name="/benchmarks/">
     <Project Path="benchmarks/B3.EntryPoint.Benchmarks/B3.EntryPoint.Benchmarks.csproj" />
   </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/B3.EntryPoint.Quickstart/B3.EntryPoint.Quickstart.csproj" />
+  </Folder>
 </Solution>

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,88 @@
+# Quickstart
+
+This guide gets a working `EntryPointClient` running in less than a minute,
+without a real B3 EntryPoint endpoint, by routing it to the in-memory FIXP
+peer that ships with this repo.
+
+## Prerequisites
+
+- .NET 10 SDK (see `global.json` for the exact version pin)
+
+## Run the sample
+
+```bash
+dotnet run --project samples/B3.EntryPoint.Quickstart
+```
+
+Expected output:
+
+```
+Connected. State=Established
+Submitted 42
+Terminated.
+```
+
+## What the sample does
+
+The full source is at
+[`samples/B3.EntryPoint.Quickstart/Program.cs`](../samples/B3.EntryPoint.Quickstart/Program.cs)
+and walks through the canonical lifecycle:
+
+1. **Boot a local peer** — `InMemoryFixpPeer` listens on a dynamic loopback
+   port and answers Negotiate / Establish / Terminate.
+2. **Build options** — `EntryPointClientOptions` carries the peer endpoint,
+   `SessionId`, `SessionVerId`, `EnteringFirm`, and `Credentials`.
+3. **`ConnectAsync`** — runs the FIXP handshake (Negotiate → Establish) and
+   starts the inbound loop.
+4. **`SubmitAsync(NewOrderRequest)`** — encodes a `NewOrderSingle` SBE frame
+   and pushes it across the socket. Pre-trade `RiskGates` (if registered)
+   evaluate first.
+5. **Drain `Events()`** — `IAsyncEnumerable<EntryPointEvent>` of decoded
+   `OrderAccepted` / `OrderModified` / `OrderCancelled` / `OrderTrade` /
+   `OrderRejected` / `BusinessReject`.
+6. **`TerminateAsync`** — sends a `Terminate(Finished)` and tears the session
+   down cleanly.
+
+## Adding a real endpoint
+
+Swap the peer for a real address:
+
+```csharp
+var options = new EntryPointClientOptions
+{
+    Endpoint = new IPEndPoint(IPAddress.Parse("10.0.0.5"), 9_000),
+    SessionId = 12345,
+    SessionVerId = 1,
+    EnteringFirm = 1234,
+    Credentials = Credentials.FromUtf8(File.ReadAllText("/secrets/key")),
+};
+```
+
+## Warm-restart (snapshot persistence)
+
+Wire an `ISessionStateStore` (e.g. `FileSessionStateStore`) via
+`EntryPointClientOptions.SessionStateStore` and the client will:
+
+- Hydrate `LastOutboundSeqNum` / outstanding orders on `ConnectAsync`.
+- Append an `OutboundDelta` after every send.
+- Append `OrderClosedDelta` on terminal Execution Reports.
+- Compact every `StateCompactEveryDeltas` (default 1024) updates.
+
+```csharp
+options.SessionStateStore = new FileSessionStateStore("/var/lib/myapp/state");
+options.StateCompactEveryDeltas = 512;
+```
+
+## Observability
+
+Telemetry uses pure BCL primitives (no SDK dependency):
+
+- `ActivitySource("B3.EntryPoint.Client")` — spans for Connect/Negotiate/
+  Establish/Terminate and every Submit/Replace/Cancel/MassAction.
+- `Meter("B3.EntryPoint.Client")` — counters
+  (`orders.submitted`, `orders.replaced`, `orders.cancelled`,
+  `orders.mass_actions`, `risk.rejections`, `session.terminations`)
+  and a histogram (`outbound.latency` in ms).
+
+Hook them up with the OpenTelemetry .NET SDK in your host process — no
+configuration is needed in this library.

--- a/samples/B3.EntryPoint.Quickstart/B3.EntryPoint.Quickstart.csproj
+++ b/samples/B3.EntryPoint.Quickstart/B3.EntryPoint.Quickstart.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>B3.EntryPoint.Quickstart</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.EntryPoint.Client\B3.EntryPoint.Client.csproj" />
+    <ProjectReference Include="..\..\tests\B3.EntryPoint.TestPeer\B3.EntryPoint.TestPeer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/B3.EntryPoint.Quickstart/Program.cs
+++ b/samples/B3.EntryPoint.Quickstart/Program.cs
@@ -1,0 +1,57 @@
+// Quickstart: connect EntryPointClient to the in-memory FIXP peer,
+// submit a NewOrderSingle, drain a couple of events, then terminate.
+//
+// Run:  dotnet run --project samples/B3.EntryPoint.Quickstart
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.TestPeer;
+
+await using var peer = new InMemoryFixpPeer();
+peer.Start();
+
+var options = new EntryPointClientOptions
+{
+    Endpoint = peer.Endpoint,
+    SessionId = 1,
+    SessionVerId = 1,
+    EnteringFirm = 1234,
+    Credentials = Credentials.FromUtf8("demo-key"),
+};
+
+await using var client = new EntryPointClient(options);
+await client.ConnectAsync();
+Console.WriteLine($"Connected. State={client.State}");
+
+try
+{
+    var clordid = await client.SubmitAsync(new NewOrderRequest
+    {
+        ClOrdID = (ClOrdID)42UL,
+        SecurityId = 1001,
+        Side = Side.Buy,
+        OrderType = OrderType.Limit,
+        Price = 12.34m,
+        OrderQty = 100,
+    });
+    Console.WriteLine($"Submitted {clordid.Value}");
+}
+catch (NotImplementedException ex)
+{
+    // Some send paths still surface NotImplementedException while wire-up
+    // (issues #W*) lands. The interface is stable; the swap is purely
+    // internal. See README "Roadmap (next phase — wire-up)".
+    Console.WriteLine($"Submit not yet wired: {ex.Message}");
+}
+
+// Drain up to ~1s of events without blocking forever.
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+try
+{
+    await foreach (var evt in client.Events().WithCancellation(cts.Token))
+        Console.WriteLine($"<- {evt.GetType().Name} seq={evt.SeqNum}");
+}
+catch (OperationCanceledException) { /* expected */ }
+
+await client.TerminateAsync(TerminationCode.Finished);
+Console.WriteLine("Terminated.");


### PR DESCRIPTION
Closes #52.

Adds a runnable end-to-end sample and a quickstart doc so consumers can verify the lifecycle in under a minute, without provisioning a real B3 endpoint.

- `samples/B3.EntryPoint.Quickstart/` — console app: boots `InMemoryFixpPeer`, builds `EntryPointClientOptions`, `ConnectAsync` → `SubmitAsync(NewOrderRequest)` → drain `Events()` for ~1s → `TerminateAsync(Finished)`.
- Registered under `/samples/` in `SbeB3EntryPointClient.slnx`.
- `docs/QUICKSTART.md` — prerequisites, run command, lifecycle walkthrough, warm-restart (ISessionStateStore) snippet, telemetry note.
- README: new Quickstart section + sample bullet.

Verified locally — sample prints:

```
Connected. State=Established
Submitted 42
Terminated.
```

88/88 unit + 8/8 conformance under ENTRYPOINT_TESTPEER=1.