### PR TITLE
Wire NewOrderCross SBE encoder (#58)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -477,12 +477,23 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     }
 
     /// <inheritdoc />
-    public Task<string> SubmitCrossAsync(NewOrderCrossRequest request, CancellationToken ct = default)
+    public async Task<string> SubmitCrossAsync(NewOrderCrossRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
-        throw new NotImplementedException(
-            "NewOrderCross wire-up pending — tracked by issue #51 (interface exposed for early integration).");
+        var clordid = request.CrossId;
+        await EvaluateRiskAsync(OutboundRequestKind.NewOrder, request, request.SecurityId, clordid, ct).ConfigureAwait(false);
+        using var activity = StartOutbound("entrypoint.submit_cross", OutboundRequestKind.NewOrder, request.SecurityId, clordid);
+        var startTs = Stopwatch.GetTimestamp();
+        var seq = _session!.NextOutboundSeqNum();
+        var legBytes = (request.Legs?.Count ?? 0) * B3.Entrypoint.Fixp.Sbe.V6.NewOrderCrossData.NoSidesData.MESSAGE_SIZE;
+        var buffer = new byte[B3.Entrypoint.Fixp.Sbe.V6.NewOrderCrossData.MESSAGE_SIZE + legBytes + 256];
+        var len = OrderEntryEncoder.EncodeNewOrderCross(buffer, request, _options, seq);
+        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
+        EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "NewOrderCross"));
+        RecordLatency(startTs, OutboundRequestKind.NewOrder);
+        return request.CrossId;
     }
 
     /// <inheritdoc />

--- a/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
@@ -13,6 +13,8 @@ using SbeSimpleTimeInForce = B3.Entrypoint.Fixp.Sbe.V6.SimpleTimeInForce;
 using SbeAccountType = B3.Entrypoint.Fixp.Sbe.V6.AccountType;
 using SbeMassActionType = B3.Entrypoint.Fixp.Sbe.V6.MassActionType;
 using SbeMassActionScope = B3.Entrypoint.Fixp.Sbe.V6.MassActionScope;
+using SbeCrossType = B3.Entrypoint.Fixp.Sbe.V6.CrossType;
+using SbeCrossPrioritization = B3.Entrypoint.Fixp.Sbe.V6.CrossPrioritization;
 
 namespace B3.EntryPoint.Client.Fixp;
 
@@ -284,6 +286,74 @@ internal static class OrderEntryEncoder
 
     private static ReadOnlySpan<byte> MemoBytes(string? memo) =>
         string.IsNullOrEmpty(memo) ? ReadOnlySpan<byte>.Empty : Encoding.UTF8.GetBytes(memo);
+
+    /// <summary>Encodes a NewOrderCross (template id 106). Returns total bytes written.</summary>
+    public static int EncodeNewOrderCross(
+        Span<byte> buffer,
+        NewOrderCrossRequest request,
+        EntryPointClientOptions options,
+        ulong msgSeqNum)
+    {
+        if (request.Legs is null || request.Legs.Count == 0)
+            throw new ArgumentException("NewOrderCross requires at least one leg.", nameof(request));
+
+        const int GroupSizeEncodingSize = 4; // BlockLength (ushort) + NumInGroup (ushort)
+        var noSidesPayloadSize = GroupSizeEncodingSize + (NewOrderCrossData.NoSidesData.MESSAGE_SIZE * request.Legs.Count);
+        // Variable-length data length encoding is 1 byte each (per existing pattern in EncodeNewOrderSingle).
+        var deskIdLen = 0;
+        var memoBytes = ReadOnlySpan<byte>.Empty;
+        var payloadSize = NewOrderCrossData.MESSAGE_SIZE + noSidesPayloadSize + 1 + deskIdLen + 1 + memoBytes.Length;
+        var totalSize = SofhSize + SbeHeaderSize + payloadSize;
+        WriteHeaders(buffer.Slice(0, totalSize), totalSize, p => NewOrderCrossData.WriteHeader(p));
+
+        var msg = default(NewOrderCrossData);
+        msg.BusinessHeader = BuildBusinessHeader(options, msgSeqNum);
+        msg.CrossID = new CrossID(ParseCrossId(request.CrossId));
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 28, 10), options.SenderLocation);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 38, 5), options.EnteringTrader);
+        msg.SecurityID = new SecurityID(request.SecurityId);
+        msg.OrderQty = new Quantity(SumLegQty(request.Legs));
+        BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 64, 8), PriceMantissa(request.Price));
+        msg.SetCrossType((SbeCrossType?)(byte)request.CrossType);
+        msg.SetCrossPrioritization((SbeCrossPrioritization?)(byte)request.Prioritization);
+
+        // Materialize legs into the wire NoSidesData layout.
+        var legs = new NewOrderCrossData.NoSidesData[request.Legs.Count];
+        for (int i = 0; i < request.Legs.Count; i++)
+        {
+            var leg = request.Legs[i];
+            ref var slot = ref legs[i];
+            slot = default;
+            slot.Side = (B3.Entrypoint.Fixp.Sbe.V6.Side)(byte)leg.Side;
+            if (leg.Account.HasValue)
+                BinaryPrimitives.WriteUInt32LittleEndian(MemoryMarshalAsBytes(ref slot, 2, 4), checked((uint)leg.Account.Value));
+            BinaryPrimitives.WriteUInt32LittleEndian(MemoryMarshalAsBytes(ref slot, 6, 4), options.EnteringFirm);
+            slot.ClOrdID = new SbeClOrdID(leg.ClOrdID.Value);
+        }
+
+        if (!NewOrderCrossData.TryEncode(msg, buffer.Slice(SofhSize + SbeHeaderSize), legs,
+                ReadOnlySpan<byte>.Empty, memoBytes, out _))
+            throw new InvalidOperationException("Failed to encode NewOrderCrossData.");
+        return totalSize;
+    }
+
+    private static ulong SumLegQty(IReadOnlyList<CrossLeg> legs)
+    {
+        ulong sum = 0;
+        for (int i = 0; i < legs.Count; i++) sum += legs[i].OrderQty;
+        return sum;
+    }
+
+    private static ulong ParseCrossId(string crossId)
+    {
+        if (string.IsNullOrEmpty(crossId))
+            throw new ArgumentException("CrossId is required.", nameof(crossId));
+        if (!ulong.TryParse(crossId, out var value))
+            throw new ArgumentException(
+                $"CrossId must be a numeric string parseable to ulong (was '{crossId}').", nameof(crossId));
+        return value;
+    }
+
 
     /// <summary>
     /// Hands out a <see cref="Span{Byte}"/> view over a fixed offset/length within a struct

--- a/src/B3.EntryPoint.Client/Models/CrossQuoteModels.cs
+++ b/src/B3.EntryPoint.Client/Models/CrossQuoteModels.cs
@@ -1,10 +1,12 @@
 namespace B3.EntryPoint.Client.Models;
 
-/// <summary>Cross trade type for <c>NewOrderCross</c> (FIX <c>CrossType</c>).</summary>
+/// <summary>Cross trade type for <c>NewOrderCross</c> (FIX <c>CrossType</c>, schema enum).</summary>
 public enum CrossType : byte
 {
     AllOrNone = 1,
-    Default = 2,
+    CrossExecutedAgainstBookFromClient = 4,
+    VwapCross = 7,
+    ClosingPriceCross = 8,
 }
 
 /// <summary>Cross prioritization (FIX <c>CrossPrioritization</c>).</summary>

--- a/tests/B3.EntryPoint.Client.Tests/CrossQuoteApiSurfaceTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/CrossQuoteApiSurfaceTests.cs
@@ -20,7 +20,7 @@ public class CrossQuoteApiSurfaceTests
         {
             CrossId = "X-1",
             SecurityId = 5,
-            CrossType = CrossType.Default,
+            CrossType = CrossType.AllOrNone,
             Prioritization = CrossPrioritization.None,
             Price = 12.34m,
             Legs = new[]

--- a/tests/B3.EntryPoint.Client.Tests/NewOrderCrossEncoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/NewOrderCrossEncoderTests.cs
@@ -1,0 +1,112 @@
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Framing;
+using Xunit;
+using ClOrdID = B3.EntryPoint.Client.Models.ClOrdID;
+using ClientCrossPrioritization = B3.EntryPoint.Client.Models.CrossPrioritization;
+using ClientCrossType = B3.EntryPoint.Client.Models.CrossType;
+using NewOrderCrossRequest = B3.EntryPoint.Client.Models.NewOrderCrossRequest;
+using CrossLeg = B3.EntryPoint.Client.Models.CrossLeg;
+using Side = B3.EntryPoint.Client.Models.Side;
+using SbeCrossPrioritization = B3.Entrypoint.Fixp.Sbe.V6.CrossPrioritization;
+using SbeCrossType = B3.Entrypoint.Fixp.Sbe.V6.CrossType;
+
+namespace B3.EntryPoint.Client.Tests;
+
+public class NewOrderCrossEncoderTests
+{
+    private static EntryPointClientOptions Options() => new()
+    {
+        Endpoint = new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 1),
+        SessionId = 7,
+        SessionVerId = 1,
+        EnteringFirm = 1234,
+        Credentials = Credentials.FromUtf8("k"),
+        SenderLocation = "SP",
+        EnteringTrader = "TR1",
+    };
+
+    [Fact]
+    public void EncodeNewOrderCross_RoundTripsViaSbeReader()
+    {
+        var req = new NewOrderCrossRequest
+        {
+            CrossId = "987654321",
+            SecurityId = 4242,
+            CrossType = ClientCrossType.AllOrNone,
+            Prioritization = ClientCrossPrioritization.None,
+            Price = 12.34m,
+            Legs = new[]
+            {
+                new CrossLeg { ClOrdID = (ClOrdID)1001UL, Side = Side.Buy, OrderQty = 10 },
+                new CrossLeg { ClOrdID = (ClOrdID)1002UL, Side = Side.Sell, OrderQty = 10 },
+            },
+        };
+
+        var buffer = new byte[NewOrderCrossData.MESSAGE_SIZE + 2 * NewOrderCrossData.NoSidesData.MESSAGE_SIZE + 256];
+        var len = OrderEntryEncoder.EncodeNewOrderCross(buffer, req, Options(), msgSeqNum: 42);
+
+        Assert.True(len > NewOrderCrossData.MESSAGE_SIZE);
+
+        Assert.True(SofhFrameReader.TryParseHeader(buffer, out var msgLen, out _));
+        Assert.Equal((ushort)len, msgLen);
+
+        var afterSofh = buffer.AsSpan(SofhFrameReader.HeaderSize, len - SofhFrameReader.HeaderSize);
+        Assert.True(MessageHeader.TryParse(afterSofh, out var header, out _));
+        Assert.Equal(NewOrderCrossData.MESSAGE_ID, (int)header.TemplateId);
+
+        var payload = afterSofh.Slice(MessageHeader.MESSAGE_SIZE);
+        Assert.True(NewOrderCrossData.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Equal(987654321UL, (ulong)data.CrossID);
+        Assert.Equal(4242UL, (ulong)data.SecurityID);
+        Assert.Equal(20UL, (ulong)data.OrderQty);
+        Assert.Equal(SbeCrossType.ALL_OR_NONE_CROSS, data.CrossType);
+        Assert.Equal(SbeCrossPrioritization.NONE, data.CrossPrioritization);
+        Assert.Equal(123400L, data.Price.Mantissa);
+        Assert.Equal(42u, (uint)data.BusinessHeader.MsgSeqNum);
+
+        int legCount = 0;
+        foreach (var leg in reader.NoSides)
+        {
+            legCount++;
+            Assert.True((ulong)leg.ClOrdID == 1001UL || (ulong)leg.ClOrdID == 1002UL);
+        }
+        Assert.Equal(2, legCount);
+    }
+
+    [Fact]
+    public void EncodeNewOrderCross_RejectsEmptyLegs()
+    {
+        var req = new NewOrderCrossRequest
+        {
+            CrossId = "1",
+            SecurityId = 1,
+            CrossType = ClientCrossType.AllOrNone,
+            Prioritization = ClientCrossPrioritization.None,
+            Price = 1m,
+            Legs = Array.Empty<CrossLeg>(),
+        };
+        var buf = new byte[NewOrderCrossData.MESSAGE_SIZE + 64];
+        Assert.Throws<ArgumentException>(() => OrderEntryEncoder.EncodeNewOrderCross(buf, req, Options(), 1));
+    }
+
+    [Fact]
+    public void EncodeNewOrderCross_RejectsNonNumericCrossId()
+    {
+        var req = new NewOrderCrossRequest
+        {
+            CrossId = "not-a-number",
+            SecurityId = 1,
+            CrossType = ClientCrossType.AllOrNone,
+            Prioritization = ClientCrossPrioritization.None,
+            Price = 1m,
+            Legs = new[] { new CrossLeg { ClOrdID = (ClOrdID)1UL, Side = Side.Buy, OrderQty = 1 } },
+        };
+        var buf = new byte[NewOrderCrossData.MESSAGE_SIZE + 64];
+        Assert.Throws<ArgumentException>(() => OrderEntryEncoder.EncodeNewOrderCross(buf, req, Options(), 1));
+    }
+}


### PR DESCRIPTION
Closes #58.

Replaces the `NotImplementedException` stub on `ISubmitCross.SubmitCrossAsync` (shipped via #56) with a real wire-level encoder.

- `OrderEntryEncoder.EncodeNewOrderCross` builds `NewOrderCrossData` (BusinessHeader, CrossID, SecurityID, OrderQty as sum of legs, Price mantissa, CrossType, CrossPrioritization, SenderLocation, EnteringTrader) plus the `NoSides` repeating group (Side, Account, EnteringFirm, ClOrdID per leg).
- `EntryPointClient.SubmitCrossAsync` now follows the standard pattern shared with the other order-entry methods: risk-gate -> `NextOutboundSeqNum` -> encode -> `SendApplicationFrameAsync` -> `AppendOutboundDeltaAsync` -> telemetry counter + latency.
- `Models.CrossType` enum aligned to the v8.4.2 schema (`AllOrNone`, `CrossExecutedAgainstBookFromClient`, `VwapCross`, `ClosingPriceCross`).
- Tests: SBE round-trip via `NewOrderCrossData.TryParse`, empty-legs reject, non-numeric `CrossId` reject.

91/91 unit + 8/8 conformance under `ENTRYPOINT_TESTPEER=1`.