### PR TITLE
Wire Quote/QuoteRequest/QuoteCancel SBE encoders (#59)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -497,30 +497,54 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     }
 
     /// <inheritdoc />
-    public Task SendQuoteRequestAsync(QuoteRequestMessage request, CancellationToken ct = default)
+    public async Task SendQuoteRequestAsync(QuoteRequestMessage request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureEstablished();
-        throw new NotImplementedException(
-            "QuoteRequest wire-up pending — tracked by issue #51 (interface exposed for early integration).");
+        await EvaluateRiskAsync(OutboundRequestKind.NewOrder, request, request.SecurityId, request.QuoteReqId, ct).ConfigureAwait(false);
+        using var activity = StartOutbound("entrypoint.quote_request", OutboundRequestKind.NewOrder, request.SecurityId, request.QuoteReqId);
+        var startTs = Stopwatch.GetTimestamp();
+        var seq = _session!.NextOutboundSeqNum();
+        var buffer = new byte[QuoteRequestData.MESSAGE_SIZE + 32];
+        var len = OrderEntryEncoder.EncodeQuoteRequest(buffer, request, _options, seq);
+        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        await AppendOutboundDeltaAsync(seq, request.QuoteReqId, request.SecurityId, ct).ConfigureAwait(false);
+        EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "QuoteRequest"));
+        RecordLatency(startTs, OutboundRequestKind.NewOrder);
     }
 
     /// <inheritdoc />
-    public Task SendQuoteAsync(QuoteMessage quote, CancellationToken ct = default)
+    public async Task SendQuoteAsync(QuoteMessage quote, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(quote);
         EnsureEstablished();
-        throw new NotImplementedException(
-            "Quote wire-up pending — tracked by issue #51 (interface exposed for early integration).");
+        await EvaluateRiskAsync(OutboundRequestKind.NewOrder, quote, quote.SecurityId, quote.QuoteId, ct).ConfigureAwait(false);
+        using var activity = StartOutbound("entrypoint.quote", OutboundRequestKind.NewOrder, quote.SecurityId, quote.QuoteId);
+        var startTs = Stopwatch.GetTimestamp();
+        var seq = _session!.NextOutboundSeqNum();
+        var buffer = new byte[QuoteData.MESSAGE_SIZE + 32];
+        var len = OrderEntryEncoder.EncodeQuote(buffer, quote, _options, seq);
+        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        await AppendOutboundDeltaAsync(seq, quote.QuoteId, quote.SecurityId, ct).ConfigureAwait(false);
+        EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "Quote"));
+        RecordLatency(startTs, OutboundRequestKind.NewOrder);
     }
 
     /// <inheritdoc />
-    public Task CancelQuoteAsync(string quoteId, CancellationToken ct = default)
+    public async Task CancelQuoteAsync(string quoteId, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(quoteId);
         EnsureEstablished();
-        throw new NotImplementedException(
-            "QuoteCancel wire-up pending — tracked by issue #51 (interface exposed for early integration).");
+        await EvaluateRiskAsync(OutboundRequestKind.Cancel, quoteId, 0UL, quoteId, ct).ConfigureAwait(false);
+        using var activity = StartOutbound("entrypoint.quote_cancel", OutboundRequestKind.Cancel, 0UL, quoteId);
+        var startTs = Stopwatch.GetTimestamp();
+        var seq = _session!.NextOutboundSeqNum();
+        var buffer = new byte[QuoteCancelData.MESSAGE_SIZE + 32];
+        var len = OrderEntryEncoder.EncodeQuoteCancel(buffer, quoteId, 0UL, _options, seq);
+        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        await AppendOutboundDeltaAsync(seq, quoteId, 0UL, ct).ConfigureAwait(false);
+        EntryPointTelemetry.OrdersCancelled.Add(1, new KeyValuePair<string, object?>("kind", "QuoteCancel"));
+        RecordLatency(startTs, OutboundRequestKind.Cancel);
     }
 
     /// <summary>

--- a/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
@@ -13,6 +13,8 @@ using SbeSimpleTimeInForce = B3.Entrypoint.Fixp.Sbe.V6.SimpleTimeInForce;
 using SbeAccountType = B3.Entrypoint.Fixp.Sbe.V6.AccountType;
 using SbeMassActionType = B3.Entrypoint.Fixp.Sbe.V6.MassActionType;
 using SbeMassActionScope = B3.Entrypoint.Fixp.Sbe.V6.MassActionScope;
+using SbeSettlType = B3.Entrypoint.Fixp.Sbe.V6.SettlType;
+using SbeExecuteUnderlyingTrade = B3.Entrypoint.Fixp.Sbe.V6.ExecuteUnderlyingTrade;
 using SbeCrossType = B3.Entrypoint.Fixp.Sbe.V6.CrossType;
 using SbeCrossPrioritization = B3.Entrypoint.Fixp.Sbe.V6.CrossPrioritization;
 
@@ -42,6 +44,24 @@ internal static class OrderEntryEncoder
         header.MarketSegmentID = new MarketSegmentID(options.DefaultMarketSegmentId);
         return header;
     }
+
+    private static BidirectionalBusinessHeader BuildBidirectionalBusinessHeader(EntryPointClientOptions options, ulong msgSeqNum)
+    {
+        var header = default(BidirectionalBusinessHeader);
+        header.SessionID = new SessionID(options.SessionId);
+        header.MsgSeqNum = new SeqNum(checked((uint)msgSeqNum));
+        header.SendingTime = default;
+        // MarketSegmentID is optional on bidirectional messages; left at NullValue (0) to mean "not set".
+        if (options.DefaultMarketSegmentId != 0)
+            MemoryMarshalAsBytes(ref header, 17, 1)[0] = options.DefaultMarketSegmentId;
+        return header;
+    }
+
+    private static long Percentage8Mantissa(decimal value) =>
+        (long)(value * 100_000_000m);
+
+    private static long Price8Mantissa(decimal value) =>
+        (long)(value * 100_000_000m);
 
     private static void WriteHeaders(Span<byte> buffer, int totalSize, Action<Span<byte>> writeSbeHeader)
     {
@@ -352,6 +372,115 @@ internal static class OrderEntryEncoder
             throw new ArgumentException(
                 $"CrossId must be a numeric string parseable to ulong (was '{crossId}').", nameof(crossId));
         return value;
+    }
+
+    private static ulong ParseQuoteUlongId(string id, string fieldName)
+    {
+        if (string.IsNullOrEmpty(id))
+            throw new ArgumentException($"{fieldName} is required.", fieldName);
+        if (!ulong.TryParse(id, out var value))
+            throw new ArgumentException(
+                $"{fieldName} must be a numeric string parseable to ulong (was '{id}').", fieldName);
+        return value;
+    }
+
+    /// <summary>Encodes a QuoteRequest (template id 401) for B3 Termo. Returns total bytes written.</summary>
+    public static int EncodeQuoteRequest(
+        Span<byte> buffer,
+        QuoteRequestMessage request,
+        EntryPointClientOptions options,
+        ulong msgSeqNum)
+    {
+        var totalSize = SofhSize + SbeHeaderSize + QuoteRequestData.MESSAGE_SIZE;
+        WriteHeaders(buffer.Slice(0, totalSize), totalSize, p => QuoteRequestData.WriteHeader(p));
+
+        var msg = default(QuoteRequestData);
+        msg.BusinessHeader = BuildBidirectionalBusinessHeader(options, msgSeqNum);
+        msg.SecurityID = new SecurityID(request.SecurityId);
+        msg.QuoteReqID = new QuoteReqID(ParseQuoteUlongId(request.QuoteReqId, nameof(request.QuoteReqId)));
+        if (!string.IsNullOrEmpty(request.QuoteId))
+            msg.SetQuoteID(ParseQuoteUlongId(request.QuoteId, nameof(request.QuoteId)));
+        if (request.TradeId.HasValue)
+            msg.SetTradeID(request.TradeId.Value);
+        msg.ContraBroker = new Firm(request.ContraBroker);
+        BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 60, 8), Price8Mantissa(request.Price));
+        msg.SettlType = (SbeSettlType)(byte)request.SettlType;
+        if (request.ExecuteUnderlyingTrade.HasValue)
+            msg.SetExecuteUnderlyingTrade((SbeExecuteUnderlyingTrade)(byte)request.ExecuteUnderlyingTrade.Value);
+        msg.OrderQty = new Quantity(request.OrderQty);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 78, 10), options.SenderLocation);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 88, 5), options.EnteringTrader);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 93, 5), options.EnteringTrader);
+        BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 98, 8), Percentage8Mantissa(request.FixedRate));
+        msg.DaysToSettlement = new DaysToSettlement(request.DaysToSettlement);
+
+        if (!msg.TryEncode(buffer.Slice(SofhSize + SbeHeaderSize), out _))
+            throw new InvalidOperationException("Failed to encode QuoteRequestData.");
+        return totalSize;
+    }
+
+    /// <summary>Encodes a Quote (template id 403) for B3 Termo. Returns total bytes written.</summary>
+    public static int EncodeQuote(
+        Span<byte> buffer,
+        QuoteMessage quote,
+        EntryPointClientOptions options,
+        ulong msgSeqNum)
+    {
+        var totalSize = SofhSize + SbeHeaderSize + QuoteData.MESSAGE_SIZE;
+        WriteHeaders(buffer.Slice(0, totalSize), totalSize, p => QuoteData.WriteHeader(p));
+
+        var msg = default(QuoteData);
+        msg.BusinessHeader = BuildBidirectionalBusinessHeader(options, msgSeqNum);
+        msg.SecurityID = new SecurityID(quote.SecurityId);
+        if (!string.IsNullOrEmpty(quote.QuoteReqId))
+            msg.QuoteReqID = new QuoteReqID(ParseQuoteUlongId(quote.QuoteReqId, nameof(quote.QuoteReqId)));
+        msg.QuoteID = new QuoteID(ParseQuoteUlongId(quote.QuoteId, nameof(quote.QuoteId)));
+        if (quote.Price.HasValue)
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 52, 8), Price8Mantissa(quote.Price.Value));
+        else
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 52, 8), long.MinValue);
+        msg.OrderQty = new Quantity(quote.OrderQty);
+        msg.Side = (SbeSide)(byte)quote.Side;
+        msg.SettlType = (SbeSettlType)(byte)quote.SettlType;
+        if (quote.Account.HasValue)
+            msg.SetAccount(quote.Account.Value);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 74, 10), options.SenderLocation);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 84, 5), options.EnteringTrader);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 89, 5), options.EnteringTrader);
+        BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 94, 8), Percentage8Mantissa(quote.FixedRate));
+        if (quote.ExecuteUnderlyingTrade.HasValue)
+            msg.SetExecuteUnderlyingTrade((SbeExecuteUnderlyingTrade)(byte)quote.ExecuteUnderlyingTrade.Value);
+        msg.DaysToSettlement = new DaysToSettlement(quote.DaysToSettlement);
+        if (quote.TradingSubAccount.HasValue)
+            msg.SetTradingSubAccount(quote.TradingSubAccount.Value);
+
+        if (!msg.TryEncode(buffer.Slice(SofhSize + SbeHeaderSize), out _))
+            throw new InvalidOperationException("Failed to encode QuoteData.");
+        return totalSize;
+    }
+
+    /// <summary>Encodes a QuoteCancel (template id 404). Returns total bytes written.</summary>
+    public static int EncodeQuoteCancel(
+        Span<byte> buffer,
+        string quoteId,
+        ulong securityId,
+        EntryPointClientOptions options,
+        ulong msgSeqNum)
+    {
+        var totalSize = SofhSize + SbeHeaderSize + QuoteCancelData.MESSAGE_SIZE;
+        WriteHeaders(buffer.Slice(0, totalSize), totalSize, p => QuoteCancelData.WriteHeader(p));
+
+        var msg = default(QuoteCancelData);
+        msg.BusinessHeader = BuildBidirectionalBusinessHeader(options, msgSeqNum);
+        msg.SecurityID = new SecurityID(securityId);
+        msg.SetQuoteID(ParseQuoteUlongId(quoteId, nameof(quoteId)));
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 48, 10), options.SenderLocation);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 58, 5), options.EnteringTrader);
+        WriteFixedString(MemoryMarshalAsBytes(ref msg, 63, 5), options.EnteringTrader);
+
+        if (!msg.TryEncode(buffer.Slice(SofhSize + SbeHeaderSize), out _))
+            throw new InvalidOperationException("Failed to encode QuoteCancelData.");
+        return totalSize;
     }
 
 

--- a/src/B3.EntryPoint.Client/Models/CrossQuoteModels.cs
+++ b/src/B3.EntryPoint.Client/Models/CrossQuoteModels.cs
@@ -38,29 +38,69 @@ public sealed record NewOrderCrossRequest
     public required IReadOnlyList<CrossLeg> Legs { get; init; }
 }
 
-/// <summary>Logical request shape for <c>QuoteRequest</c>.</summary>
+/// <summary>Indicates who in the contract has control over evoking settlement
+/// (B3 <c>SettlType</c>: BuyersDiscretion=<c>'0'</c>, SellersDiscretion=<c>'8'</c>, Mutual=<c>'X'</c>).</summary>
+public enum SettlementType : byte
+{
+    BuyersDiscretion = (byte)'0',
+    SellersDiscretion = (byte)'8',
+    Mutual = (byte)'X',
+}
+
+/// <summary>Indicates a simultaneous trade of the underlying when reporting Termo Vista forwards.</summary>
+public enum ExecuteUnderlyingTrade : byte
+{
+    NoUnderlyingTrade = (byte)'0',
+    UnderlyingOpposingTrade = (byte)'1',
+}
+
+/// <summary>
+/// Logical request shape for <c>QuoteRequest</c> (B3 Termo §10).
+/// Models a forward (Termo) quote request — required fields mirror the wire
+/// payload; <see cref="QuoteReqId"/> is exposed as a string for FIX semantics
+/// and parsed to <c>ulong</c> on encode.
+/// </summary>
 public sealed record QuoteRequestMessage
 {
     public required string QuoteReqId { get; init; }
     public required ulong SecurityId { get; init; }
-    public ulong? OrderQty { get; init; }
-    public Side? Side { get; init; }
+    public required Side Side { get; init; }
+    public required decimal Price { get; init; }
+    public required ulong OrderQty { get; init; }
+    public required SettlementType SettlType { get; init; }
+    public required ushort DaysToSettlement { get; init; }
+    public required uint ContraBroker { get; init; }
+    public decimal FixedRate { get; init; }
+    public string? QuoteId { get; init; }
+    public uint? TradeId { get; init; }
+    public ExecuteUnderlyingTrade? ExecuteUnderlyingTrade { get; init; }
 }
 
-/// <summary>Logical request shape for <c>Quote</c> (a market-maker quote).</summary>
+/// <summary>
+/// Logical request shape for <c>Quote</c> (B3 Termo §10).
+/// Models the response a Termo dealer sends back to a <see cref="QuoteRequestMessage"/>.
+/// One side per message — emit two messages to quote both bid and offer.
+/// </summary>
 public sealed record QuoteMessage
 {
     public required string QuoteId { get; init; }
     public required ulong SecurityId { get; init; }
-    public decimal? BidPrice { get; init; }
-    public decimal? OfferPrice { get; init; }
-    public ulong? BidSize { get; init; }
-    public ulong? OfferSize { get; init; }
+    public required Side Side { get; init; }
+    public required ulong OrderQty { get; init; }
+    public required SettlementType SettlType { get; init; }
+    public required ushort DaysToSettlement { get; init; }
+    public decimal? Price { get; init; }
+    public decimal FixedRate { get; init; }
     public string? QuoteReqId { get; init; }
+    public uint? Account { get; init; }
+    public uint? TradingSubAccount { get; init; }
+    public ExecuteUnderlyingTrade? ExecuteUnderlyingTrade { get; init; }
 }
 
-/// <summary>Reason carried by <c>QuoteRequestReject</c> (FIX <c>QuoteRequestRejectReason</c>).</summary>
-public enum QuoteRequestRejectReason : byte
+/// <summary>Reason carried by <c>QuoteRequestReject</c>. The wire field is a free-form
+/// <c>uint</c>; common FIX values are surfaced for convenience but the underlying
+/// integer is preserved on the inbound event.</summary>
+public enum QuoteRequestRejectReason : uint
 {
     UnknownSymbol = 1,
     ExchangeClosed = 2,
@@ -71,14 +111,14 @@ public enum QuoteRequestRejectReason : byte
     Other = 99,
 }
 
-/// <summary>Status of an outstanding quote (FIX <c>QuoteStatus</c> subset).</summary>
+/// <summary>Status of an outstanding quote (matches B3 <c>QuoteStatus</c> v8.4.2).</summary>
 public enum QuoteStatus : byte
 {
     Accepted = 0,
-    CanceledForSymbol = 1,
-    CanceledAll = 4,
     Rejected = 5,
-    RemovedFromMarket = 6,
     Expired = 7,
-    Active = 16,
+    QuoteNotFound = 9,
+    Pending = 10,
+    Pass = 11,
+    Canceled = 17,
 }

--- a/tests/B3.EntryPoint.Client.Tests/CrossQuoteApiSurfaceTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/CrossQuoteApiSurfaceTests.cs
@@ -35,9 +35,28 @@ public class CrossQuoteApiSurfaceTests
     [Fact]
     public void QuoteAndQuoteRequest_AreConstructible()
     {
-        var qr = new QuoteRequestMessage { QuoteReqId = "QR-1", SecurityId = 1 };
-        var q = new QuoteMessage { QuoteId = "Q-1", SecurityId = 1, BidPrice = 1m, OfferPrice = 2m };
-        Assert.Equal("QR-1", qr.QuoteReqId);
-        Assert.Equal("Q-1", q.QuoteId);
+        var qr = new QuoteRequestMessage
+        {
+            QuoteReqId = "1001",
+            SecurityId = 1,
+            Side = Side.Buy,
+            Price = 1m,
+            OrderQty = 100,
+            SettlType = SettlementType.Mutual,
+            DaysToSettlement = 30,
+            ContraBroker = 7,
+        };
+        var q = new QuoteMessage
+        {
+            QuoteId = "2001",
+            SecurityId = 1,
+            Side = Side.Sell,
+            OrderQty = 100,
+            SettlType = SettlementType.Mutual,
+            DaysToSettlement = 30,
+            Price = 2m,
+        };
+        Assert.Equal("1001", qr.QuoteReqId);
+        Assert.Equal("2001", q.QuoteId);
     }
 }

--- a/tests/B3.EntryPoint.Client.Tests/QuoteEncoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/QuoteEncoderTests.cs
@@ -1,0 +1,146 @@
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Framing;
+using Xunit;
+using Side = B3.EntryPoint.Client.Models.Side;
+using QuoteRequestMessage = B3.EntryPoint.Client.Models.QuoteRequestMessage;
+using QuoteMessage = B3.EntryPoint.Client.Models.QuoteMessage;
+using SettlementType = B3.EntryPoint.Client.Models.SettlementType;
+using SbeSettlType = B3.Entrypoint.Fixp.Sbe.V6.SettlType;
+
+namespace B3.EntryPoint.Client.Tests;
+
+public class QuoteEncoderTests
+{
+    private static EntryPointClientOptions Options() => new()
+    {
+        Endpoint = new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 1),
+        SessionId = 7,
+        SessionVerId = 1,
+        EnteringFirm = 1234,
+        Credentials = Credentials.FromUtf8("k"),
+        SenderLocation = "SP",
+        EnteringTrader = "TR1",
+    };
+
+    [Fact]
+    public void EncodeQuoteRequest_RoundTripsViaSbeReader()
+    {
+        var req = new QuoteRequestMessage
+        {
+            QuoteReqId = "1001",
+            SecurityId = 4242,
+            Side = Side.Buy,
+            Price = 12.34m,
+            OrderQty = 100,
+            SettlType = SettlementType.Mutual,
+            DaysToSettlement = 30,
+            ContraBroker = 99,
+            FixedRate = 0.0125m,
+        };
+
+        var buffer = new byte[QuoteRequestData.MESSAGE_SIZE + 32];
+        var len = OrderEntryEncoder.EncodeQuoteRequest(buffer, req, Options(), msgSeqNum: 42);
+
+        Assert.True(SofhFrameReader.TryParseHeader(buffer, out var msgLen, out _));
+        Assert.Equal((ushort)len, msgLen);
+
+        var afterSofh = buffer.AsSpan(SofhFrameReader.HeaderSize, len - SofhFrameReader.HeaderSize);
+        Assert.True(MessageHeader.TryParse(afterSofh, out var header, out _));
+        Assert.Equal(QuoteRequestData.MESSAGE_ID, (int)header.TemplateId);
+
+        var payload = afterSofh.Slice(MessageHeader.MESSAGE_SIZE);
+        Assert.True(QuoteRequestData.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Equal(1001UL, (ulong)data.QuoteReqID);
+        Assert.Equal(4242UL, (ulong)data.SecurityID);
+        Assert.Equal(100UL, (ulong)data.OrderQty);
+        Assert.Equal(99u, (uint)data.ContraBroker);
+        Assert.Equal(SbeSettlType.MUTUAL, data.SettlType);
+        Assert.Equal(30, (ushort)data.DaysToSettlement);
+        Assert.Equal(1234000000L, data.Price.Mantissa);
+        Assert.Equal(1250000L, data.FixedRate.Mantissa);
+        Assert.Equal(42u, (uint)data.BusinessHeader.MsgSeqNum);
+    }
+
+    [Fact]
+    public void EncodeQuote_RoundTripsViaSbeReader()
+    {
+        var quote = new QuoteMessage
+        {
+            QuoteId = "2002",
+            SecurityId = 4242,
+            Side = Side.Sell,
+            OrderQty = 50,
+            SettlType = SettlementType.BuyersDiscretion,
+            DaysToSettlement = 60,
+            Price = 5.5m,
+            QuoteReqId = "1001",
+            FixedRate = 0.001m,
+            Account = 5555,
+        };
+
+        var buffer = new byte[QuoteData.MESSAGE_SIZE + 32];
+        var len = OrderEntryEncoder.EncodeQuote(buffer, quote, Options(), msgSeqNum: 7);
+
+        var afterSofh = buffer.AsSpan(SofhFrameReader.HeaderSize, len - SofhFrameReader.HeaderSize);
+        Assert.True(MessageHeader.TryParse(afterSofh, out var header, out _));
+        Assert.Equal(QuoteData.MESSAGE_ID, (int)header.TemplateId);
+
+        var payload = afterSofh.Slice(MessageHeader.MESSAGE_SIZE);
+        Assert.True(QuoteData.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Equal(2002UL, (ulong)data.QuoteID);
+        Assert.Equal(1001UL, (ulong)data.QuoteReqID);
+        Assert.Equal(4242UL, (ulong)data.SecurityID);
+        Assert.Equal(50UL, (ulong)data.OrderQty);
+        Assert.Equal((byte)Side.Sell, (byte)data.Side);
+        Assert.Equal(SbeSettlType.BUYERS_DISCRETION, data.SettlType);
+        Assert.Equal(60, (ushort)data.DaysToSettlement);
+        Assert.Equal(550000000L, data.Price.Mantissa);
+        Assert.Equal(100000L, data.FixedRate.Mantissa);
+        Assert.Equal(5555u, data.Account);
+        Assert.Equal(7u, (uint)data.BusinessHeader.MsgSeqNum);
+    }
+
+    [Fact]
+    public void EncodeQuoteCancel_RoundTripsViaSbeReader()
+    {
+        var buffer = new byte[QuoteCancelData.MESSAGE_SIZE + 32];
+        var len = OrderEntryEncoder.EncodeQuoteCancel(buffer, "2002", securityId: 4242, Options(), msgSeqNum: 9);
+
+        var afterSofh = buffer.AsSpan(SofhFrameReader.HeaderSize, len - SofhFrameReader.HeaderSize);
+        Assert.True(MessageHeader.TryParse(afterSofh, out var header, out _));
+        Assert.Equal(QuoteCancelData.MESSAGE_ID, (int)header.TemplateId);
+
+        var payload = afterSofh.Slice(MessageHeader.MESSAGE_SIZE);
+        Assert.True(QuoteCancelData.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Equal(2002UL, data.QuoteID);
+        Assert.Equal(4242UL, (ulong)data.SecurityID);
+        Assert.Equal(9u, (uint)data.BusinessHeader.MsgSeqNum);
+    }
+
+    [Fact]
+    public void EncodeQuoteRequest_RejectsNonNumericQuoteReqId()
+    {
+        var req = new QuoteRequestMessage
+        {
+            QuoteReqId = "not-a-number",
+            SecurityId = 1,
+            Side = Side.Buy,
+            Price = 1m,
+            OrderQty = 1,
+            SettlType = SettlementType.Mutual,
+            DaysToSettlement = 1,
+            ContraBroker = 1,
+        };
+        var buf = new byte[QuoteRequestData.MESSAGE_SIZE + 32];
+        Assert.Throws<ArgumentException>(() => OrderEntryEncoder.EncodeQuoteRequest(buf, req, Options(), 1));
+    }
+}


### PR DESCRIPTION
Closes #59.

Reshapes QuoteRequestMessage / QuoteMessage DTOs to match the B3 v8.4.2 Termo (forward) wire schema — the prior bid/offer-pair surface from #56 did not align with the actual SBE messages (templates 401/403/404 carry single-side Side+Price+OrderQty + Termo-specific SettlType/DaysToSettlement/ContraBroker/FixedRate).

**Encoders**
- `EncodeQuoteRequest` (template 401)
- `EncodeQuote` (template 403)
- `EncodeQuoteCancel` (template 404)

**Wiring**
- `SendQuoteRequestAsync`, `SendQuoteAsync`, `CancelQuoteAsync` follow the standard pattern: risk → seq → encode → send → outbound delta → metric → latency.

**Schema alignment**
- New `SettlementType` and `ExecuteUnderlyingTrade` DTO enums mirror the schema char codes.
- `QuoteStatus` updated to v8.4.2 (Accepted/Rejected/Expired/QuoteNotFound/Pending/Pass/Canceled).
- `QuoteRequestRejectReason` widened to `uint` to match the wire field.

**Tests**: 4 new encoder round-trip + reject tests. 95/95 unit tests passing locally.

**Follow-up**: inbound decode of QuoteRequestReject + QuoteStatusReport into `EntryPointEvent` records will land in a separate issue.