### PR TITLE
Wire inbound decode for QuoteRequestReject + QuoteStatusReport (#62)

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
@@ -9,6 +9,8 @@ using ClientReject = B3.EntryPoint.Client.Models.OrderRejected;
 using ClientTrade = B3.EntryPoint.Client.Models.OrderTrade;
 using ClientAccepted = B3.EntryPoint.Client.Models.OrderAccepted;
 using ClientBusinessReject = B3.EntryPoint.Client.Models.BusinessReject;
+using ClientQuoteRequestRejected = B3.EntryPoint.Client.Models.QuoteRequestRejected;
+using ClientQuoteStatusUpdated = B3.EntryPoint.Client.Models.QuoteStatusUpdated;
 using SbeBmr = B3.Entrypoint.Fixp.Sbe.V6.BusinessMessageRejectData;
 using SbeErCancel = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_CancelData;
 using SbeErForward = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_ForwardData;
@@ -16,6 +18,8 @@ using SbeErModify = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_ModifyData;
 using SbeErNew = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_NewData;
 using SbeErReject = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_RejectData;
 using SbeErTrade = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_TradeData;
+using SbeQuoteRequestReject = B3.Entrypoint.Fixp.Sbe.V6.QuoteRequestRejectData;
+using SbeQuoteStatusReport = B3.Entrypoint.Fixp.Sbe.V6.QuoteStatusReportData;
 using ClientClOrdID = B3.EntryPoint.Client.Models.ClOrdID;
 
 namespace B3.EntryPoint.Client.Fixp;
@@ -69,6 +73,12 @@ internal static class InboundDecoder
                 return true;
             case SbeBmr.MESSAGE_ID:
                 evt = DecodeBmr(payload);
+                return true;
+            case SbeQuoteRequestReject.MESSAGE_ID:
+                evt = DecodeQuoteRequestReject(payload);
+                return true;
+            case SbeQuoteStatusReport.MESSAGE_ID:
+                evt = DecodeQuoteStatusReport(payload);
                 return true;
             default:
                 return false;
@@ -181,6 +191,39 @@ internal static class InboundDecoder
             SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
             RefSeqNum = msg.RefSeqNum.Value,
             RejectReason = (ushort)msg.BusinessRejectReason.Value,
+        };
+    }
+
+    private static ClientQuoteRequestRejected DecodeQuoteRequestReject(ReadOnlySpan<byte> payload)
+    {
+        ref readonly var msg = ref MemoryMarshal.AsRef<SbeQuoteRequestReject>(payload);
+        return new ClientQuoteRequestRejected
+        {
+            SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
+            SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
+            QuoteReqId = ((ulong)msg.QuoteReqID).ToString(System.Globalization.CultureInfo.InvariantCulture),
+            SecurityId = msg.SecurityID.Value,
+            QuoteId = msg.QuoteID.HasValue
+                ? msg.QuoteID.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                : null,
+            RejectReason = msg.QuoteRequestRejectReason,
+            TransactTime = ToDateTime(msg.TransactTime.Time),
+        };
+    }
+
+    private static ClientQuoteStatusUpdated DecodeQuoteStatusReport(ReadOnlySpan<byte> payload)
+    {
+        ref readonly var msg = ref MemoryMarshal.AsRef<SbeQuoteStatusReport>(payload);
+        return new ClientQuoteStatusUpdated
+        {
+            SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
+            SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
+            QuoteId = ((ulong)msg.QuoteID).ToString(System.Globalization.CultureInfo.InvariantCulture),
+            QuoteReqId = ((ulong)msg.QuoteReqID).ToString(System.Globalization.CultureInfo.InvariantCulture),
+            SecurityId = msg.SecurityID.Value,
+            Status = (Models.QuoteStatus)(byte)msg.QuoteStatus,
+            QuoteRejectReason = msg.QuoteRejectReason,
+            TransactTime = ToDateTime(msg.TransactTime.Time),
         };
     }
 

--- a/src/B3.EntryPoint.Client/Models/EntryPointEvents.cs
+++ b/src/B3.EntryPoint.Client/Models/EntryPointEvents.cs
@@ -131,3 +131,26 @@ public sealed record BusinessReject : EntryPointEvent
     public required ushort RejectReason { get; init; }
     public string? Text { get; init; }
 }
+
+/// <summary>Maps to <c>QuoteRequestReject</c> (template 405). The exchange rejected
+/// a previously submitted <see cref="QuoteRequestMessage"/>.</summary>
+public sealed record QuoteRequestRejected : EntryPointEvent
+{
+    public required string QuoteReqId { get; init; }
+    public required ulong SecurityId { get; init; }
+    public string? QuoteId { get; init; }
+    public uint? RejectReason { get; init; }
+    public DateTimeOffset? TransactTime { get; init; }
+}
+
+/// <summary>Maps to <c>QuoteStatusReport</c> (template 402). Carries the
+/// lifecycle status of a quote previously submitted via <see cref="QuoteMessage"/>.</summary>
+public sealed record QuoteStatusUpdated : EntryPointEvent
+{
+    public required string QuoteId { get; init; }
+    public required string QuoteReqId { get; init; }
+    public required ulong SecurityId { get; init; }
+    public required QuoteStatus Status { get; init; }
+    public uint? QuoteRejectReason { get; init; }
+    public DateTimeOffset? TransactTime { get; init; }
+}

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/InboundDecoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/InboundDecoderTests.cs
@@ -91,4 +91,76 @@ public class InboundDecoderTests
         Assert.False(InboundDecoder.TryDecode(frame, out var evt));
         Assert.Null(evt);
     }
+
+    [Fact]
+    public void TryDecode_QuoteRequestReject_ReturnsQuoteRequestRejected()
+    {
+        var msg = new QuoteRequestRejectData
+        {
+            BusinessHeader = new BidirectionalBusinessHeader
+            {
+                SessionID = 1,
+                MsgSeqNum = new SeqNum(55),
+            },
+            QuoteReqID = new QuoteReqID(1001UL),
+            SecurityID = new SecurityID(4242UL),
+            ContraBroker = new Firm(99),
+            EnteringTrader = default,
+            ExecutingTrader = default,
+            SenderLocation = default,
+            TransactTime = new UTCTimestampNanos { Time = 1_700_000_000_000_000_000UL },
+        };
+        msg.SetQuoteRequestRejectReason(5);
+        msg.SetQuoteID(2002UL);
+
+        var frame = BuildFrame(QuoteRequestRejectData.MESSAGE_ID, QuoteRequestRejectData.MESSAGE_SIZE, span =>
+        {
+            if (!msg.TryEncode(span, out _))
+                throw new InvalidOperationException("encode failed");
+        });
+
+        Assert.True(InboundDecoder.TryDecode(frame, out var evt));
+        var rejected = Assert.IsType<QuoteRequestRejected>(evt);
+        Assert.Equal(55UL, rejected.SeqNum);
+        Assert.Equal("1001", rejected.QuoteReqId);
+        Assert.Equal(4242UL, rejected.SecurityId);
+        Assert.Equal("2002", rejected.QuoteId);
+        Assert.Equal(5u, rejected.RejectReason);
+    }
+
+    [Fact]
+    public void TryDecode_QuoteStatusReport_ReturnsQuoteStatusUpdated()
+    {
+        var msg = new QuoteStatusReportData
+        {
+            BusinessHeader = new BidirectionalBusinessHeader
+            {
+                SessionID = 1,
+                MsgSeqNum = new SeqNum(77),
+            },
+            QuoteReqID = new QuoteReqID(1001UL),
+            QuoteID = new QuoteID(2002UL),
+            SecurityID = new SecurityID(4242UL),
+            ContraBroker = new Firm(99),
+            EnteringTrader = default,
+            ExecutingTrader = default,
+            SenderLocation = default,
+            QuoteStatus = B3.Entrypoint.Fixp.Sbe.V6.QuoteStatus.ACCEPTED,
+            TransactTime = new UTCTimestampNanos { Time = 1_700_000_000_000_000_000UL },
+        };
+
+        var frame = BuildFrame(QuoteStatusReportData.MESSAGE_ID, QuoteStatusReportData.MESSAGE_SIZE, span =>
+        {
+            if (!msg.TryEncode(span, out _))
+                throw new InvalidOperationException("encode failed");
+        });
+
+        Assert.True(InboundDecoder.TryDecode(frame, out var evt));
+        var updated = Assert.IsType<QuoteStatusUpdated>(evt);
+        Assert.Equal(77UL, updated.SeqNum);
+        Assert.Equal("2002", updated.QuoteId);
+        Assert.Equal("1001", updated.QuoteReqId);
+        Assert.Equal(4242UL, updated.SecurityId);
+        Assert.Equal(B3.EntryPoint.Client.Models.QuoteStatus.Accepted, updated.Status);
+    }
 }


### PR DESCRIPTION
Closes #62.

Completes the closed loop on the Quote family (outbound encoders shipped via #61).

- New `EntryPointEvent` records: `QuoteRequestRejected` (template 405) and `QuoteStatusUpdated` (template 402).
- `InboundDecoder` dispatches the two template ids and decodes via `MemoryMarshal.AsRef`, mirroring the existing ER-family pattern.
- Quote IDs surface as numeric strings (matches the outbound DTO contract from #61).
- 2 new round-trip tests; suite at 97/97.