### PR TITLE
Decode OrderMassActionReport (template 702) (#64)

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
@@ -20,6 +20,8 @@ using SbeErReject = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_RejectData;
 using SbeErTrade = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_TradeData;
 using SbeQuoteRequestReject = B3.Entrypoint.Fixp.Sbe.V6.QuoteRequestRejectData;
 using SbeQuoteStatusReport = B3.Entrypoint.Fixp.Sbe.V6.QuoteStatusReportData;
+using SbeMassActionReport = B3.Entrypoint.Fixp.Sbe.V6.OrderMassActionReportData;
+using ClientMassActionExecuted = B3.EntryPoint.Client.Models.MassActionExecuted;
 using ClientClOrdID = B3.EntryPoint.Client.Models.ClOrdID;
 
 namespace B3.EntryPoint.Client.Fixp;
@@ -79,6 +81,9 @@ internal static class InboundDecoder
                 return true;
             case SbeQuoteStatusReport.MESSAGE_ID:
                 evt = DecodeQuoteStatusReport(payload);
+                return true;
+            case SbeMassActionReport.MESSAGE_ID:
+                evt = DecodeMassActionReport(payload);
                 return true;
             default:
                 return false;
@@ -223,6 +228,32 @@ internal static class InboundDecoder
             SecurityId = msg.SecurityID.Value,
             Status = (Models.QuoteStatus)(byte)msg.QuoteStatus,
             QuoteRejectReason = msg.QuoteRejectReason,
+            TransactTime = ToDateTime(msg.TransactTime.Time),
+        };
+    }
+
+    private static ClientMassActionExecuted DecodeMassActionReport(ReadOnlySpan<byte> payload)
+    {
+        ref readonly var msg = ref MemoryMarshal.AsRef<SbeMassActionReport>(payload);
+        return new ClientMassActionExecuted
+        {
+            SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
+            SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
+            ClOrdID = new ClientClOrdID(msg.ClOrdID.Value),
+            MassActionReportId = msg.MassActionReportID.Value,
+            ActionType = (Models.MassActionType)(byte)msg.MassActionType,
+            Scope = msg.MassActionScope.HasValue
+                ? (Models.MassActionScope)(byte)msg.MassActionScope.Value
+                : Models.MassActionScope.AllOrdersForATradingSession,
+            Response = (Models.MassActionResponse)(byte)msg.MassActionResponse,
+            RejectReason = msg.MassActionRejectReason.HasValue
+                ? (Models.MassActionRejectReason)(byte)msg.MassActionRejectReason.Value
+                : null,
+            RestatementReason = msg.ExecRestatementReason.HasValue
+                ? (Models.ExecRestatementReason)(byte)msg.ExecRestatementReason.Value
+                : null,
+            Side = msg.Side.HasValue ? (Models.Side)(byte)msg.Side.Value : null,
+            SecurityId = msg.SecurityID,
             TransactTime = ToDateTime(msg.TransactTime.Time),
         };
     }

--- a/src/B3.EntryPoint.Client/Models/EntryPointEvents.cs
+++ b/src/B3.EntryPoint.Client/Models/EntryPointEvents.cs
@@ -154,3 +154,20 @@ public sealed record QuoteStatusUpdated : EntryPointEvent
     public uint? QuoteRejectReason { get; init; }
     public DateTimeOffset? TransactTime { get; init; }
 }
+
+/// <summary>Maps to <c>OrderMassActionReport</c> (template 702). Confirmation /
+/// rejection event for a previously sent <see cref="MassActionRequest"/>; also
+/// emitted on Drop Copy sessions for any mass action affecting the firm.</summary>
+public sealed record MassActionExecuted : EntryPointEvent
+{
+    public required ClOrdID ClOrdID { get; init; }
+    public required ulong MassActionReportId { get; init; }
+    public required MassActionType ActionType { get; init; }
+    public required MassActionScope Scope { get; init; }
+    public required MassActionResponse Response { get; init; }
+    public MassActionRejectReason? RejectReason { get; init; }
+    public ExecRestatementReason? RestatementReason { get; init; }
+    public Side? Side { get; init; }
+    public ulong? SecurityId { get; init; }
+    public DateTimeOffset? TransactTime { get; init; }
+}

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/InboundDecoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/InboundDecoderTests.cs
@@ -163,4 +163,45 @@ public class InboundDecoderTests
         Assert.Equal(4242UL, updated.SecurityId);
         Assert.Equal(B3.EntryPoint.Client.Models.QuoteStatus.Accepted, updated.Status);
     }
+
+    [Fact]
+    public void TryDecode_OrderMassActionReport_ReturnsMassActionExecuted()
+    {
+        var msg = new OrderMassActionReportData
+        {
+            BusinessHeader = new OutboundBusinessHeader
+            {
+                SessionID = 1,
+                MsgSeqNum = new SeqNum(123),
+            },
+            MassActionType = B3.Entrypoint.Fixp.Sbe.V6.MassActionType.CANCEL_ORDERS,
+            ClOrdID = new B3.Entrypoint.Fixp.Sbe.V6.ClOrdID(8888UL),
+            MassActionReportID = new MassActionReportID(55555UL),
+            TransactTime = new UTCTimestampNanos { Time = 1_700_000_000_000_000_000UL },
+            MassActionResponse = B3.Entrypoint.Fixp.Sbe.V6.MassActionResponse.ACCEPTED,
+        };
+        msg.SetMassActionScope(B3.Entrypoint.Fixp.Sbe.V6.MassActionScope.ALL_ORDERS_FOR_A_TRADING_SESSION);
+        msg.SetMassActionRejectReason(null);
+        msg.SetExecRestatementReason(null);
+        msg.SetSide(B3.Entrypoint.Fixp.Sbe.V6.Side.BUY);
+        msg.SetSecurityID(4242UL);
+
+        var frame = BuildFrame(OrderMassActionReportData.MESSAGE_ID, OrderMassActionReportData.MESSAGE_SIZE, span =>
+        {
+            if (!msg.TryEncode(span, out _))
+                throw new InvalidOperationException("encode failed");
+        });
+
+        Assert.True(InboundDecoder.TryDecode(frame, out var evt));
+        var report = Assert.IsType<MassActionExecuted>(evt);
+        Assert.Equal(123UL, report.SeqNum);
+        Assert.Equal(8888UL, report.ClOrdID.Value);
+        Assert.Equal(55555UL, report.MassActionReportId);
+        Assert.Equal(B3.EntryPoint.Client.Models.MassActionType.CancelOrders, report.ActionType);
+        Assert.Equal(B3.EntryPoint.Client.Models.MassActionScope.AllOrdersForATradingSession, report.Scope);
+        Assert.Equal(B3.EntryPoint.Client.Models.MassActionResponse.Accepted, report.Response);
+        Assert.Equal(B3.EntryPoint.Client.Models.Side.Buy, report.Side);
+        Assert.Equal(4242UL, report.SecurityId);
+        Assert.Null(report.RejectReason);
+    }
 }


### PR DESCRIPTION
Adds inbound decode for OrderMassActionReport (template 702) and exposes it as a new `MassActionExecuted` event on the Events stream.

This completes the round-trip for `IOrderEntry.MassActionAsync` and broadens Drop Copy decoder coverage (DropCopyClient is a thin wrapper over EntryPointClient, so it inherits the new decode case automatically).

### Changes
- New `MassActionExecuted` record in `Models/EntryPointEvents.cs` carrying ClOrdID, MassActionReportId, ActionType, Scope, Response, optional RejectReason / RestatementReason / Side / SecurityId / TransactTime.
- New switch case in `InboundDecoder` for template 702, using the existing `MemoryMarshal.AsRef` pattern.
- Round-trip unit test in `InboundDecoderTests`.

### Test
- 98/98 unit tests pass locally.
- 8 conformance scenarios still skip-by-default.

Closes #64