### PR TITLE
Decode AllocationReport (template 602) — H1 hardening (#68)

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
@@ -21,7 +21,9 @@ using SbeErTrade = B3.Entrypoint.Fixp.Sbe.V6.ExecutionReport_TradeData;
 using SbeQuoteRequestReject = B3.Entrypoint.Fixp.Sbe.V6.QuoteRequestRejectData;
 using SbeQuoteStatusReport = B3.Entrypoint.Fixp.Sbe.V6.QuoteStatusReportData;
 using SbeMassActionReport = B3.Entrypoint.Fixp.Sbe.V6.OrderMassActionReportData;
+using SbeAllocationReport = B3.Entrypoint.Fixp.Sbe.V6.AllocationReportData;
 using ClientMassActionExecuted = B3.EntryPoint.Client.Models.MassActionExecuted;
+using ClientAllocationReceived = B3.EntryPoint.Client.Models.AllocationReceived;
 using ClientClOrdID = B3.EntryPoint.Client.Models.ClOrdID;
 
 namespace B3.EntryPoint.Client.Fixp;
@@ -84,6 +86,9 @@ internal static class InboundDecoder
                 return true;
             case SbeMassActionReport.MESSAGE_ID:
                 evt = DecodeMassActionReport(payload);
+                return true;
+            case SbeAllocationReport.MESSAGE_ID:
+                evt = DecodeAllocationReport(payload);
                 return true;
             default:
                 return false;
@@ -254,6 +259,28 @@ internal static class InboundDecoder
                 : null,
             Side = msg.Side.HasValue ? (Models.Side)(byte)msg.Side.Value : null,
             SecurityId = msg.SecurityID,
+            TransactTime = ToDateTime(msg.TransactTime.Time),
+        };
+    }
+
+    private static ClientAllocationReceived DecodeAllocationReport(ReadOnlySpan<byte> payload)
+    {
+        ref readonly var msg = ref MemoryMarshal.AsRef<SbeAllocationReport>(payload);
+        return new ClientAllocationReceived
+        {
+            SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
+            SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
+            AllocId = msg.AllocID.Value,
+            AllocReportId = msg.AllocReportID.Value,
+            SecurityId = msg.SecurityID.Value,
+            TransType = (Models.AllocTransType)(byte)msg.AllocTransType,
+            ReportType = (Models.AllocReportType)(byte)msg.AllocReportType,
+            Status = (Models.AllocStatus)(byte)msg.AllocStatus,
+            Quantity = msg.Quantity.Value,
+            Side = (Models.Side)(byte)msg.Side,
+            NoOrdersType = (Models.AllocNoOrdersType)(byte)msg.AllocNoOrdersType,
+            RejCode = msg.AllocRejCode,
+            TradeDate = msg.TradeDate,
             TransactTime = ToDateTime(msg.TransactTime.Time),
         };
     }

--- a/src/B3.EntryPoint.Client/Models/EntryPointEvents.cs
+++ b/src/B3.EntryPoint.Client/Models/EntryPointEvents.cs
@@ -171,3 +171,48 @@ public sealed record MassActionExecuted : EntryPointEvent
     public ulong? SecurityId { get; init; }
     public DateTimeOffset? TransactTime { get; init; }
 }
+
+/// <summary>Allocation transaction type (schema enum <c>AllocTransType</c>).</summary>
+public enum AllocTransType : byte
+{
+    New = (byte)'0',
+    Cancel = (byte)'2',
+}
+
+/// <summary>Allocation report purpose (schema enum <c>AllocReportType</c>).</summary>
+public enum AllocReportType : byte
+{
+    RequestToIntermediary = (byte)'8',
+}
+
+/// <summary>How orders are booked / allocated (schema enum <c>AllocNoOrdersType</c>).</summary>
+public enum AllocNoOrdersType : byte
+{
+    NotSpecified = (byte)'0',
+}
+
+/// <summary>Allocation lifecycle status (schema enum <c>AllocStatus</c>).</summary>
+public enum AllocStatus : byte
+{
+    Accepted = (byte)'0',
+    RejectedByIntermediary = (byte)'5',
+}
+
+/// <summary>Maps to <c>AllocationReport</c> (template 602). Post-trade
+/// allocation lifecycle event; surfaces on both Order Entry and Drop Copy
+/// sessions when an allocation is booked, accepted or rejected.</summary>
+public sealed record AllocationReceived : EntryPointEvent
+{
+    public required ulong AllocId { get; init; }
+    public required ulong AllocReportId { get; init; }
+    public required ulong SecurityId { get; init; }
+    public required AllocTransType TransType { get; init; }
+    public required AllocReportType ReportType { get; init; }
+    public required AllocStatus Status { get; init; }
+    public required ulong Quantity { get; init; }
+    public required Side Side { get; init; }
+    public AllocNoOrdersType? NoOrdersType { get; init; }
+    public uint? RejCode { get; init; }
+    public ushort? TradeDate { get; init; }
+    public DateTimeOffset? TransactTime { get; init; }
+}

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/InboundDecoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/InboundDecoderTests.cs
@@ -204,4 +204,47 @@ public class InboundDecoderTests
         Assert.Equal(4242UL, report.SecurityId);
         Assert.Null(report.RejectReason);
     }
+
+    [Fact]
+    public void TryDecode_AllocationReport_ReturnsAllocationReceived()
+    {
+        var msg = new AllocationReportData
+        {
+            BusinessHeader = new OutboundBusinessHeader
+            {
+                SessionID = 1,
+                MsgSeqNum = new SeqNum(321),
+            },
+            AllocID = new AllocID(7777UL),
+            SecurityID = new SecurityID(4242UL),
+            AllocReportID = new AllocReportID(99999UL),
+            AllocTransType = B3.Entrypoint.Fixp.Sbe.V6.AllocTransType.NEW,
+            AllocReportType = B3.Entrypoint.Fixp.Sbe.V6.AllocReportType.REQUEST_TO_INTERMEDIARY,
+            AllocNoOrdersType = B3.Entrypoint.Fixp.Sbe.V6.AllocNoOrdersType.NOT_SPECIFIED,
+            Quantity = new Quantity(10UL),
+            AllocStatus = B3.Entrypoint.Fixp.Sbe.V6.AllocStatus.ACCEPTED,
+            TransactTime = new UTCTimestampNanos { Time = 1_700_000_000_000_000_000UL },
+            Side = B3.Entrypoint.Fixp.Sbe.V6.Side.BUY,
+        };
+        msg.SetTradeDate((ushort)9876);
+
+        var frame = BuildFrame(AllocationReportData.MESSAGE_ID, AllocationReportData.MESSAGE_SIZE, span =>
+        {
+            if (!msg.TryEncode(span, out _))
+                throw new InvalidOperationException("encode failed");
+        });
+
+        Assert.True(InboundDecoder.TryDecode(frame, out var evt));
+        var alloc = Assert.IsType<AllocationReceived>(evt);
+        Assert.Equal(321UL, alloc.SeqNum);
+        Assert.Equal(7777UL, alloc.AllocId);
+        Assert.Equal(99999UL, alloc.AllocReportId);
+        Assert.Equal(4242UL, alloc.SecurityId);
+        Assert.Equal(B3.EntryPoint.Client.Models.AllocTransType.New, alloc.TransType);
+        Assert.Equal(B3.EntryPoint.Client.Models.AllocReportType.RequestToIntermediary, alloc.ReportType);
+        Assert.Equal(B3.EntryPoint.Client.Models.AllocStatus.Accepted, alloc.Status);
+        Assert.Equal(10UL, alloc.Quantity);
+        Assert.Equal(B3.EntryPoint.Client.Models.Side.Buy, alloc.Side);
+        Assert.Equal((ushort?)9876, alloc.TradeDate);
+    }
 }


### PR DESCRIPTION
Closes #68. Adds inbound decode + new `AllocationReceived` event for post-trade allocation lifecycle. Covers both Order Entry and Drop Copy callers since Drop Copy is a thin wrapper.