### PR TITLE
Peer RetransmitRequest handling — H4 hardening (#74)

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -171,21 +171,21 @@ internal sealed class FixpClientSession : IAsyncDisposable
                             OnInboundSequence?.Invoke(System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload));
                             break;
                         case RetransmissionData.MESSAGE_ID:
-                            // SessionID(8) + RequestTimestamp(8) + NextSeqNo(4) + Count(4) = 24 bytes
+                            // SessionID(4) + RequestTimestamp(8) + NextSeqNo(4) + Count(4) = 20 bytes
                             if (payload.Length >= RetransmissionData.MESSAGE_SIZE)
                             {
-                                var reqTs = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload.Slice(8, 8));
-                                var nextSeq = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(16, 4));
-                                var cnt = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(20, 4));
+                                var reqTs = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload.Slice(4, 8));
+                                var nextSeq = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(12, 4));
+                                var cnt = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(16, 4));
                                 OnInboundRetransmission?.Invoke(nextSeq, cnt, reqTs);
                             }
                             break;
                         case RetransmitRejectData.MESSAGE_ID:
-                            // SessionID(8) + RequestTimestamp(8) + Code(1)
+                            // SessionID(4) + RequestTimestamp(8) + Code(1)
                             if (payload.Length >= RetransmitRejectData.MESSAGE_SIZE)
                             {
-                                var reqTs = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload.Slice(8, 8));
-                                var code = (uint)payload[16];
+                                var reqTs = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload.Slice(4, 8));
+                                var code = (uint)payload[12];
                                 OnInboundRetransmitReject?.Invoke(code, reqTs);
                             }
                             break;

--- a/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/RetransmitTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/RetransmitTests.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Client;
 using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
 using B3.EntryPoint.Conformance.Infrastructure;
 
 namespace B3.EntryPoint.Conformance.Spec_4_7_Retransmit;
@@ -27,7 +28,16 @@ public class RetransmitTests
 
         await client.ConnectAsync();
         Assert.NotNull(client.Retransmit);
-        // The in-memory peer doesn't model RetransmitRequest; just verify the
-        // client-side handler is wired and exposes the contract.
+
+        var received = new TaskCompletionSource<RetransmissionEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.Retransmit!.RetransmissionReceived += (_, args) => received.TrySetResult(args);
+
+        await client.Retransmit.RequestRetransmitAsync(fromSeqNo: 1UL, count: 5U);
+
+        var completed = await Task.WhenAny(received.Task, Task.Delay(TimeSpan.FromSeconds(3)));
+        Assert.Same(received.Task, completed);
+        var evt = await received.Task;
+        Assert.Equal(1UL, evt.NextSeqNo);
+        Assert.Equal(0u, evt.Count);
     }
 }

--- a/tests/B3.EntryPoint.TestPeer/InMemoryFixpPeer.cs
+++ b/tests/B3.EntryPoint.TestPeer/InMemoryFixpPeer.cs
@@ -101,6 +101,9 @@ public sealed class InMemoryFixpPeer : IAsyncDisposable
                         case OrderMassActionRequestData.MESSAGE_ID:
                             await SendOrderMassActionReportAsync(stream, frame, state, ct).ConfigureAwait(false);
                             break;
+                        case RetransmitRequestData.MESSAGE_ID:
+                            await SendRetransmissionAsync(stream, frame, ct).ConfigureAwait(false);
+                            break;
                         default:
                             // Application or session-layer messages we don't model — swallow.
                             break;
@@ -338,6 +341,37 @@ public sealed class InMemoryFixpPeer : IAsyncDisposable
         await SendAppFrameAsync(stream, OrderMassActionReportData.MESSAGE_ID, OrderMassActionReportData.MESSAGE_SIZE,
             (Span<byte> buf, out int bw) => msg.TryEncode(buf, out bw),
             ct).ConfigureAwait(false);
+    }
+
+    private static async Task SendRetransmissionAsync(Stream stream, byte[] requestFrame, CancellationToken ct)
+    {
+        if (!RetransmitRequestData.TryParse(requestFrame.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out var reader))
+            return;
+        var sessionId = reader.Data.SessionID;
+        var requestTs = reader.Data.Timestamp;
+        var fromSeqNo = reader.Data.FromSeqNo;
+
+        var totalSize = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + RetransmissionData.MESSAGE_SIZE;
+        var buffer = new byte[totalSize];
+        SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
+        RetransmissionData.WriteHeader(buffer.AsSpan(SofhFrameReader.HeaderSize));
+
+        var msg = new RetransmissionData
+        {
+            SessionID = sessionId,
+            RequestTimestamp = requestTs,
+            NextSeqNo = fromSeqNo,
+            Count = new MessageCounter(0u),
+        };
+        if (!msg.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
+            return;
+
+        try
+        {
+            await stream.WriteAsync(buffer, ct).ConfigureAwait(false);
+            await stream.FlushAsync(ct).ConfigureAwait(false);
+        }
+        catch (IOException) { }
     }
 
     private static long _orderIdSeq;


### PR DESCRIPTION
Closes #74. Peer replies with Retransmission(Count=0); client parsing offsets fixed; conformance test exercises round-trip.