### PR TITLE
DI extensions: AddEntryPointClient / AddDropCopyClient (#76)

### DIFF
--- a/src/B3.EntryPoint.Client/B3.EntryPoint.Client.csproj
+++ b/src/B3.EntryPoint.Client/B3.EntryPoint.Client.csproj
@@ -18,6 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/B3.EntryPoint.Client/DependencyInjection/EntryPointClientServiceCollectionExtensions.cs
+++ b/src/B3.EntryPoint.Client/DependencyInjection/EntryPointClientServiceCollectionExtensions.cs
@@ -1,0 +1,86 @@
+using B3.EntryPoint.Client.DropCopy;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace B3.EntryPoint.Client.DependencyInjection;
+
+/// <summary>
+/// <see cref="IServiceCollection"/> helpers that register
+/// <see cref="EntryPointClient"/> and <see cref="DropCopyClient"/> using
+/// the standard Options pattern. Both clients hold a long-lived TCP
+/// connection and are registered as singletons.
+/// </summary>
+/// <remarks>
+/// The caller owns the connection lifecycle: resolve the client and call
+/// <c>ConnectAsync</c>. The DI container will dispose the singleton on
+/// shutdown via <see cref="IAsyncDisposable"/>.
+/// </remarks>
+public static class EntryPointClientServiceCollectionExtensions
+{
+    /// <summary>Named-options key used by <see cref="AddDropCopyClient"/>.</summary>
+    public const string DropCopyOptionsName = "B3.EntryPoint.DropCopy";
+
+    /// <summary>
+    /// Registers a singleton <see cref="EntryPointClient"/> configured via
+    /// <paramref name="configure"/>. Options are validated on first resolve.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">If any argument is null.</exception>
+    public static IServiceCollection AddEntryPointClient(
+        this IServiceCollection services,
+        Action<EntryPointClientOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.AddOptions<EntryPointClientOptions>()
+            .Configure(configure)
+            .Validate(ValidateOptions, "Invalid EntryPointClientOptions: Endpoint, SessionId, EnteringFirm, and Credentials are required.");
+
+        services.TryAddSingleton(static sp =>
+            new EntryPointClient(sp.GetRequiredService<IOptions<EntryPointClientOptions>>().Value));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a singleton <see cref="DropCopyClient"/> configured via
+    /// <paramref name="configure"/>. Options are validated on first resolve.
+    /// </summary>
+    /// <remarks>
+    /// Uses a separately-named options instance so an application can
+    /// register both an Order-Entry client and a Drop-Copy client side
+    /// by side without their options colliding.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">If any argument is null.</exception>
+    public static IServiceCollection AddDropCopyClient(
+        this IServiceCollection services,
+        Action<EntryPointClientOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.AddOptions<EntryPointClientOptions>(DropCopyOptionsName)
+            .Configure(configure)
+            .PostConfigure(static o => o.Profile = SessionProfile.DropCopy)
+            .Validate(ValidateOptions, "Invalid EntryPointClientOptions for DropCopyClient: Endpoint, SessionId, EnteringFirm, and Credentials are required.");
+
+        services.TryAddSingleton(static sp =>
+        {
+            var monitor = sp.GetRequiredService<IOptionsMonitor<EntryPointClientOptions>>();
+            return new DropCopyClient(monitor.Get(DropCopyOptionsName));
+        });
+
+        return services;
+    }
+
+    private static bool ValidateOptions(EntryPointClientOptions options)
+    {
+        if (options is null) return false;
+        if (options.Endpoint is null) return false;
+        if (options.SessionId == 0u) return false;
+        if (options.EnteringFirm == 0u) return false;
+        if (options.Credentials is null) return false;
+        return true;
+    }
+}

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -7,24 +7,24 @@ namespace B3.EntryPoint.Client;
 
 public sealed class EntryPointClientOptions
 {
-    public required IPEndPoint Endpoint { get; init; }
+    public IPEndPoint Endpoint { get; set; } = null!;
 
     /// <summary>Client connection identification on the gateway, assigned by B3.</summary>
-    public required uint SessionId { get; init; }
+    public uint SessionId { get; set; }
 
     /// <summary>Session version identification — must increase on each new Negotiate.</summary>
-    public required uint SessionVerId { get; set; }
+    public uint SessionVerId { get; set; }
 
     /// <summary>Identifies the broker firm that will enter orders.</summary>
-    public required uint EnteringFirm { get; init; }
+    public uint EnteringFirm { get; set; }
 
-    public required Credentials Credentials { get; init; }
+    public Credentials Credentials { get; set; } = null!;
 
     /// <summary>Convenience constructor for shared-secret/UAT-style auth.</summary>
     public static Credentials AccessKey(string value) => Credentials.FromUtf8(value);
 
     /// <summary>FIXP keep-alive interval requested by the client (ms).</summary>
-    public uint KeepAliveIntervalMs { get; init; } = 1000;
+    public uint KeepAliveIntervalMs { get; set; } = 1000;
 
     /// <summary>FIXP keep-alive interval requested by the client.</summary>
     public TimeSpan KeepAliveInterval => TimeSpan.FromMilliseconds(KeepAliveIntervalMs);
@@ -33,19 +33,19 @@ public sealed class EntryPointClientOptions
     /// Identifies the original location for routing orders (FIX <c>SenderLocation</c>,
     /// max 10 chars). Required on every order entry message.
     /// </summary>
-    public string SenderLocation { get; init; } = "";
+    public string SenderLocation { get; set; } = "";
 
     /// <summary>
     /// Identifier of the trader entering the orders (FIX <c>EnteringTrader</c>,
     /// max 5 chars). Required on every order entry message.
     /// </summary>
-    public string EnteringTrader { get; init; } = "";
+    public string EnteringTrader { get; set; } = "";
 
     /// <summary>
     /// Default <c>MarketSegmentID</c> stamped on the inbound business header
     /// when a request does not specify one. Defaults to 1 (single-segment).
     /// </summary>
-    public byte DefaultMarketSegmentId { get; init; } = 1;
+    public byte DefaultMarketSegmentId { get; set; } = 1;
 
     /// <summary>
     /// Cancel-on-disconnect behaviour requested at <c>Negotiate</c>. Defaults
@@ -53,7 +53,7 @@ public sealed class EntryPointClientOptions
     /// — the safest choice for a participant that must not leave open orders
     /// after losing the session.
     /// </summary>
-    public CancelOnDisconnectType CancelOnDisconnect { get; init; } =
+    public CancelOnDisconnectType CancelOnDisconnect { get; set; } =
         CancelOnDisconnectType.CancelOnDisconnectOrTerminate;
 
     /// <summary>
@@ -61,41 +61,41 @@ public sealed class EntryPointClientOptions
     /// the default and allows order submission. <see cref="SessionProfile.DropCopy"/>
     /// is read-only and used by <see cref="DropCopy.DropCopyClient"/>.
     /// </summary>
-    public SessionProfile Profile { get; init; } = SessionProfile.OrderEntry;
+    public SessionProfile Profile { get; set; } = SessionProfile.OrderEntry;
 
     /// <summary>Optional client metadata sent in <c>Negotiate.ClientAppName</c>.</summary>
-    public string ClientAppName { get; init; } = "B3.EntryPoint.Client";
+    public string ClientAppName { get; set; } = "B3.EntryPoint.Client";
 
     /// <summary>Optional client metadata sent in <c>Negotiate.ClientAppVersion</c>.</summary>
-    public string ClientAppVersion { get; init; } = ThisAssemblyVersion();
+    public string ClientAppVersion { get; set; } = ThisAssemblyVersion();
 
     /// <summary>Optional client IP override sent in <c>Negotiate.ClientIP</c>; resolved automatically when null.</summary>
-    public string? ClientIP { get; init; }
+    public string? ClientIP { get; set; }
 
     /// <summary>TCP connect timeout.</summary>
-    public TimeSpan ConnectTimeout { get; init; } = TimeSpan.FromSeconds(10);
+    public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>Time to wait for <c>NegotiateResponse</c> / <c>EstablishmentAck</c>.</summary>
-    public TimeSpan HandshakeTimeout { get; init; } = TimeSpan.FromSeconds(10);
+    public TimeSpan HandshakeTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>Maximum number of <c>ConnectAsync</c> attempts (TCP+Negotiate+Establish) before
     /// surfacing the underlying exception. <c>1</c> disables retry. Defaults to 1 to preserve
     /// fail-fast semantics in the unit tests.</summary>
-    public int ConnectMaxAttempts { get; init; } = 1;
+    public int ConnectMaxAttempts { get; set; } = 1;
 
     /// <summary>Base delay for exponential backoff between connect attempts.</summary>
-    public TimeSpan ConnectBaseDelay { get; init; } = TimeSpan.FromMilliseconds(250);
+    public TimeSpan ConnectBaseDelay { get; set; } = TimeSpan.FromMilliseconds(250);
 
     /// <summary>Maximum delay between connect attempts (caps the exponential growth).</summary>
-    public TimeSpan ConnectMaxDelay { get; init; } = TimeSpan.FromSeconds(10);
+    public TimeSpan ConnectMaxDelay { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>Idle timeout — if no inbound frame is observed for this duration the client
     /// closes the session. Defaults to <see cref="TimeSpan.Zero"/> (disabled).</summary>
-    public TimeSpan IdleTimeout { get; init; } = TimeSpan.Zero;
+    public TimeSpan IdleTimeout { get; set; } = TimeSpan.Zero;
 
     /// <summary>Optional <see cref="ILogger"/> used by the client for structured events.
     /// Defaults to <see cref="NullLogger.Instance"/> so existing tests are unaffected.</summary>
-    public ILogger Logger { get; init; } = NullLogger.Instance;
+    public ILogger Logger { get; set; } = NullLogger.Instance;
 
     /// <summary>
     /// Optional persistence for warm-restart. When provided, the client hydrates
@@ -105,11 +105,11 @@ public sealed class EntryPointClientOptions
     /// and triggers a snapshot+truncate after every
     /// <see cref="StateCompactEveryDeltas"/> appends.
     /// </summary>
-    public State.ISessionStateStore? SessionStateStore { get; init; }
+    public State.ISessionStateStore? SessionStateStore { get; set; }
 
     /// <summary>How many appended deltas trigger a <see cref="State.ISessionStateStore.CompactAsync"/>.
     /// Set to <c>0</c> to disable automatic compaction. Defaults to 1024.</summary>
-    public int StateCompactEveryDeltas { get; init; } = 1024;
+    public int StateCompactEveryDeltas { get; set; } = 1024;
 
     private static string ThisAssemblyVersion() =>
         typeof(EntryPointClientOptions).Assembly.GetName().Version?.ToString() ?? "0.0.0";

--- a/tests/B3.EntryPoint.Client.Tests/B3.EntryPoint.Client.Tests.csproj
+++ b/tests/B3.EntryPoint.Client.Tests/B3.EntryPoint.Client.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/tests/B3.EntryPoint.Client.Tests/DependencyInjection/EntryPointClientServiceCollectionExtensionsTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/DependencyInjection/EntryPointClientServiceCollectionExtensionsTests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.DependencyInjection;
+using B3.EntryPoint.Client.DropCopy;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace B3.EntryPoint.Client.Tests.DependencyInjection;
+
+public class EntryPointClientServiceCollectionExtensionsTests
+{
+    private static void ConfigureValid(EntryPointClientOptions o, ushort port = 9000, uint sessionId = 42u)
+    {
+        o.Endpoint = new IPEndPoint(IPAddress.Loopback, port);
+        o.SessionId = sessionId;
+        o.SessionVerId = 1u;
+        o.EnteringFirm = 7u;
+        o.Credentials = Credentials.FromUtf8("k");
+    }
+
+    [Fact]
+    public async Task AddEntryPointClient_RegistersSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddEntryPointClient(o => ConfigureValid(o));
+
+        var sp = services.BuildServiceProvider();
+        try
+        {
+            var a = sp.GetRequiredService<EntryPointClient>();
+            var b = sp.GetRequiredService<EntryPointClient>();
+            Assert.Same(a, b);
+        }
+        finally { await ((IAsyncDisposable)sp).DisposeAsync(); }
+    }
+
+    [Fact]
+    public async Task AddEntryPointClient_AppliesOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddEntryPointClient(o =>
+        {
+            ConfigureValid(o, sessionId: 99u);
+            o.KeepAliveIntervalMs = 7777u;
+        });
+
+        var sp = services.BuildServiceProvider();
+        try
+        {
+            var opts = sp.GetRequiredService<IOptions<EntryPointClientOptions>>().Value;
+            Assert.Equal(99u, opts.SessionId);
+            Assert.Equal(7777u, opts.KeepAliveIntervalMs);
+        }
+        finally { await ((IAsyncDisposable)sp).DisposeAsync(); }
+    }
+
+    [Fact]
+    public void AddEntryPointClient_NullArgs_Throw()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            EntryPointClientServiceCollectionExtensions.AddEntryPointClient(null!, _ => { }));
+        Assert.Throws<ArgumentNullException>(() =>
+            new ServiceCollection().AddEntryPointClient(null!));
+    }
+
+    [Fact]
+    public async Task AddEntryPointClient_ValidatesOnResolve()
+    {
+        var services = new ServiceCollection();
+        services.AddEntryPointClient(_ => { /* leave defaults: missing required fields */ });
+
+        var sp = services.BuildServiceProvider();
+        try
+        {
+            Assert.Throws<OptionsValidationException>(() => sp.GetRequiredService<EntryPointClient>());
+        }
+        finally { await ((IAsyncDisposable)sp).DisposeAsync(); }
+    }
+
+    [Fact]
+    public async Task AddDropCopyClient_RegistersSingleton_WithSeparateNamedOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddEntryPointClient(o => ConfigureValid(o, port: 9000, sessionId: 1u));
+        services.AddDropCopyClient(o => ConfigureValid(o, port: 9001, sessionId: 2u));
+
+        var sp = services.BuildServiceProvider();
+        try
+        {
+            Assert.NotNull(sp.GetRequiredService<EntryPointClient>());
+            Assert.NotNull(sp.GetRequiredService<DropCopyClient>());
+
+            var monitor = sp.GetRequiredService<IOptionsMonitor<EntryPointClientOptions>>();
+            Assert.Equal(1u, monitor.Get(Microsoft.Extensions.Options.Options.DefaultName).SessionId);
+            Assert.Equal(2u, monitor.Get(EntryPointClientServiceCollectionExtensions.DropCopyOptionsName).SessionId);
+        }
+        finally { await ((IAsyncDisposable)sp).DisposeAsync(); }
+    }
+
+    [Fact]
+    public void AddDropCopyClient_NullArgs_Throw()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            EntryPointClientServiceCollectionExtensions.AddDropCopyClient(null!, _ => { }));
+        Assert.Throws<ArgumentNullException>(() =>
+            new ServiceCollection().AddDropCopyClient(null!));
+    }
+}


### PR DESCRIPTION
Closes #76. New `B3.EntryPoint.Client.DependencyInjection` helpers + Options-pattern relaxation on `EntryPointClientOptions`.