### PR TITLE
NuGet release flow hardening (#78)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
           --logger "console;verbosity=normal"
           --results-directory ./TestResults
 
+      - name: Pack (validation)
+        run: dotnet pack SbeB3EntryPointClient.slnx --no-build -c Release -o ./nupkgs
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,8 +37,6 @@ jobs:
 
       - name: Push to NuGet.org
         if: ${{ env.NUGET_API_KEY != '' }}
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           for pkg in ./nupkgs/*.nupkg; do
             dotnet nuget push "$pkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- DI helpers `AddEntryPointClient` and `AddDropCopyClient` (`B3.EntryPoint.Client.DependencyInjection`).
+- Inbound decoders for `AllocationReport` (template 602) and `PositionMaintenanceReport` (template 503).
+- `InMemoryFixpPeer` now emits periodic `Sequence` frames at the negotiated keep-alive interval and replies to `RetransmitRequest` with a `Retransmission(Count=0)`.
+- `dotnet pack` validation step in CI to catch packaging breakage on PRs.
+
+### Changed
+- `EntryPointClientOptions` properties relaxed from `required init` to `set` so the standard Options pattern can populate them. Existing object-initializer call sites continue to compile.
+
+### Fixed
+- `FixpClientSession` was reading `RetransmissionData` / `RetransmitRejectData` at the wrong byte offsets (assumed `SessionID` was 8 bytes; it is 4). Would throw on a real `Retransmission` frame.
+- Publish workflow's API-key guard (`if: ${{ env.NUGET_API_KEY != '' }}`) was evaluated before the step's `env:` block ran, silently skipping every push. Job-level `env:` now hoists the secret correctly.
+
+## [0.4.2]
+
+Pre-public-release internal milestones (Hardening + wire-up). See git history for details.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ dotnet run -c Release --project benchmarks/B3.EntryPoint.Benchmarks -- --filter 
 Or trigger the [`Benchmarks`](.github/workflows/bench.yml) workflow via
 `workflow_dispatch` to run on CI and download the artifacts.
 
+## Releasing (NuGet)
+
+Both packages ship from the same git tag:
+
+1. Bump `<Version>` in [`Directory.Build.props`](Directory.Build.props) and update [`CHANGELOG.md`](CHANGELOG.md).
+2. Commit, then tag: `git tag v0.5.0 && git push origin v0.5.0` (use `v0.5.0-alpha.1` for pre-releases).
+3. The [`Publish NuGet`](.github/workflows/publish.yml) workflow runs on `v*` tags: it builds, tests, packs, and pushes both `.nupkg` + `.snupkg` to nuget.org via the `NUGET_API_KEY` repo secret.
+
+Without `NUGET_API_KEY`, the workflow still produces uploadable artifacts you can grab from the run page.
+
 ## License
 
 MIT — see [`LICENSE`](LICENSE).


### PR DESCRIPTION
Closes #78. Fixes silent push-skip in publish.yml; adds pack validation to CI; introduces CHANGELOG; documents release flow.