### PR TITLE
H5: Eager constructor validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `EntryPointClient` and `DropCopyClient` constructors now eagerly validate `EntryPointClientOptions` (non-null `Endpoint`/`Credentials`, non-zero `SessionId`/`EnteringFirm`) and throw `ArgumentException` instead of failing later with `NullReferenceException` inside `ConnectAsync`.
+
 ## [0.5.0] - 2026-05-01
 
 ### Added

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -58,7 +58,20 @@ public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceO
     public EntryPointClient(EntryPointClientOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
+        ValidateOptions(options);
         _options = options;
+    }
+
+    private static void ValidateOptions(EntryPointClientOptions options)
+    {
+        if (options.Endpoint is null)
+            throw new ArgumentException($"{nameof(EntryPointClientOptions.Endpoint)} is required.", nameof(options));
+        if (options.Credentials is null)
+            throw new ArgumentException($"{nameof(EntryPointClientOptions.Credentials)} is required.", nameof(options));
+        if (options.SessionId == 0u)
+            throw new ArgumentException($"{nameof(EntryPointClientOptions.SessionId)} must be non-zero.", nameof(options));
+        if (options.EnteringFirm == 0u)
+            throw new ArgumentException($"{nameof(EntryPointClientOptions.EnteringFirm)} must be non-zero.", nameof(options));
     }
 
     public FixpClientState State => _session?.State ?? FixpClientState.Disconnected;

--- a/tests/B3.EntryPoint.Client.Tests/EntryPointClientConstructorTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/EntryPointClientConstructorTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.DropCopy;
+
+namespace B3.EntryPoint.Client.Tests;
+
+public class EntryPointClientConstructorTests
+{
+    private static EntryPointClientOptions Valid() => new()
+    {
+        Endpoint = new IPEndPoint(IPAddress.Loopback, 9000),
+        SessionId = 1u,
+        SessionVerId = 1u,
+        EnteringFirm = 7u,
+        Credentials = Credentials.FromUtf8("k"),
+    };
+
+    [Fact]
+    public void Ctor_NullOptions_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new EntryPointClient(null!));
+    }
+
+    [Fact]
+    public void Ctor_MissingEndpoint_Throws()
+    {
+        var opts = Valid();
+        opts.Endpoint = null!;
+        var ex = Assert.Throws<ArgumentException>(() => new EntryPointClient(opts));
+        Assert.Contains("Endpoint", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_MissingCredentials_Throws()
+    {
+        var opts = Valid();
+        opts.Credentials = null!;
+        var ex = Assert.Throws<ArgumentException>(() => new EntryPointClient(opts));
+        Assert.Contains("Credentials", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_ZeroSessionId_Throws()
+    {
+        var opts = Valid();
+        opts.SessionId = 0u;
+        var ex = Assert.Throws<ArgumentException>(() => new EntryPointClient(opts));
+        Assert.Contains("SessionId", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_ZeroEnteringFirm_Throws()
+    {
+        var opts = Valid();
+        opts.EnteringFirm = 0u;
+        var ex = Assert.Throws<ArgumentException>(() => new EntryPointClient(opts));
+        Assert.Contains("EnteringFirm", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_ValidOptions_Succeeds()
+    {
+        var client = new EntryPointClient(Valid());
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void DropCopyCtor_MissingEndpoint_Throws()
+    {
+        var opts = Valid();
+        opts.Profile = SessionProfile.DropCopy;
+        opts.Endpoint = null!;
+        Assert.Throws<ArgumentException>(() => new DropCopyClient(opts));
+    }
+
+    [Fact]
+    public void DropCopyCtor_WrongProfile_Throws()
+    {
+        var opts = Valid(); // Profile defaults to OrderEntry.
+        var ex = Assert.Throws<ArgumentException>(() => new DropCopyClient(opts));
+        Assert.Contains("DropCopy", ex.Message);
+    }
+}


### PR DESCRIPTION
Closes #81

Adds eager argument validation in `EntryPointClient` and `DropCopyClient` constructors so non-DI callers fail fast with `ArgumentException` instead of `NullReferenceException` deep in `ConnectAsync`.

Validates: non-null Endpoint/Credentials, non-zero SessionId/EnteringFirm. DropCopyClient keeps its existing Profile check. 8 new unit tests, 114 total passing.