### PR TITLE
H7: README badges + install snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- README badges (CI, license, .NET) and `dotnet add package` install snippets.
+
 ### Changed
 - `EntryPointClient` and `DropCopyClient` constructors now eagerly validate `EntryPointClientOptions` (non-null `Endpoint`/`Credentials`, non-zero `SessionId`/`EnteringFirm`) and throw `ArgumentException` instead of failing later with `NullReferenceException` inside `ConnectAsync`.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # B3EntryPointClient
 
+[![CI](https://github.com/pedrosakuma/B3EntryPointClient/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/pedrosakuma/B3EntryPointClient/actions/workflows/ci.yml)
 [![NuGet — Client](https://img.shields.io/nuget/v/B3.EntryPoint.Client?label=B3.EntryPoint.Client)](https://www.nuget.org/packages/B3.EntryPoint.Client)
 [![NuGet — Sbe](https://img.shields.io/nuget/v/B3.EntryPoint.Sbe?label=B3.EntryPoint.Sbe)](https://www.nuget.org/packages/B3.EntryPoint.Sbe)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![.NET](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
 
 Wire-puro **client** library for the B3 EntryPoint (SBE/FIXP 8.4.2) order-entry
 protocol. Symmetric counterpart of [`B3MarketDataPlatform`][md] (UMDF consumer):
@@ -39,6 +42,16 @@ wire-puro is so the same code can drive the simulator or B3 UAT.
   (`connect` only in the bootstrap).
 - **`samples/B3.EntryPoint.Quickstart`** — end-to-end console demo against
   the in-memory FIXP peer. See [Quickstart](docs/QUICKSTART.md).
+
+## Install
+
+```bash
+dotnet add package B3.EntryPoint.Client
+# Optional: only the SBE 8.4.2 codecs (no FIXP session layer)
+dotnet add package B3.EntryPoint.Sbe
+```
+
+Targets `net10.0`. Symbols are published as `.snupkg` to nuget.org (sourcelink-enabled).
 
 ## Quickstart
 


### PR DESCRIPTION
Closes #83. Adds CI/license/.NET badges next to the existing NuGet badges, plus a top-level Install section with `dotnet add package` snippets for both shipped packages.