### PR TITLE
H6: Stabilize flaky telemetry/keep-alive tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README badges (CI, license, .NET) and `dotnet add package` install snippets.
 
 ### Changed
+- Stabilized two timing-sensitive tests (telemetry `ActivityListener` filters by operation name; keep-alive scheduler test polls with deadline instead of fixed `Task.Delay`).
 - `EntryPointClient` and `DropCopyClient` constructors now eagerly validate `EntryPointClientOptions` (non-null `Endpoint`/`Credentials`, non-zero `SessionId`/`EnteringFirm`) and throw `ArgumentException` instead of failing later with `NullReferenceException` inside `ConnectAsync`.
 
 ## [0.5.0] - 2026-05-01

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/KeepAliveSchedulerTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/KeepAliveSchedulerTests.cs
@@ -90,9 +90,18 @@ public class KeepAliveSchedulerPeriodicTests
             (Func<ulong>)(() => System.Threading.Interlocked.Increment(ref nextSeq)),
         });
         scheduler.Start();
-        await Task.Delay(180);
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            int count;
+            lock (ticks) count = ticks.Count;
+            if (count >= 2) break;
+            await Task.Delay(20);
+        }
         scheduler.Stop();
         scheduler.Dispose();
-        Assert.True(ticks.Count >= 2, $"expected >=2 ticks, got {ticks.Count}");
+        int finalCount;
+        lock (ticks) finalCount = ticks.Count;
+        Assert.True(finalCount >= 2, $"expected >=2 ticks, got {finalCount}");
     }
 }

--- a/tests/B3.EntryPoint.Client.Tests/Telemetry/EntryPointTelemetryTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Telemetry/EntryPointTelemetryTests.cs
@@ -63,19 +63,23 @@ public class EntryPointTelemetryTests
     [Fact]
     public void ActivitySource_Emits_Activity_When_Listener_Sampled()
     {
+        const string opName = "entrypoint.unit-test.activity-emit";
         Activity? captured = null;
         using var listener = new ActivityListener
         {
             ShouldListenTo = src => src.Name == EntryPointTelemetry.SourceName,
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
-            ActivityStarted = a => captured = a,
+            ActivityStarted = a =>
+            {
+                if (a.OperationName == opName) captured = a;
+            },
         };
         ActivitySource.AddActivityListener(listener);
 
-        using var activity = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.unit-test", ActivityKind.Client);
+        using var activity = EntryPointTelemetry.ActivitySource.StartActivity(opName, ActivityKind.Client);
 
         Assert.NotNull(activity);
         Assert.Same(activity, captured);
-        Assert.Equal("entrypoint.unit-test", captured!.OperationName);
+        Assert.Equal(opName, captured!.OperationName);
     }
 }


### PR DESCRIPTION
Closes #85.

- Telemetry ActivityListener now filters by OperationName so other tests starting Activities on the same source can't overwrite `captured`.
- KeepAliveSchedulerPeriodicTests polls for >=2 ticks with a 5s deadline instead of a fixed 180ms wait.