### PR TITLE
feat: IEntryPointClient + IDropCopyClient interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - README badges (CI, license, .NET) and `dotnet add package` install snippets.
 - `Microsoft.CodeAnalysis.PublicApiAnalyzers` on `B3.EntryPoint.Client` with the v0.5.0 surface seeded into `PublicAPI.Shipped.txt`. New public API additions must be tracked in `PublicAPI.Unshipped.txt` (analyzer error `RS0016` on additions, `RS0017` on removals).
+- `IEntryPointClient` and `IDropCopyClient` interfaces aggregating the public surface of the corresponding clients. DI helpers now also register the interface forwarders, so consumers can depend on the abstractions for mocking.
 
 ### Changed
 - Stabilized two timing-sensitive tests (telemetry `ActivityListener` filters by operation name; keep-alive scheduler test polls with deadline instead of fixed `Task.Delay`).

--- a/src/B3.EntryPoint.Client/DependencyInjection/EntryPointClientServiceCollectionExtensions.cs
+++ b/src/B3.EntryPoint.Client/DependencyInjection/EntryPointClientServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ public static class EntryPointClientServiceCollectionExtensions
 
         services.TryAddSingleton(static sp =>
             new EntryPointClient(sp.GetRequiredService<IOptions<EntryPointClientOptions>>().Value));
+        services.TryAddSingleton<IEntryPointClient>(static sp => sp.GetRequiredService<EntryPointClient>());
 
         return services;
     }
@@ -70,6 +71,7 @@ public static class EntryPointClientServiceCollectionExtensions
             var monitor = sp.GetRequiredService<IOptionsMonitor<EntryPointClientOptions>>();
             return new DropCopyClient(monitor.Get(DropCopyOptionsName));
         });
+        services.TryAddSingleton<IDropCopyClient>(static sp => sp.GetRequiredService<DropCopyClient>());
 
         return services;
     }

--- a/src/B3.EntryPoint.Client/DropCopy/DropCopyClient.cs
+++ b/src/B3.EntryPoint.Client/DropCopy/DropCopyClient.cs
@@ -9,7 +9,7 @@ namespace B3.EntryPoint.Client.DropCopy;
 /// Submission (NewOrder / Replace / Cancel) is intentionally absent —
 /// callers should use <see cref="EntryPointClient"/> for that.
 /// </summary>
-public sealed class DropCopyClient : IAsyncDisposable
+public sealed class DropCopyClient : IDropCopyClient
 {
     private readonly EntryPointClient _inner;
 

--- a/src/B3.EntryPoint.Client/DropCopy/IDropCopyClient.cs
+++ b/src/B3.EntryPoint.Client/DropCopy/IDropCopyClient.cs
@@ -1,0 +1,23 @@
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client.DropCopy;
+
+/// <summary>
+/// Drop Copy session client contract. Implemented by
+/// <see cref="DropCopyClient"/>. Exists so consumers can mock the drop-copy
+/// flow independently of the concrete TCP-bound implementation.
+/// </summary>
+public interface IDropCopyClient : IAsyncDisposable
+{
+    /// <summary>Establishes the Drop Copy FIXP session.</summary>
+    Task ConnectAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Streams inbound EntryPoint events (drop-copy reports).</summary>
+    IAsyncEnumerable<EntryPointEvent> Events(CancellationToken cancellationToken = default);
+
+    /// <summary>Sends a <c>Terminate</c> frame and closes the drop-copy session.</summary>
+    Task TerminateAsync(TerminationCode code = TerminationCode.Finished, CancellationToken cancellationToken = default);
+
+    /// <summary>Raised when the drop-copy session is terminated.</summary>
+    event EventHandler<TerminatedEventArgs>? Terminated;
+}

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -21,7 +21,7 @@ namespace B3.EntryPoint.Client;
 /// public API surface; their wire-level implementations land incrementally
 /// (see <c>docs/CONFORMANCE.md</c> and the issues tagged <c>area/api-surface</c>).
 /// </summary>
-public sealed class EntryPointClient : IAsyncDisposable, ISubmitOrder, IReplaceOrder, ICancelOrder, ISubmitCross, IQuoteFlow
+public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplaceOrder, ICancelOrder, ISubmitCross, IQuoteFlow
 {
     private readonly EntryPointClientOptions _options;
     private readonly Channel<EntryPointEvent> _events =

--- a/src/B3.EntryPoint.Client/IEntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/IEntryPointClient.cs
@@ -1,0 +1,55 @@
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Client.Risk;
+using B3.EntryPoint.Client.State;
+using B3.EntryPoint.Client.Telemetry;
+
+namespace B3.EntryPoint.Client;
+
+/// <summary>
+/// High-level B3 EntryPoint client contract. Aggregates the order-flow
+/// interfaces (<see cref="ISubmitOrder"/>, <see cref="IReplaceOrder"/>,
+/// <see cref="ICancelOrder"/>, <see cref="ISubmitCross"/>,
+/// <see cref="IQuoteFlow"/>) and exposes session lifecycle, telemetry and
+/// inbound event streaming. Implemented by <see cref="EntryPointClient"/>;
+/// this interface exists so consumers (notably <c>B3TradingPlatform</c>) can
+/// depend on an abstraction and substitute it in unit tests.
+/// </summary>
+public interface IEntryPointClient :
+    IAsyncDisposable,
+    ISubmitOrder,
+    IReplaceOrder,
+    ICancelOrder,
+    ISubmitCross,
+    IQuoteFlow
+{
+    /// <summary>Current FIXP session state.</summary>
+    FixpClientState State { get; }
+
+    /// <summary>Pre-trade risk gates evaluated before any outbound order frame.</summary>
+    IList<IPreTradeGate> RiskGates { get; }
+
+    /// <summary>Keep-alive scheduler bound after <see cref="ConnectAsync"/>.</summary>
+    IKeepAliveScheduler? KeepAlive { get; }
+
+    /// <summary>Retransmit handler bound after <see cref="ConnectAsync"/>.</summary>
+    IRetransmitRequestHandler? Retransmit { get; }
+
+    /// <summary>Raised when the session is terminated (sent or received).</summary>
+    event EventHandler<TerminatedEventArgs>? Terminated;
+
+    /// <summary>Establishes the FIXP session (TCP + Negotiate + Establish).</summary>
+    Task ConnectAsync(CancellationToken ct = default);
+
+    /// <summary>Sends a <c>Terminate</c> frame and closes the session.</summary>
+    Task TerminateAsync(TerminationCode code, CancellationToken ct = default);
+
+    /// <summary>Reconnects with a bumped <c>SessionVerId</c>.</summary>
+    Task ReconnectAsync(uint nextSessionVerId, CancellationToken ct = default);
+
+    /// <summary>Snapshot of in-memory client health counters.</summary>
+    ClientHealth GetHealth();
+
+    /// <summary>Streams inbound EntryPoint events as they are decoded.</summary>
+    IAsyncEnumerable<EntryPointEvent> Events(CancellationToken ct = default);
+}

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -1,1 +1,17 @@
 #nullable enable
+B3.EntryPoint.Client.DropCopy.IDropCopyClient
+B3.EntryPoint.Client.DropCopy.IDropCopyClient.ConnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+B3.EntryPoint.Client.DropCopy.IDropCopyClient.Events(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<B3.EntryPoint.Client.Models.EntryPointEvent!>!
+B3.EntryPoint.Client.DropCopy.IDropCopyClient.TerminateAsync(B3.EntryPoint.Client.TerminationCode code = B3.EntryPoint.Client.TerminationCode.Finished, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+B3.EntryPoint.Client.DropCopy.IDropCopyClient.Terminated -> System.EventHandler<B3.EntryPoint.Client.TerminatedEventArgs!>?
+B3.EntryPoint.Client.IEntryPointClient
+B3.EntryPoint.Client.IEntryPointClient.ConnectAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+B3.EntryPoint.Client.IEntryPointClient.Events(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<B3.EntryPoint.Client.Models.EntryPointEvent!>!
+B3.EntryPoint.Client.IEntryPointClient.GetHealth() -> B3.EntryPoint.Client.Telemetry.ClientHealth
+B3.EntryPoint.Client.IEntryPointClient.KeepAlive.get -> B3.EntryPoint.Client.Fixp.IKeepAliveScheduler?
+B3.EntryPoint.Client.IEntryPointClient.ReconnectAsync(uint nextSessionVerId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+B3.EntryPoint.Client.IEntryPointClient.Retransmit.get -> B3.EntryPoint.Client.Fixp.IRetransmitRequestHandler?
+B3.EntryPoint.Client.IEntryPointClient.RiskGates.get -> System.Collections.Generic.IList<B3.EntryPoint.Client.Risk.IPreTradeGate!>!
+B3.EntryPoint.Client.IEntryPointClient.State.get -> B3.EntryPoint.Client.Fixp.FixpClientState
+B3.EntryPoint.Client.IEntryPointClient.TerminateAsync(B3.EntryPoint.Client.TerminationCode code, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+B3.EntryPoint.Client.IEntryPointClient.Terminated -> System.EventHandler<B3.EntryPoint.Client.TerminatedEventArgs!>?

--- a/tests/B3.EntryPoint.Client.Tests/DependencyInjection/EntryPointClientServiceCollectionExtensionsTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/DependencyInjection/EntryPointClientServiceCollectionExtensionsTests.cs
@@ -30,6 +30,8 @@ public class EntryPointClientServiceCollectionExtensionsTests
             var a = sp.GetRequiredService<EntryPointClient>();
             var b = sp.GetRequiredService<EntryPointClient>();
             Assert.Same(a, b);
+            var i = sp.GetRequiredService<IEntryPointClient>();
+            Assert.Same(a, i);
         }
         finally { await ((IAsyncDisposable)sp).DisposeAsync(); }
     }
@@ -89,6 +91,8 @@ public class EntryPointClientServiceCollectionExtensionsTests
         {
             Assert.NotNull(sp.GetRequiredService<EntryPointClient>());
             Assert.NotNull(sp.GetRequiredService<DropCopyClient>());
+            Assert.Same(sp.GetRequiredService<DropCopyClient>(), sp.GetRequiredService<IDropCopyClient>());
+            Assert.Same(sp.GetRequiredService<EntryPointClient>(), sp.GetRequiredService<IEntryPointClient>());
 
             var monitor = sp.GetRequiredService<IOptionsMonitor<EntryPointClientOptions>>();
             Assert.Equal(1u, monitor.Get(Microsoft.Extensions.Options.Options.DefaultName).SessionId);


### PR DESCRIPTION
Closes #89.

Adds full-surface interfaces so downstream consumers (notably `B3TradingPlatform`) can depend on an abstraction and substitute it in unit tests.

- `IEntryPointClient` aggregates the existing focused interfaces (ISubmitOrder, IReplaceOrder, ICancelOrder, ISubmitCross, IQuoteFlow) plus session lifecycle: State, RiskGates, KeepAlive, Retransmit, Terminated event, ConnectAsync, TerminateAsync, ReconnectAsync, GetHealth, Events.
- `IDropCopyClient` mirrors DropCopyClient (ConnectAsync, Events, TerminateAsync, Terminated).
- DI helpers register the interface forwarders alongside the concrete singletons.
- New types appended to `PublicAPI.Unshipped.txt`. CHANGELOG updated under [Unreleased].