### PR TITLE
ci: SourceLink gate on .snupkg PDBs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Use the PR head SHA (not the synthetic merge commit) so the SHA
+          # SourceLink embeds is reachable from raw.githubusercontent.com.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up .NET SDK (pinned by global.json)
         uses: actions/setup-dotnet@v5
@@ -63,6 +67,28 @@ jobs:
 
       - name: Pack (validation)
         run: dotnet pack SbeB3EntryPointClient.slnx --no-build -c Release -o ./nupkgs
+
+      # SourceLink gate: every .snupkg's PDB must contain GitHub URLs that
+      # resolve (HTTP 200) and whose content checksum matches the PDB hash.
+      - name: Install sourcelink tool
+        run: dotnet tool install --global sourcelink
+
+      - name: SourceLink test (snupkgs)
+        run: |
+          set -euo pipefail
+          mkdir -p ./snupkg-extract
+          shopt -s nullglob globstar
+          for snupkg in ./nupkgs/*.snupkg; do
+            name=$(basename "$snupkg" .snupkg)
+            dest="./snupkg-extract/$name"
+            mkdir -p "$dest"
+            unzip -q -o "$snupkg" -d "$dest"
+            for pdb in "$dest"/lib/**/*.pdb; do
+              echo "::group::sourcelink test $pdb"
+              sourcelink test "$pdb"
+              echo "::endgroup::"
+            done
+          done
 
       - name: Upload test results
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README badges (CI, license, .NET) and `dotnet add package` install snippets.
 - `Microsoft.CodeAnalysis.PublicApiAnalyzers` on `B3.EntryPoint.Client` with the v0.5.0 surface seeded into `PublicAPI.Shipped.txt`. New public API additions must be tracked in `PublicAPI.Unshipped.txt` (analyzer error `RS0016` on additions, `RS0017` on removals).
 - `IEntryPointClient` and `IDropCopyClient` interfaces aggregating the public surface of the corresponding clients. DI helpers now also register the interface forwarders, so consumers can depend on the abstractions for mocking.
+- CI gate: `sourcelink test` runs on every `.snupkg` to verify the embedded GitHub source URLs resolve and match the PDB content hashes (catches broken SourceLink before release).
 
 ### Changed
 - Stabilized two timing-sensitive tests (telemetry `ActivityListener` filters by operation name; keep-alive scheduler test polls with deadline instead of fixed `Task.Delay`).


### PR DESCRIPTION
Closes #91.

Adds a CI step (after `dotnet pack`) that:
1. Installs the `sourcelink` global tool.
2. Extracts each `.snupkg` and locates its `.pdb`.
3. Runs `sourcelink test` to verify every embedded GitHub source URL resolves (HTTP 200) and matches the PDB content hash.

Also pins `actions/checkout` to the PR head SHA on PR builds so the SHA SourceLink embeds is fetchable from raw.githubusercontent.com (the default merge commit isn't pushed back, hence not reachable).