### PR TITLE
docs: refresh README Roadmap → Status matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Stabilized two timing-sensitive tests (telemetry `ActivityListener` filters by operation name; keep-alive scheduler test polls with deadline instead of fixed `Task.Delay`).
+- README: replaced the outdated "Roadmap" issue table with a "Status" matrix reflecting that all wire-up issues (#3–#11, #51) are merged. Removed the stale `NotImplementedException` disclaimer; updated the `ICrossQuoteFlows` doc-comments accordingly.
 - `EntryPointClient` and `DropCopyClient` constructors now eagerly validate `EntryPointClientOptions` (non-null `Endpoint`/`Credentials`, non-zero `SessionId`/`EnteringFirm`) and throw `ArgumentException` instead of failing later with `NullReferenceException` inside `ConnectAsync`.
 
 ## [0.5.0] - 2026-05-01

--- a/README.md
+++ b/README.md
@@ -117,27 +117,34 @@ dotnet test tests/B3.EntryPoint.Conformance --filter "Category=Conformance"
 byte-identical with the copy in `B3MatchingPlatform`. Do not hand-edit;
 regenerate the bindings when upgrading and mirror the change there.
 
-## Roadmap
+## Status
 
-API-surface-first: stubs públicos lançam `NotImplementedException` para destravar
-integração com `B3MatchingPlatform` antes da fiação SBE/FIXP completa.
+The wire-puro client is **feature-complete for the schemas currently shipped**
+(SBE FIXP 8.4.2 order-entry + drop-copy). All session, order-flow and inbound
+decoder paths are implemented and exercised by the in-process conformance
+suite.
 
-| Área | Issue |
+| Área | Estado |
 | --- | --- |
-| Reliability §4.6 — Sequence / Heartbeat | [#3](https://github.com/pedrosakuma/B3EntryPointClient/issues/3) |
-| Reliability §4.7 — Retransmit / NotApplied | [#5](https://github.com/pedrosakuma/B3EntryPointClient/issues/5) |
-| Reliability §4.8 — Terminate / Reconnect / CancelOnDisconnect | [#6](https://github.com/pedrosakuma/B3EntryPointClient/issues/6) |
-| Order Entry — `ISubmitOrder` (NewOrderSingle / SimpleNewOrder) | [#4](https://github.com/pedrosakuma/B3EntryPointClient/issues/4) |
-| Order Entry — `IReplaceOrder` (OrderCancelReplace / SimpleModify) | [#7](https://github.com/pedrosakuma/B3EntryPointClient/issues/7) |
-| Order Entry — `ICancelOrder` + `OrderMassAction` | [#8](https://github.com/pedrosakuma/B3EntryPointClient/issues/8) |
-| ExecutionReport family + BusinessMessageReject (Events stream) | [#9](https://github.com/pedrosakuma/B3EntryPointClient/issues/9) |
-| Drop Copy session profile | [#10](https://github.com/pedrosakuma/B3EntryPointClient/issues/10) |
-| Conformance §4.5..§4.8 + Order Entry + Drop Copy | [#11](https://github.com/pedrosakuma/B3EntryPointClient/issues/11) |
+| Reliability §4.6 — Sequence / Heartbeat | ✅ wired |
+| Reliability §4.7 — Retransmit / NotApplied | ✅ wired |
+| Reliability §4.8 — Terminate / Reconnect / CancelOnDisconnect | ✅ wired |
+| Order Entry — `ISubmitOrder` (NewOrderSingle / SimpleNewOrder) | ✅ wired |
+| Order Entry — `IReplaceOrder` (OrderCancelReplace / SimpleModify) | ✅ wired |
+| Order Entry — `ICancelOrder` + `OrderMassAction` | ✅ wired |
+| ExecutionReport family + BusinessMessageReject (Events stream) | ✅ wired |
+| Cross / Quote (`ISubmitCross`, `IQuoteFlow`) | ✅ wired |
+| Drop Copy session profile (`DropCopyClient` + `IDropCopyClient`) | ✅ wired |
+| AllocationReport / PositionMaintenanceReport inbound decoders | ✅ wired |
+| Conformance §4.5..§4.8 + Order Entry + Drop Copy | ✅ in-process suite |
+| DI helpers (`AddEntryPointClient`, `AddDropCopyClient`) | ✅ shipped |
+| `IEntryPointClient` / `IDropCopyClient` interfaces for mocking | ✅ shipped |
+| PublicApiAnalyzers gating breaking changes | ✅ shipped |
+| SourceLink + `.snupkg` published to nuget.org | ✅ shipped |
 
-Position / Allocation / SecurityDefinition messages estão fora de escopo
-nesta fase (não constam do schema atual). Cross / Quote possuem **interface
-estável** (`ISubmitCross`, `IQuoteFlow`) — wire-up SBE rastreado pela issue
-[#51](https://github.com/pedrosakuma/B3EntryPointClient/issues/51).
+`SecurityDefinitionRequest` and outbound `AllocationInstruction` /
+`PositionMaintenanceRequest` are intentionally **out of scope** until they
+appear in the schema bundle.
 
 ## Benchmarks
 

--- a/src/B3.EntryPoint.Client/ICrossQuoteFlows.cs
+++ b/src/B3.EntryPoint.Client/ICrossQuoteFlows.cs
@@ -3,9 +3,8 @@ using B3.EntryPoint.Client.Models;
 namespace B3.EntryPoint.Client;
 
 /// <summary>
-/// Submits a <c>NewOrderCross</c> message (schema §9). Wire-up is tracked by
-/// issue #51; the current implementation throws <see cref="NotImplementedException"/>
-/// so consumers can integrate against the typed contract today.
+/// Submits a <c>NewOrderCross</c> message (schema §9). Implemented by
+/// <see cref="EntryPointClient.SubmitCrossAsync"/>.
 /// </summary>
 public interface ISubmitCross
 {
@@ -14,9 +13,8 @@ public interface ISubmitCross
 }
 
 /// <summary>
-/// Quote-side messaging (QuoteRequest, Quote, QuoteCancel). Wire-up tracked
-/// by issue #51 — interfaces are exposed today so dependent services can
-/// integrate against them while wiring lands incrementally.
+/// Quote-side messaging (QuoteRequest, Quote, QuoteCancel). Implemented by
+/// <see cref="EntryPointClient"/>.
 /// </summary>
 public interface IQuoteFlow
 {


### PR DESCRIPTION
Closes #93.

All wire-up issues (#3–#11, #51) are merged and there are zero `NotImplementedException`s in src/. Replaced the stale Roadmap issue table with a Status matrix that reflects what's actually shipping in v0.5.0. Also removed the same stale wording from the `ICrossQuoteFlows.cs` interface doc-comments.