### PR TITLE
feat: add opt-in TLS transport (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- TLS transport support via `EntryPointClientOptions.Tls` (`TlsOptions`). Opt-in (`Tls.Enabled = false` by default to preserve back-compat with the in-process simulator and plain-TCP UAT). Configurable target host, certificate validation callback, optional client certificates and `EnabledSslProtocols` (defaults to `SslProtocols.None` so the OS negotiates TLS 1.2/1.3). The handshake is layered transparently under `FixpClientSession` and tagged on the `entrypoint.connect` activity (`net.transport = tls|tcp`).
+- `InMemoryFixpPeer` now accepts an optional `X509Certificate2` to wrap accepted connections in `SslStream`, enabling end-to-end TLS integration tests.
+
 ## [0.6.0] - 2026-05-01
 
 ### Added

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
@@ -72,6 +73,8 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             throw new ArgumentException($"{nameof(EntryPointClientOptions.SessionId)} must be non-zero.", nameof(options));
         if (options.EnteringFirm == 0u)
             throw new ArgumentException($"{nameof(EntryPointClientOptions.EnteringFirm)} must be non-zero.", nameof(options));
+        if (options.Tls is { Enabled: false, ClientCertificates: { Count: > 0 } })
+            throw new ArgumentException($"{nameof(EntryPointClientOptions.Tls)}.{nameof(TlsOptions.ClientCertificates)} requires {nameof(TlsOptions)}.{nameof(TlsOptions.Enabled)} = true.", nameof(options));
     }
 
     public FixpClientState State => _session?.State ?? FixpClientState.Disconnected;
@@ -119,6 +122,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         using var activity = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.connect", ActivityKind.Client);
         activity?.SetTag("net.peer.name", _options.Endpoint.Address.ToString());
         activity?.SetTag("net.peer.port", _options.Endpoint.Port);
+        activity?.SetTag("net.transport", _options.Tls.Enabled ? "tls" : "tcp");
         var tcp = new TcpClient();
         try
         {
@@ -134,7 +138,8 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         }
 
         _tcp = tcp;
-        _session = new FixpClientSession(tcp.GetStream(), _options);
+        var transportStream = await EstablishTransportStreamAsync(tcp, ct).ConfigureAwait(false);
+        _session = new FixpClientSession(transportStream, _options);
 
         using (var negotiate = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.negotiate", ActivityKind.Client))
         {
@@ -191,6 +196,34 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             RaiseTerminated((TerminationCode)code, reason: null, initiatedByClient: false);
         };
         _lastInboundUtc = DateTime.UtcNow;
+    }
+
+    private async Task<System.IO.Stream> EstablishTransportStreamAsync(TcpClient tcp, CancellationToken ct)
+    {
+        var raw = tcp.GetStream();
+        if (!_options.Tls.Enabled)
+            return raw;
+
+        var ssl = new SslStream(raw, leaveInnerStreamOpen: false, _options.Tls.RemoteCertificateValidationCallback);
+        try
+        {
+            var targetHost = _options.Tls.TargetHost ?? _options.Endpoint.Address.ToString();
+            var auth = new SslClientAuthenticationOptions
+            {
+                TargetHost = targetHost,
+                EnabledSslProtocols = _options.Tls.EnabledSslProtocols,
+                ClientCertificates = _options.Tls.ClientCertificates,
+            };
+            await ssl.AuthenticateAsClientAsync(auth, ct).ConfigureAwait(false);
+            _options.Logger.LogInformation("TLS handshake completed with {Endpoint} (target host {TargetHost}, protocol {Protocol})",
+                _options.Endpoint, targetHost, ssl.SslProtocol);
+            return ssl;
+        }
+        catch
+        {
+            await ssl.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
     }
 
     private TimeSpan ComputeBackoff(int attempt)

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -111,6 +111,9 @@ public sealed class EntryPointClientOptions
     /// Set to <c>0</c> to disable automatic compaction. Defaults to 1024.</summary>
     public int StateCompactEveryDeltas { get; set; } = 1024;
 
+    /// <summary>TLS configuration for the FIXP transport. Disabled by default.</summary>
+    public TlsOptions Tls { get; set; } = new();
+
     private static string ThisAssemblyVersion() =>
         typeof(EntryPointClientOptions).Assembly.GetName().Version?.ToString() ?? "0.0.0";
 }

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -1,1 +1,15 @@
 #nullable enable
+B3.EntryPoint.Client.EntryPointClientOptions.Tls.get -> B3.EntryPoint.Client.TlsOptions!
+B3.EntryPoint.Client.EntryPointClientOptions.Tls.set -> void
+B3.EntryPoint.Client.TlsOptions
+B3.EntryPoint.Client.TlsOptions.ClientCertificates.get -> System.Security.Cryptography.X509Certificates.X509CertificateCollection?
+B3.EntryPoint.Client.TlsOptions.ClientCertificates.set -> void
+B3.EntryPoint.Client.TlsOptions.Enabled.get -> bool
+B3.EntryPoint.Client.TlsOptions.Enabled.set -> void
+B3.EntryPoint.Client.TlsOptions.EnabledSslProtocols.get -> System.Security.Authentication.SslProtocols
+B3.EntryPoint.Client.TlsOptions.EnabledSslProtocols.set -> void
+B3.EntryPoint.Client.TlsOptions.RemoteCertificateValidationCallback.get -> System.Net.Security.RemoteCertificateValidationCallback?
+B3.EntryPoint.Client.TlsOptions.RemoteCertificateValidationCallback.set -> void
+B3.EntryPoint.Client.TlsOptions.TargetHost.get -> string?
+B3.EntryPoint.Client.TlsOptions.TargetHost.set -> void
+B3.EntryPoint.Client.TlsOptions.TlsOptions() -> void

--- a/src/B3.EntryPoint.Client/TlsOptions.cs
+++ b/src/B3.EntryPoint.Client/TlsOptions.cs
@@ -1,0 +1,50 @@
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace B3.EntryPoint.Client;
+
+/// <summary>
+/// TLS configuration for the FIXP transport. When <see cref="Enabled"/> is
+/// <c>true</c>, the client wraps the underlying TCP stream in an
+/// <see cref="SslStream"/> and performs an outbound TLS handshake before
+/// FIXP Negotiate.
+/// </summary>
+/// <remarks>
+/// B3 production EntryPoint endpoints require TLS. The in-process simulator
+/// runs over plain TCP, so this is opt-in to preserve the simulator path.
+/// </remarks>
+public sealed class TlsOptions
+{
+    /// <summary>Enable TLS for the FIXP transport. Defaults to <c>false</c>.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// SNI / certificate-target host. When <c>null</c>, the client uses the
+    /// IP address from <see cref="EntryPointClientOptions.Endpoint"/>, which
+    /// only works if the gateway certificate's SAN matches that IP. Set this
+    /// explicitly to the DNS name presented by the B3 gateway certificate.
+    /// </summary>
+    public string? TargetHost { get; set; }
+
+    /// <summary>
+    /// Optional override of remote certificate validation. When <c>null</c>,
+    /// the framework's standard chain validation is used. Provide a callback
+    /// (e.g. returning <c>true</c>) to disable validation in test environments.
+    /// </summary>
+    public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; set; }
+
+    /// <summary>
+    /// Optional client certificates for mutual TLS. When set, requires
+    /// <see cref="Enabled"/> = <c>true</c>; otherwise <see cref="EntryPointClient"/>
+    /// constructor throws.
+    /// </summary>
+    public X509CertificateCollection? ClientCertificates { get; set; }
+
+    /// <summary>
+    /// Allowed TLS protocol versions. <see cref="SslProtocols.None"/> (default)
+    /// lets the OS negotiate (recommended; typically TLS 1.2/1.3). Pin to
+    /// <c>Tls12 | Tls13</c> if compliance requires it.
+    /// </summary>
+    public SslProtocols EnabledSslProtocols { get; set; } = SslProtocols.None;
+}

--- a/tests/B3.EntryPoint.Client.Tests/B3.EntryPoint.Client.Tests.csproj
+++ b/tests/B3.EntryPoint.Client.Tests/B3.EntryPoint.Client.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\B3.EntryPoint.Client\B3.EntryPoint.Client.csproj" />
+    <ProjectReference Include="..\B3.EntryPoint.TestPeer\B3.EntryPoint.TestPeer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/B3.EntryPoint.Client.Tests/TlsTransportTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/TlsTransportTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.TestPeer;
+
+namespace B3.EntryPoint.Client.Tests;
+
+public class TlsTransportTests
+{
+    private static EntryPointClientOptions Options(IPEndPoint endpoint, Action<TlsOptions>? configureTls = null)
+    {
+        var opts = new EntryPointClientOptions
+        {
+            Endpoint = endpoint,
+            SessionId = 42u,
+            SessionVerId = 1u,
+            EnteringFirm = 7u,
+            Credentials = Credentials.FromUtf8("test-key"),
+            KeepAliveIntervalMs = 60_000u,
+        };
+        configureTls?.Invoke(opts.Tls);
+        return opts;
+    }
+
+    [Fact]
+    public void TlsOptions_DefaultsAreOff()
+    {
+        var opts = new EntryPointClientOptions();
+        Assert.NotNull(opts.Tls);
+        Assert.False(opts.Tls.Enabled);
+        Assert.Null(opts.Tls.TargetHost);
+        Assert.Null(opts.Tls.RemoteCertificateValidationCallback);
+        Assert.Null(opts.Tls.ClientCertificates);
+        Assert.Equal(SslProtocols.None, opts.Tls.EnabledSslProtocols);
+    }
+
+    [Fact]
+    public void Ctor_ClientCertificatesWithoutEnabled_Throws()
+    {
+        var opts = Options(new IPEndPoint(IPAddress.Loopback, 9000));
+        opts.Tls.ClientCertificates = new X509CertificateCollection { CreateSelfSigned("client") };
+        var ex = Assert.Throws<ArgumentException>(() => new EntryPointClient(opts));
+        Assert.Contains("ClientCertificates", ex.Message);
+        Assert.Contains("Enabled", ex.Message);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_OverTls_PerformsHandshakeAndEstablishes()
+    {
+        using var serverCert = CreateSelfSigned("localhost");
+        await using var peer = new InMemoryFixpPeer(serverCert);
+        peer.Start();
+
+        var opts = Options(peer.Endpoint, tls =>
+        {
+            tls.Enabled = true;
+            tls.TargetHost = "localhost";
+            tls.RemoteCertificateValidationCallback = (_, _, _, _) => true;
+        });
+
+        await using var client = new EntryPointClient(opts);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+        Assert.Equal(FixpClientState.Established, client.State);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_TlsDisabled_StillConnectsToPlainPeer()
+    {
+        await using var peer = new InMemoryFixpPeer();
+        peer.Start();
+
+        var opts = Options(peer.Endpoint);
+        await using var client = new EntryPointClient(opts);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+        Assert.Equal(FixpClientState.Established, client.State);
+    }
+
+    private static X509Certificate2 CreateSelfSigned(string subject)
+    {
+        using var rsa = RSA.Create(2048);
+        var req = new CertificateRequest($"CN={subject}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddDnsName(subject);
+        sanBuilder.AddIpAddress(IPAddress.Loopback);
+        req.CertificateExtensions.Add(sanBuilder.Build());
+        var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+        // Re-import with private key persisted (Windows quirk; harmless on Linux).
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), password: null);
+    }
+}

--- a/tests/B3.EntryPoint.TestPeer/InMemoryFixpPeer.cs
+++ b/tests/B3.EntryPoint.TestPeer/InMemoryFixpPeer.cs
@@ -1,5 +1,7 @@
 using System.Net;
+using System.Net.Security;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 using B3.Entrypoint.Fixp.Sbe.V6;
 using B3.EntryPoint.Client.Framing;
 
@@ -21,11 +23,20 @@ public sealed class InMemoryFixpPeer : IAsyncDisposable
     private readonly TcpListener _listener;
     private readonly CancellationTokenSource _cts = new();
     private readonly List<Task> _connections = new();
+    private readonly X509Certificate2? _serverCertificate;
     private Task? _acceptLoop;
 
-    public InMemoryFixpPeer()
+    public InMemoryFixpPeer() : this(serverCertificate: null) { }
+
+    /// <summary>
+    /// Creates a peer that wraps every accepted TCP connection in an
+    /// <see cref="SslStream"/> using <paramref name="serverCertificate"/>
+    /// for the TLS handshake. Pass <c>null</c> for plain TCP.
+    /// </summary>
+    public InMemoryFixpPeer(X509Certificate2? serverCertificate)
     {
         _listener = new TcpListener(IPAddress.Loopback, 0);
+        _serverCertificate = serverCertificate;
     }
 
     public IPEndPoint Endpoint => (IPEndPoint)_listener.LocalEndpoint;
@@ -44,7 +55,7 @@ public sealed class InMemoryFixpPeer : IAsyncDisposable
             {
                 var tcp = await _listener.AcceptTcpClientAsync(ct).ConfigureAwait(false);
                 lock (_connections)
-                    _connections.Add(HandleConnectionAsync(tcp, ct));
+                    _connections.Add(HandleConnectionAsync(tcp, _serverCertificate, ct));
             }
         }
         catch (OperationCanceledException) { }
@@ -58,14 +69,27 @@ public sealed class InMemoryFixpPeer : IAsyncDisposable
         public CancellationTokenSource? KeepAliveCts;
     }
 
-    private static async Task HandleConnectionAsync(TcpClient tcp, CancellationToken ct)
+    private static async Task HandleConnectionAsync(TcpClient tcp, X509Certificate2? serverCertificate, CancellationToken ct)
     {
         var state = new ConnectionState();
         try
         {
             using (tcp)
-            await using (var stream = tcp.GetStream())
             {
+                System.IO.Stream stream = tcp.GetStream();
+                SslStream? ssl = null;
+                if (serverCertificate is not null)
+                {
+                    ssl = new SslStream(stream, leaveInnerStreamOpen: false);
+                    await ssl.AuthenticateAsServerAsync(new SslServerAuthenticationOptions
+                    {
+                        ServerCertificate = serverCertificate,
+                        ClientCertificateRequired = false,
+                    }, ct).ConfigureAwait(false);
+                    stream = ssl;
+                }
+                await using var _ssl = ssl;
+                await using var _stream = stream;
                 while (!ct.IsCancellationRequested)
                 {
                     byte[] frame;


### PR DESCRIPTION
Closes #97.

Adds opt-in TLS transport via `EntryPointClientOptions.Tls` (`TlsOptions`).

## Design
- TLS is layered transparently under `FixpClientSession` — the session keeps consuming an abstract `Stream`, so no session-layer changes were needed.
- **Opt-in default** (`Tls.Enabled = false`) preserves back-compat with the in-process simulator and any plain-TCP UAT setup.
- `SslProtocols.None` default lets the OS negotiate TLS 1.2/1.3 (modern best practice; pin to `Tls12 | Tls13` only if compliance requires).

## Surface
```
TlsOptions
├── Enabled : bool
├── TargetHost : string?           (falls back to Endpoint.Address.ToString())
├── RemoteCertificateValidationCallback : RemoteCertificateValidationCallback?
├── ClientCertificates : X509CertificateCollection?
└── EnabledSslProtocols : SslProtocols
```

`ValidateOptions` rejects `ClientCertificates` set without `Enabled = true` (config-bug catch).

## Observability
`entrypoint.connect` activity is tagged with `net.transport = tls|tcp`.

## Tests
- 4 new tests in `TlsTransportTests`:
  - `TlsOptions_DefaultsAreOff`
  - `Ctor_ClientCertificatesWithoutEnabled_Throws`
  - `ConnectAsync_OverTls_PerformsHandshakeAndEstablishes` — full SSL handshake against `InMemoryFixpPeer` wrapping a runtime self-signed RSA-2048 cert.
  - `ConnectAsync_TlsDisabled_StillConnectsToPlainPeer` (regression).
- `InMemoryFixpPeer` gained an optional `X509Certificate2` ctor arg (null = plain TCP, unchanged behavior).
- 118 unit tests pass locally (was 114).