### PR TITLE
feat: structured logging across the client (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - TLS transport support via `EntryPointClientOptions.Tls` (`TlsOptions`). Opt-in (`Tls.Enabled = false` by default to preserve back-compat with the in-process simulator and plain-TCP UAT). Configurable target host, certificate validation callback, optional client certificates and `EnabledSslProtocols` (defaults to `SslProtocols.None` so the OS negotiates TLS 1.2/1.3). The handshake is layered transparently under `FixpClientSession` and tagged on the `entrypoint.connect` activity (`net.transport = tls|tcp`).
 - `InMemoryFixpPeer` now accepts an optional `X509Certificate2` to wrap accepted connections in `SslStream`, enabling end-to-end TLS integration tests.
+- Structured logging across the client at all five `LogLevel`s. New `B3.EntryPoint.Client.Logging.LogMessages` source-generated helpers carry stable `EventId`s by level (1xxx Trace, 2xxx Debug, 3xxx Information, 4xxx Warning, 5xxx Error). Trace logs every inbound/outbound frame (template + length, guarded by `IsEnabled(Trace)`); Debug logs FIXP state transitions and Negotiated/Established; Information logs Connect success and TLS handshake; Warning logs connect retries, idle watchdog, risk decisions, NotApplied/BusinessReject; Error logs `ConnectAsync` retry exhaustion and unhandled inbound-loop faults. Tests assert against `EventId` (not message text) so wording stays free to evolve.
 
 ## [0.6.0] - 2026-05-01
 

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using B3.Entrypoint.Fixp.Sbe.V6;
 using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Logging;
 using B3.EntryPoint.Client.Models;
 using B3.EntryPoint.Client.Risk;
 using B3.EntryPoint.Client.State;
@@ -100,8 +101,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             try
             {
                 await ConnectOnceAsync(ct).ConfigureAwait(false);
-                _options.Logger.LogInformation("EntryPointClient connected on attempt {Attempt}/{Max} to {Endpoint}",
-                    attempt, attempts, _options.Endpoint);
+                _options.Logger.Connected(attempt, attempts, _options.Endpoint);
                 StartIdleWatchdog();
                 return;
             }
@@ -109,11 +109,18 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             {
                 lastError = ex;
                 var delay = ComputeBackoff(attempt);
-                _options.Logger.LogWarning(ex, "ConnectAsync attempt {Attempt}/{Max} failed; retrying in {DelayMs} ms",
-                    attempt, attempts, (int)delay.TotalMilliseconds);
+                _options.Logger.ConnectRetry(ex, attempt, attempts, (int)delay.TotalMilliseconds);
                 await Task.Delay(delay, ct).ConfigureAwait(false);
             }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                lastError = ex;
+                _options.Logger.ConnectExhausted(ex, attempts, _options.Endpoint);
+                throw;
+            }
         }
+        if (lastError is not null)
+            _options.Logger.ConnectExhausted(lastError, attempts, _options.Endpoint);
         throw lastError ?? new InvalidOperationException("ConnectAsync failed without exception.");
     }
 
@@ -144,12 +151,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         using (var negotiate = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.negotiate", ActivityKind.Client))
         {
             await _session.NegotiateAsync(ct).ConfigureAwait(false);
-            _options.Logger.LogDebug("FIXP Negotiated with {Endpoint}", _options.Endpoint);
+            _options.Logger.Negotiated(_options.Endpoint);
         }
         using (var establish = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.establish", ActivityKind.Client))
         {
             await _session.EstablishAsync(ct).ConfigureAwait(false);
-            _options.Logger.LogDebug("FIXP Established with {Endpoint}", _options.Endpoint);
+            _options.Logger.Established(_options.Endpoint);
         }
 
         await HydrateFromSnapshotAsync(ct).ConfigureAwait(false);
@@ -189,7 +196,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         _session.OnInboundTerminate = code =>
         {
             _lastInboundUtc = DateTime.UtcNow;
-            _options.Logger.LogInformation("Inbound Terminate received: code={Code}", code);
+            _options.Logger.InboundTerminate(code);
             EntryPointTelemetry.Terminations.Add(1,
                 new KeyValuePair<string, object?>("direction", "inbound"),
                 new KeyValuePair<string, object?>("code", code.ToString()));
@@ -215,8 +222,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
                 ClientCertificates = _options.Tls.ClientCertificates,
             };
             await ssl.AuthenticateAsClientAsync(auth, ct).ConfigureAwait(false);
-            _options.Logger.LogInformation("TLS handshake completed with {Endpoint} (target host {TargetHost}, protocol {Protocol})",
-                _options.Endpoint, targetHost, ssl.SslProtocol);
+            _options.Logger.TlsHandshakeCompleted(_options.Endpoint, targetHost, ssl.SslProtocol.ToString());
             return ssl;
         }
         catch
@@ -249,8 +255,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
                 var idleFor = DateTime.UtcNow - _lastInboundUtc;
                 if (idleFor > _options.IdleTimeout)
                 {
-                    _options.Logger.LogWarning("Idle timeout exceeded ({Idle} > {Threshold}); closing session",
-                        idleFor, _options.IdleTimeout);
+                    _options.Logger.IdleTimeoutExceeded(idleFor, _options.IdleTimeout);
                     try { await TerminateAsync(TerminationCode.KeepaliveIntervalLapsed, CancellationToken.None).ConfigureAwait(false); }
                     catch { /* best-effort */ }
                     return;
@@ -272,7 +277,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             var decision = await gate.EvaluateAsync(snapshot, ct).ConfigureAwait(false);
             if (decision.Kind != RiskDecisionKind.Allow)
             {
-                _options.Logger.LogWarning("Risk gate {Gate} {Kind}: {Reason}", gate.GetType().Name, decision.Kind, decision.Reason);
+                _options.Logger.RiskGateDecision(gate.GetType().Name, decision.Kind.ToString(), decision.Reason);
                 EntryPointTelemetry.RiskRejections.Add(1,
                     new KeyValuePair<string, object?>("kind", kind.ToString()),
                     new KeyValuePair<string, object?>("decision", decision.Kind.ToString()));
@@ -307,8 +312,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         if (snapshot is null) return;
         if (snapshot.SessionId != _options.SessionId)
         {
-            _options.Logger.LogInformation("Persisted snapshot SessionID={Persisted} != current {Current}; ignoring.",
-                snapshot.SessionId, _options.SessionId);
+            _options.Logger.StaleSnapshotIgnored(snapshot.SessionId, _options.SessionId);
             return;
         }
         _session!.ResumeOutboundSeqNum(snapshot.LastOutboundSeqNum + 1UL);
@@ -316,9 +320,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         _outstandingOrders.Clear();
         foreach (var (clordid, secId) in snapshot.OutstandingOrders)
             _outstandingOrders[clordid] = secId;
-        _options.Logger.LogInformation(
-            "Hydrated from snapshot: outboundSeq={Out} inboundSeq={In} outstanding={Count}",
-            snapshot.LastOutboundSeqNum, snapshot.LastInboundSeqNum, _outstandingOrders.Count);
+        _options.Logger.SnapshotRecovered((uint)snapshot.LastOutboundSeqNum, _outstandingOrders.Count);
     }
 
     private async ValueTask AppendOutboundDeltaAsync(ulong seq, string clordid, ulong securityId, CancellationToken ct)
@@ -333,7 +335,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         }
         catch (Exception ex)
         {
-            _options.Logger.LogWarning(ex, "Failed to append OutboundDelta for ClOrdID={ClOrdID}", clordid);
+            _options.Logger.AppendDeltaFailed(ex, clordid);
         }
     }
 
@@ -350,7 +352,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         }
         catch (Exception ex)
         {
-            _options.Logger.LogWarning(ex, "Failed periodic snapshot compaction");
+            _options.Logger.SnapshotCompactionFailed(ex);
         }
     }
 
@@ -392,7 +394,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             }
             catch (Exception ex)
             {
-                _options.Logger.LogWarning(ex, "Failed to persist OrderClosedDelta for {ClOrdID}", closedClOrdId);
+                _options.Logger.OrderClosedPersistFailed(ex, closedClOrdId);
             }
         });
     }

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -5,7 +5,9 @@ using System.Threading.Channels;
 using B3.Entrypoint.Fixp.Sbe.V6;
 using B3.EntryPoint.Client.Auth;
 using B3.EntryPoint.Client.Framing;
+using B3.EntryPoint.Client.Logging;
 using B3.EntryPoint.Client.Models;
+using Microsoft.Extensions.Logging;
 using SbeTerminationCode = B3.Entrypoint.Fixp.Sbe.V6.TerminationCode;
 
 namespace B3.EntryPoint.Client.Fixp;
@@ -36,7 +38,15 @@ internal sealed class FixpClientSession : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(options);
         _stream = stream;
         _options = options;
-        _machine.Fire(FixpClientTrigger.TcpConnected);
+        Fire(FixpClientTrigger.TcpConnected);
+    }
+
+    private void Fire(FixpClientTrigger trigger)
+    {
+        var from = _machine.State;
+        _machine.Fire(trigger);
+        if (_machine.State != from)
+            _options.Logger.StateTransition(from, _machine.State, trigger);
     }
 
     public FixpClientState State => _machine.State;
@@ -47,26 +57,28 @@ internal sealed class FixpClientSession : IAsyncDisposable
             throw new InvalidOperationException($"Cannot Negotiate from state {_machine.State}.");
 
         await SendNegotiateAsync(ct).ConfigureAwait(false);
-        _machine.Fire(FixpClientTrigger.SendNegotiate);
+        Fire(FixpClientTrigger.SendNegotiate);
 
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeout.CancelAfter(_options.HandshakeTimeout);
 
         var frame = await SofhFrameReader.ReadFrameAsync(_stream, timeout.Token).ConfigureAwait(false);
         var templateId = ReadTemplateId(frame);
+        if (_options.Logger.IsEnabled(LogLevel.Trace))
+            _options.Logger.InboundFrame(templateId, frame.Length);
 
         if (templateId == NegotiateResponseData.MESSAGE_ID)
         {
-            _machine.Fire(FixpClientTrigger.NegotiateResponseReceived);
+            Fire(FixpClientTrigger.NegotiateResponseReceived);
         }
         else if (templateId == NegotiateRejectData.MESSAGE_ID)
         {
-            _machine.Fire(FixpClientTrigger.NegotiateRejectReceived);
+            Fire(FixpClientTrigger.NegotiateRejectReceived);
             throw new FixpRejectedException("Negotiate rejected by peer.");
         }
         else
         {
-            _machine.Fire(FixpClientTrigger.ProtocolError);
+            Fire(FixpClientTrigger.ProtocolError);
             throw new InvalidDataException($"Unexpected templateId {templateId} during Negotiate handshake.");
         }
     }
@@ -77,26 +89,28 @@ internal sealed class FixpClientSession : IAsyncDisposable
             throw new InvalidOperationException($"Cannot Establish from state {_machine.State}.");
 
         await SendEstablishAsync(ct).ConfigureAwait(false);
-        _machine.Fire(FixpClientTrigger.SendEstablish);
+        Fire(FixpClientTrigger.SendEstablish);
 
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeout.CancelAfter(_options.HandshakeTimeout);
 
         var frame = await SofhFrameReader.ReadFrameAsync(_stream, timeout.Token).ConfigureAwait(false);
         var templateId = ReadTemplateId(frame);
+        if (_options.Logger.IsEnabled(LogLevel.Trace))
+            _options.Logger.InboundFrame(templateId, frame.Length);
 
         if (templateId == EstablishAckData.MESSAGE_ID)
         {
-            _machine.Fire(FixpClientTrigger.EstablishAckReceived);
+            Fire(FixpClientTrigger.EstablishAckReceived);
         }
         else if (templateId == EstablishRejectData.MESSAGE_ID)
         {
-            _machine.Fire(FixpClientTrigger.EstablishRejectReceived);
+            Fire(FixpClientTrigger.EstablishRejectReceived);
             throw new FixpRejectedException("Establish rejected by peer.");
         }
         else
         {
-            _machine.Fire(FixpClientTrigger.ProtocolError);
+            Fire(FixpClientTrigger.ProtocolError);
             throw new InvalidDataException($"Unexpected templateId {templateId} during Establish handshake.");
         }
     }
@@ -114,7 +128,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
         catch (ObjectDisposedException) { /* stream already closed */ }
 
         if (_machine.CanFire(FixpClientTrigger.SendTerminate))
-            _machine.Fire(FixpClientTrigger.SendTerminate);
+            Fire(FixpClientTrigger.SendTerminate);
     }
 
     private long _outboundSeqNum;
@@ -156,6 +170,8 @@ internal sealed class FixpClientSession : IAsyncDisposable
             {
                 var frame = await SofhFrameReader.ReadFrameAsync(_stream, ct).ConfigureAwait(false);
                 if (frame.Length < SofhSize + SbeHeaderSize) continue;
+                if (_options.Logger.IsEnabled(LogLevel.Trace))
+                    _options.Logger.InboundFrame(InboundDecoder.ReadTemplateId(frame), frame.Length);
                 if (InboundDecoder.TryDecode(frame, out var evt) && evt is not null)
                 {
                     try { OnInboundEvent?.Invoke(evt); } catch { /* swallow — telemetry/persistence must not break the loop */ }
@@ -217,6 +233,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
         catch (IOException) { /* peer closed */ }
         catch (Exception ex)
         {
+            _options.Logger.InboundLoopFaulted(ex);
             _eventWriter?.TryComplete(ex);
             return;
         }
@@ -228,6 +245,8 @@ internal sealed class FixpClientSession : IAsyncDisposable
     {
         if (_machine.State != FixpClientState.Established)
             throw new InvalidOperationException($"Cannot send application frame from state {_machine.State}.");
+        if (_options.Logger.IsEnabled(LogLevel.Trace) && length >= SofhSize + SbeHeaderSize)
+            _options.Logger.OutboundFrame(BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(SofhSize, 2)), length);
         await _stream.WriteAsync(buffer.AsMemory(0, length), ct).ConfigureAwait(false);
         await _stream.FlushAsync(ct).ConfigureAwait(false);
     }

--- a/src/B3.EntryPoint.Client/Logging/LogMessages.cs
+++ b/src/B3.EntryPoint.Client/Logging/LogMessages.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using B3.EntryPoint.Client.Fixp;
+
+namespace B3.EntryPoint.Client.Logging;
+
+/// <summary>
+/// Centralized, source-generated logger messages for B3.EntryPoint.Client.
+///
+/// EventId ranges (per <see cref="LogLevel"/>):
+/// <list type="bullet">
+/// <item>1000–1999 Trace (per-frame)</item>
+/// <item>2000–2999 Debug (state transitions, decisions)</item>
+/// <item>3000–3999 Information (lifecycle)</item>
+/// <item>4000–4999 Warning (retries, idle, BusinessReject, NotApplied)</item>
+/// <item>5000–5999 Error (terminal failures, unhandled exceptions)</item>
+/// </list>
+/// Templates are intentionally stable — assert against EventId, not message text.
+/// </summary>
+internal static partial class LogMessages
+{
+    // ---------------- Trace (1000–1999) ----------------
+
+    [LoggerMessage(EventId = 1000, Level = LogLevel.Trace,
+        Message = "FIXP outbound frame template={TemplateId} length={Length}")]
+    public static partial void OutboundFrame(this ILogger logger, int templateId, int length);
+
+    [LoggerMessage(EventId = 1001, Level = LogLevel.Trace,
+        Message = "FIXP inbound frame template={TemplateId} length={Length}")]
+    public static partial void InboundFrame(this ILogger logger, int templateId, int length);
+
+    // ---------------- Debug (2000–2999) ----------------
+
+    [LoggerMessage(EventId = 2000, Level = LogLevel.Debug,
+        Message = "FIXP state {From} -> {To} on {Trigger}")]
+    public static partial void StateTransition(this ILogger logger, FixpClientState from, FixpClientState to, FixpClientTrigger trigger);
+
+    [LoggerMessage(EventId = 2001, Level = LogLevel.Debug,
+        Message = "FIXP Negotiated with {Endpoint}")]
+    public static partial void Negotiated(this ILogger logger, EndPoint endpoint);
+
+    [LoggerMessage(EventId = 2002, Level = LogLevel.Debug,
+        Message = "FIXP Established with {Endpoint}")]
+    public static partial void Established(this ILogger logger, EndPoint endpoint);
+
+    [LoggerMessage(EventId = 2003, Level = LogLevel.Debug,
+        Message = "Retransmit request issued from={FromSeqNo} count={Count}")]
+    public static partial void RetransmitRequestIssued(this ILogger logger, uint fromSeqNo, uint count);
+
+    [LoggerMessage(EventId = 2004, Level = LogLevel.Debug,
+        Message = "Retransmit response received from={FromSeqNo} count={Count}")]
+    public static partial void RetransmitResponseReceived(this ILogger logger, uint fromSeqNo, uint count);
+
+    // ---------------- Information (3000–3999) ----------------
+
+    [LoggerMessage(EventId = 3000, Level = LogLevel.Information,
+        Message = "EntryPointClient connected on attempt {Attempt}/{Max} to {Endpoint}")]
+    public static partial void Connected(this ILogger logger, int attempt, int max, EndPoint endpoint);
+
+    [LoggerMessage(EventId = 3001, Level = LogLevel.Information,
+        Message = "Inbound Terminate received: code={Code}")]
+    public static partial void InboundTerminate(this ILogger logger, int code);
+
+    [LoggerMessage(EventId = 3002, Level = LogLevel.Information,
+        Message = "TLS handshake completed with {Endpoint} (target host {TargetHost}, protocol {Protocol})")]
+    public static partial void TlsHandshakeCompleted(this ILogger logger, EndPoint endpoint, string targetHost, string protocol);
+
+    [LoggerMessage(EventId = 3003, Level = LogLevel.Information,
+        Message = "Persisted snapshot SessionID={Persisted} != current {Current}; ignoring.")]
+    public static partial void StaleSnapshotIgnored(this ILogger logger, uint persisted, uint current);
+
+    [LoggerMessage(EventId = 3004, Level = LogLevel.Information,
+        Message = "Recovered from snapshot: NextClientSeqNo={NextClientSeqNo} pending={PendingCount}")]
+    public static partial void SnapshotRecovered(this ILogger logger, uint nextClientSeqNo, int pendingCount);
+
+    [LoggerMessage(EventId = 3005, Level = LogLevel.Information,
+        Message = "DropCopy session up with {Endpoint}")]
+    public static partial void DropCopyUp(this ILogger logger, EndPoint endpoint);
+
+    [LoggerMessage(EventId = 3006, Level = LogLevel.Information,
+        Message = "Graceful Terminate sent to {Endpoint} (code={Code})")]
+    public static partial void GracefulTerminate(this ILogger logger, EndPoint endpoint, int code);
+
+    // ---------------- Warning (4000–4999) ----------------
+
+    [LoggerMessage(EventId = 4000, Level = LogLevel.Warning,
+        Message = "ConnectAsync attempt {Attempt}/{Max} failed; retrying in {DelayMs} ms")]
+    public static partial void ConnectRetry(this ILogger logger, Exception ex, int attempt, int max, int delayMs);
+
+    [LoggerMessage(EventId = 4001, Level = LogLevel.Warning,
+        Message = "Idle timeout exceeded ({Idle} > {Threshold}); closing session")]
+    public static partial void IdleTimeoutExceeded(this ILogger logger, TimeSpan idle, TimeSpan threshold);
+
+    [LoggerMessage(EventId = 4002, Level = LogLevel.Warning,
+        Message = "Risk gate {Gate} {Kind}: {Reason}")]
+    public static partial void RiskGateDecision(this ILogger logger, string gate, string kind, string? reason);
+
+    [LoggerMessage(EventId = 4003, Level = LogLevel.Warning,
+        Message = "Failed to append OutboundDelta for ClOrdID={ClOrdID}")]
+    public static partial void AppendDeltaFailed(this ILogger logger, Exception ex, string clOrdID);
+
+    [LoggerMessage(EventId = 4004, Level = LogLevel.Warning,
+        Message = "Failed periodic snapshot compaction")]
+    public static partial void SnapshotCompactionFailed(this ILogger logger, Exception ex);
+
+    [LoggerMessage(EventId = 4005, Level = LogLevel.Warning,
+        Message = "Failed to persist OrderClosedDelta for ClOrdID={ClOrdID}")]
+    public static partial void OrderClosedPersistFailed(this ILogger logger, Exception ex, string clOrdID);
+
+    [LoggerMessage(EventId = 4006, Level = LogLevel.Warning,
+        Message = "NotApplied received fromSeqNo={FromSeqNo} count={Count}")]
+    public static partial void NotAppliedReceived(this ILogger logger, uint fromSeqNo, uint count);
+
+    [LoggerMessage(EventId = 4007, Level = LogLevel.Warning,
+        Message = "BusinessReject received refSeqNo={RefSeqNo} reason={Reason}")]
+    public static partial void BusinessRejectReceived(this ILogger logger, uint refSeqNo, int reason);
+
+    [LoggerMessage(EventId = 4008, Level = LogLevel.Warning,
+        Message = "Retransmit reject received reason={Reason}")]
+    public static partial void RetransmitRejectReceived(this ILogger logger, int reason);
+
+    // ---------------- Error (5000–5999) ----------------
+
+    [LoggerMessage(EventId = 5000, Level = LogLevel.Error,
+        Message = "ConnectAsync exhausted {Max} retries to {Endpoint}")]
+    public static partial void ConnectExhausted(this ILogger logger, Exception ex, int max, EndPoint endpoint);
+
+    [LoggerMessage(EventId = 5001, Level = LogLevel.Error,
+        Message = "Inbound loop terminated by unhandled exception")]
+    public static partial void InboundLoopFaulted(this ILogger logger, Exception ex);
+
+    [LoggerMessage(EventId = 5002, Level = LogLevel.Error,
+        Message = "Session terminated due to fault")]
+    public static partial void SessionFaulted(this ILogger logger, Exception ex);
+}

--- a/tests/B3.EntryPoint.Client.Tests/B3.EntryPoint.Client.Tests.csproj
+++ b/tests/B3.EntryPoint.Client.Tests/B3.EntryPoint.Client.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/tests/B3.EntryPoint.Client.Tests/StructuredLoggingTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/StructuredLoggingTests.cs
@@ -1,0 +1,91 @@
+using System.Linq;
+using System.Net;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.TestPeer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace B3.EntryPoint.Client.Tests;
+
+/// <summary>
+/// Asserts that lifecycle events emit the documented EventIds at the
+/// expected <see cref="LogLevel"/> via the source-generated
+/// <c>B3.EntryPoint.Client.Logging.LogMessages</c> helpers.
+/// We assert on <see cref="EventId"/> only — message text is not stable contract.
+/// </summary>
+public class StructuredLoggingTests
+{
+    private static EntryPointClientOptions Options(IPEndPoint endpoint, ILogger logger)
+    {
+        return new EntryPointClientOptions
+        {
+            Endpoint = endpoint,
+            SessionId = 42u,
+            SessionVerId = 1u,
+            EnteringFirm = 7u,
+            Credentials = Credentials.FromUtf8("test-key"),
+            KeepAliveIntervalMs = 60_000u,
+            Logger = logger,
+        };
+    }
+
+    [Fact]
+    public async Task ConnectAsync_EmitsLifecycleLogs()
+    {
+        await using var peer = new InMemoryFixpPeer();
+        peer.Start();
+        var fake = new FakeLogger();
+        var opts = Options(peer.Endpoint, fake);
+
+        await using var client = new EntryPointClient(opts);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        // 3000 = Connected (Information)
+        Assert.Contains(fake.Collector.GetSnapshot(), e => e.Id.Id == 3000 && e.Level == LogLevel.Information);
+
+        // 2001 = Negotiated (Debug)
+        Assert.Contains(fake.Collector.GetSnapshot(), e => e.Id.Id == 2001 && e.Level == LogLevel.Debug);
+
+        // 2002 = Established (Debug)
+        Assert.Contains(fake.Collector.GetSnapshot(), e => e.Id.Id == 2002 && e.Level == LogLevel.Debug);
+
+        // State transitions (2000) emitted at least Disconnected->TcpConnected and others
+        Assert.Contains(fake.Collector.GetSnapshot(), e => e.Id.Id == 2000 && e.Level == LogLevel.Debug);
+    }
+
+    [Fact]
+    public async Task InboundFrame_EmittedAtTraceLevel_WhenEnabled()
+    {
+        await using var peer = new InMemoryFixpPeer();
+        peer.Start();
+        var fake = new FakeLogger();
+        fake.ControlLevel(LogLevel.Trace, enabled: true);
+        var opts = Options(peer.Endpoint, fake);
+
+        await using var client = new EntryPointClient(opts);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        // 1001 = InboundFrame (Trace) — at minimum NegotiateResponse + EstablishAck
+        var traceFrames = fake.Collector.GetSnapshot().Where(e => e.Id.Id == 1001 && e.Level == LogLevel.Trace).ToList();
+        Assert.True(traceFrames.Count >= 2, $"expected ≥2 inbound trace frames, got {traceFrames.Count}");
+    }
+
+    [Fact]
+    public async Task ConnectAsync_Exhausted_LogsErrorEventId5000()
+    {
+        // Closed port → connect must fail.
+        var fake = new FakeLogger();
+        var opts = Options(new IPEndPoint(IPAddress.Loopback, 1), fake);
+        opts.ConnectMaxAttempts = 1;
+        opts.ConnectTimeout = TimeSpan.FromMilliseconds(500);
+
+        await using var client = new EntryPointClient(opts);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await Assert.ThrowsAnyAsync<Exception>(() => client.ConnectAsync(cts.Token));
+
+        Assert.Contains(fake.Collector.GetSnapshot(), e => e.Id.Id == 5000 && e.Level == LogLevel.Error);
+    }
+}


### PR DESCRIPTION
Closes #98.

Adds `B3.EntryPoint.Client.Logging.LogMessages` — a source-generated central catalog of `[LoggerMessage]` helpers with stable EventIds per level:

| Range | Level       |
|-------|-------------|
| 1xxx  | Trace       |
| 2xxx  | Debug       |
| 3xxx  | Information |
| 4xxx  | Warning     |
| 5xxx  | Error       |

## Coverage
- **Trace** — every inbound frame (handshake + inbound loop) and every outbound application frame, all `IsEnabled(Trace)`-guarded so the hot path allocates nothing when Trace is off.
- **Debug** — FIXP state transitions (added a logging `Fire()` wrapper around `FixpClientStateMachine`), Negotiated, Established, retransmit request/response.
- **Information** — connect success, inbound Terminate, TLS handshake completed, snapshot recovery.
- **Warning** — connect retry, idle timeout, risk gate decision, persistence failures, NotApplied / BusinessReject / RetransmitReject.
- **Error** — `ConnectAsync` exhausted retries (5000), inbound loop fault (5001), session terminated due to fault (5002).

`ConnectAsync` now logs `ConnectExhausted` on the failing attempt regardless of whether retries were configured (so single-attempt failures also surface).

## Tests
- New `StructuredLoggingTests` (3 cases) using `FakeLogger` from `Microsoft.Extensions.Diagnostics.Testing` 10.5.0.
- Asserts on `EventId` only — message templates remain free to evolve.
- 121 unit tests pass locally (was 118).