### PR TITLE
release: v0.7.0 (TLS + structured logging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-01
+
 ### Added
 - TLS transport support via `EntryPointClientOptions.Tls` (`TlsOptions`). Opt-in (`Tls.Enabled = false` by default to preserve back-compat with the in-process simulator and plain-TCP UAT). Configurable target host, certificate validation callback, optional client certificates and `EnabledSslProtocols` (defaults to `SslProtocols.None` so the OS negotiates TLS 1.2/1.3). The handshake is layered transparently under `FixpClientSession` and tagged on the `entrypoint.connect` activity (`net.transport = tls|tcp`).
 - `InMemoryFixpPeer` now accepts an optional `X509Certificate2` to wrap accepted connections in `SslStream`, enabling end-to-end TLS integration tests.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- NuGet metadata shared by all packable projects. -->
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Authors>pedrosakuma</Authors>
     <Company>pedrosakuma</Company>
     <Copyright>Copyright (c) pedrosakuma</Copyright>

--- a/src/B3.EntryPoint.Client/PublicAPI.Shipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Shipped.txt
@@ -1191,3 +1191,17 @@ virtual B3.EntryPoint.Client.State.SessionDelta.PrintMembers(System.Text.StringB
 ~override B3.EntryPoint.Client.Risk.OutboundRequest.ToString() -> string
 ~override B3.EntryPoint.Client.Telemetry.ClientHealth.Equals(object obj) -> bool
 ~override B3.EntryPoint.Client.Telemetry.ClientHealth.ToString() -> string
+B3.EntryPoint.Client.EntryPointClientOptions.Tls.get -> B3.EntryPoint.Client.TlsOptions!
+B3.EntryPoint.Client.EntryPointClientOptions.Tls.set -> void
+B3.EntryPoint.Client.TlsOptions
+B3.EntryPoint.Client.TlsOptions.ClientCertificates.get -> System.Security.Cryptography.X509Certificates.X509CertificateCollection?
+B3.EntryPoint.Client.TlsOptions.ClientCertificates.set -> void
+B3.EntryPoint.Client.TlsOptions.Enabled.get -> bool
+B3.EntryPoint.Client.TlsOptions.Enabled.set -> void
+B3.EntryPoint.Client.TlsOptions.EnabledSslProtocols.get -> System.Security.Authentication.SslProtocols
+B3.EntryPoint.Client.TlsOptions.EnabledSslProtocols.set -> void
+B3.EntryPoint.Client.TlsOptions.RemoteCertificateValidationCallback.get -> System.Net.Security.RemoteCertificateValidationCallback?
+B3.EntryPoint.Client.TlsOptions.RemoteCertificateValidationCallback.set -> void
+B3.EntryPoint.Client.TlsOptions.TargetHost.get -> string?
+B3.EntryPoint.Client.TlsOptions.TargetHost.set -> void
+B3.EntryPoint.Client.TlsOptions.TlsOptions() -> void

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -1,15 +1,1 @@
 #nullable enable
-B3.EntryPoint.Client.EntryPointClientOptions.Tls.get -> B3.EntryPoint.Client.TlsOptions!
-B3.EntryPoint.Client.EntryPointClientOptions.Tls.set -> void
-B3.EntryPoint.Client.TlsOptions
-B3.EntryPoint.Client.TlsOptions.ClientCertificates.get -> System.Security.Cryptography.X509Certificates.X509CertificateCollection?
-B3.EntryPoint.Client.TlsOptions.ClientCertificates.set -> void
-B3.EntryPoint.Client.TlsOptions.Enabled.get -> bool
-B3.EntryPoint.Client.TlsOptions.Enabled.set -> void
-B3.EntryPoint.Client.TlsOptions.EnabledSslProtocols.get -> System.Security.Authentication.SslProtocols
-B3.EntryPoint.Client.TlsOptions.EnabledSslProtocols.set -> void
-B3.EntryPoint.Client.TlsOptions.RemoteCertificateValidationCallback.get -> System.Net.Security.RemoteCertificateValidationCallback?
-B3.EntryPoint.Client.TlsOptions.RemoteCertificateValidationCallback.set -> void
-B3.EntryPoint.Client.TlsOptions.TargetHost.get -> string?
-B3.EntryPoint.Client.TlsOptions.TargetHost.set -> void
-B3.EntryPoint.Client.TlsOptions.TlsOptions() -> void


### PR DESCRIPTION
Cuts v0.7.0.

## Highlights
- **TLS transport** (#97) — opt-in `EntryPointClientOptions.Tls`, transparent SslStream wrap.
- **Structured logging** (#98) — source-generated `LogMessages` catalog with stable EventIds across Trace/Debug/Information/Warning/Error.

## Mechanics
- Bump `Directory.Build.props` 0.6.0 → 0.7.0
- Promote `PublicAPI.Unshipped.txt` (TlsOptions surface) → `PublicAPI.Shipped.txt`
- Finalize CHANGELOG `[Unreleased]` → `[0.7.0] - 2026-05-01`

121 tests pass.