### PR TITLE
feat(testpeer): v0.9.0 — real ER_Trade, BusinessMessageReject, Cancel/Modify hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- TestPeer (#105): `RejectBusiness` now emits a real `BusinessMessageReject` (template 206) with `Text` and bounded `BusinessRejectReason`, decoded by the client into `BusinessReject.Text`.
+- TestPeer (#105): `AcceptAndFill` now emits a real `ExecutionReport_Trade` (template 203) with full/partial-fill semantics — `FillQty`/`FillPrice` honored, `LeavesQty` derived, status set to `FILLED` or `PARTIALLY_FILLED`.
+- TestPeer (#107): `ITestPeerScenario` extended with `OnCancel(CancelContext)` and `OnModify(ModifyContext)` default-interface hooks; `RejectAll` now also rejects cancels and modifies via `ExecutionReport_Reject` (template 204) with `CxlRejResponseTo` set accordingly. `RejectBusiness` accepts an optional `RejReason`; `AcceptAndFill` accepts optional `FillPrice`/`FillQty`.
+- `NewOrderContext` extended with optional `OrderQty`, `Price`, `Side`, `MsgSeqNum` to enable richer scenario decisions.
+
+### Changed
+- TestPeer egress is now serialized per connection via a `SemaphoreSlim` and routed through a single `SendFrameAsync` helper; var-data sections are sized dynamically (one length-prefix byte per section) instead of a fixed pad. Removes write races and oversized buffers.
+- `InboundDecoder.DecodeBmr` now decodes the `Text` var-data field via `SbeBmr.TryParse` and surfaces it on `BusinessReject.Text` (existing record property).
+
 ## [0.8.0] - 2026-05-01
 
 ### Added

--- a/src/B3.EntryPoint.Client.TestPeer/ITestPeerScenario.cs
+++ b/src/B3.EntryPoint.Client.TestPeer/ITestPeerScenario.cs
@@ -1,3 +1,5 @@
+using B3.Entrypoint.Fixp.Sbe.V6;
+
 namespace B3.EntryPoint.Client.TestPeer;
 
 /// <summary>
@@ -12,16 +14,32 @@ namespace B3.EntryPoint.Client.TestPeer;
 /// can return:
 /// <list type="bullet">
 /// <item><see cref="NewOrderResponse.AcceptAsNew"/> — single ER (NEW).</item>
-/// <item><see cref="NewOrderResponse.AcceptAndFill"/> — ER (NEW) followed by ER (FILLED).</item>
-/// <item><see cref="NewOrderResponse.RejectBusiness"/> — BusinessMessageReject.</item>
+/// <item><see cref="NewOrderResponse.AcceptAndFill"/> — ER (NEW) followed by ER (FILLED) — full or partial fill.</item>
+/// <item><see cref="NewOrderResponse.RejectBusiness"/> — BusinessMessageReject with optional <see cref="NewOrderResponse.RejectBusiness.RejReason"/> code.</item>
 /// </list>
+/// <para>
+/// <see cref="OnCancel"/> and <see cref="OnModify"/> are exposed as default
+/// interface methods so existing implementations remain source-compatible:
+/// the peer falls back to accepting cancels/modifies (mirrors v0.8.0
+/// behaviour) when the implementation does not override them.
+/// </para>
 /// </remarks>
 public interface ITestPeerScenario
 {
-    /// <summary>
-    /// Decide what the peer should respond to an inbound NewOrderSingle.
-    /// </summary>
+    /// <summary>Decide what the peer should respond to an inbound NewOrderSingle.</summary>
     NewOrderResponse OnNewOrder(NewOrderContext context);
+
+    /// <summary>
+    /// Decide what the peer should respond to an inbound OrderCancelRequest.
+    /// Default: <see cref="CancelResponse.Accept"/> (emit <c>ExecutionReport_Cancel</c>).
+    /// </summary>
+    CancelResponse OnCancel(CancelContext context) => new CancelResponse.Accept();
+
+    /// <summary>
+    /// Decide what the peer should respond to an inbound OrderCancelReplaceRequest.
+    /// Default: <see cref="ModifyResponse.Accept"/> (emit <c>ExecutionReport_Modify</c>).
+    /// </summary>
+    ModifyResponse OnModify(ModifyContext context) => new ModifyResponse.Accept();
 }
 
 /// <summary>Decoded summary of an inbound NewOrderSingle.</summary>
@@ -29,7 +47,48 @@ public readonly record struct NewOrderContext(
     uint SessionId,
     uint EnteringFirm,
     ulong SecurityId,
-    string ClOrdId);
+    string ClOrdId)
+{
+    /// <summary>OrderQty from the inbound NewOrderSingle (when present).</summary>
+    public ulong? OrderQty { get; init; }
+
+    /// <summary>Price from the inbound NewOrderSingle (when present; market orders may be unset).</summary>
+    public decimal? Price { get; init; }
+
+    /// <summary>Side from the inbound NewOrderSingle (when present).</summary>
+    public Side? Side { get; init; }
+
+    /// <summary>Inbound BusinessHeader.MsgSeqNum, surfaced for BusinessMessageReject's RefSeqNum.</summary>
+    public uint MsgSeqNum { get; init; }
+}
+
+/// <summary>Decoded summary of an inbound OrderCancelRequest.</summary>
+public readonly record struct CancelContext(
+    uint SessionId,
+    ulong SecurityId,
+    string ClOrdId,
+    string OrigClOrdId)
+{
+    /// <summary>Inbound BusinessHeader.MsgSeqNum, surfaced for ExecutionReport_Reject's MsgSeqNum context.</summary>
+    public uint MsgSeqNum { get; init; }
+}
+
+/// <summary>Decoded summary of an inbound OrderCancelReplaceRequest.</summary>
+public readonly record struct ModifyContext(
+    uint SessionId,
+    ulong SecurityId,
+    string ClOrdId,
+    string OrigClOrdId)
+{
+    /// <summary>OrderQty from the inbound OrderCancelReplaceRequest (when present).</summary>
+    public ulong? OrderQty { get; init; }
+
+    /// <summary>Price from the inbound OrderCancelReplaceRequest (when present).</summary>
+    public decimal? Price { get; init; }
+
+    /// <summary>Inbound BusinessHeader.MsgSeqNum.</summary>
+    public uint MsgSeqNum { get; init; }
+}
 
 /// <summary>Discriminated union of peer responses to a NewOrderSingle.</summary>
 public abstract record NewOrderResponse
@@ -41,29 +100,88 @@ public abstract record NewOrderResponse
 
     /// <summary>
     /// <c>ExecutionReport_New</c> immediately followed by an
-    /// <c>ExecutionReport_Trade</c> with <c>OrdStatus = FILLED</c>.
-    /// (Trade ER not yet implemented in the wire — currently sends a single
-    /// New ER. Tracked for follow-up.)
+    /// <c>ExecutionReport_Trade</c>. The trade carries
+    /// <c>OrdStatus = FILLED</c> (full fill) or <c>PARTIALLY_FILLED</c>
+    /// (when <see cref="FillQty"/> is supplied and lower than the inbound
+    /// <c>OrderQty</c>). When <see cref="FillPrice"/> is unset, the inbound
+    /// order's <c>Price</c> is used (or <c>1.0m</c> for market orders).
     /// </summary>
-    public sealed record AcceptAndFill : NewOrderResponse;
+    public sealed record AcceptAndFill : NewOrderResponse
+    {
+        /// <summary>LastPx for the trade ER. Falls back to inbound order Price, then 1.0m.</summary>
+        public decimal? FillPrice { get; init; }
+
+        /// <summary>
+        /// LastQty for the trade ER. Null = full fill (uses inbound OrderQty).
+        /// Values lower than OrderQty produce a partial fill (PARTIALLY_FILLED + LeavesQty).
+        /// Values greater than OrderQty are clamped to OrderQty.
+        /// </summary>
+        public ulong? FillQty { get; init; }
+    }
 
     /// <summary>
     /// <c>BusinessMessageReject</c> referencing the inbound order, with the
-    /// supplied <see cref="Reason"/>.
+    /// supplied <see cref="Reason"/> placed in the message's <c>Text</c>
+    /// field (ASCII, truncated at 250 bytes per schema).
     /// </summary>
-    public sealed record RejectBusiness(string Reason) : NewOrderResponse;
+    public sealed record RejectBusiness(string Reason) : NewOrderResponse
+    {
+        /// <summary>
+        /// BusinessRejectReason code emitted on the wire. Defaults to
+        /// <c>99</c> (Other) when unset.
+        /// </summary>
+        public uint? RejReason { get; init; }
+    }
+}
+
+/// <summary>Discriminated union of peer responses to an OrderCancelRequest.</summary>
+public abstract record CancelResponse
+{
+    private CancelResponse() { }
+
+    /// <summary>Emit <c>ExecutionReport_Cancel</c> with <c>OrdStatus = CANCELED</c>.</summary>
+    public sealed record Accept : CancelResponse;
+
+    /// <summary>
+    /// Emit <c>ExecutionReport_Reject</c> (template 204) with
+    /// <c>CxlRejResponseTo = CANCEL</c> and the supplied <see cref="Reason"/>.
+    /// </summary>
+    public sealed record Reject(string Reason) : CancelResponse
+    {
+        /// <summary>OrdRejReason code; defaults to <c>99</c> (Other).</summary>
+        public uint? RejReason { get; init; }
+    }
+}
+
+/// <summary>Discriminated union of peer responses to an OrderCancelReplaceRequest.</summary>
+public abstract record ModifyResponse
+{
+    private ModifyResponse() { }
+
+    /// <summary>Emit <c>ExecutionReport_Modify</c> with <c>OrdStatus = REPLACED</c>.</summary>
+    public sealed record Accept : ModifyResponse;
+
+    /// <summary>
+    /// Emit <c>ExecutionReport_Reject</c> (template 204) with
+    /// <c>CxlRejResponseTo = REPLACE</c> and the supplied <see cref="Reason"/>.
+    /// </summary>
+    public sealed record Reject(string Reason) : ModifyResponse
+    {
+        /// <summary>OrdRejReason code; defaults to <c>99</c> (Other).</summary>
+        public uint? RejReason { get; init; }
+    }
 }
 
 /// <summary>Built-in <see cref="ITestPeerScenario"/> implementations.</summary>
 public static class TestPeerScenarios
 {
-    /// <summary>Accept every NewOrder as <c>NEW</c> (historical default).</summary>
+    /// <summary>Accept every NewOrder as <c>NEW</c> (historical default). Cancel/Modify accepted.</summary>
     public static ITestPeerScenario AcceptAll { get; } = new AcceptAllScenario();
 
-    /// <summary>Accept every NewOrder and immediately fill it.</summary>
+    /// <summary>Accept every NewOrder and immediately fill it. Cancel/Modify accepted.</summary>
     public static ITestPeerScenario FillImmediately { get; } = new FillImmediatelyScenario();
 
-    /// <summary>Reject every NewOrder with the given reason.</summary>
+    /// <summary>Reject every NewOrder, Cancel, and Modify with the given reason.</summary>
     public static ITestPeerScenario RejectAll(string reason = "rejected by test peer") =>
         new RejectAllScenario(reason);
 
@@ -82,5 +200,7 @@ public static class TestPeerScenarios
         private readonly string _reason;
         public RejectAllScenario(string reason) { _reason = reason; }
         public NewOrderResponse OnNewOrder(NewOrderContext context) => new NewOrderResponse.RejectBusiness(_reason);
+        public CancelResponse OnCancel(CancelContext context) => new CancelResponse.Reject(_reason);
+        public ModifyResponse OnModify(ModifyContext context) => new ModifyResponse.Reject(_reason);
     }
 }

--- a/src/B3.EntryPoint.Client.TestPeer/InProcessFixpTestPeer.cs
+++ b/src/B3.EntryPoint.Client.TestPeer/InProcessFixpTestPeer.cs
@@ -105,6 +105,30 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
     {
         public uint OutSeq = 1;
         public CancellationTokenSource? KeepAliveCts;
+        public readonly SemaphoreSlim SendLock = new(1, 1);
+    }
+
+    /// <summary>
+    /// Single point of egress for every outbound frame. Serializes writes per
+    /// connection so concurrent senders (app frames + the peer-side Sequence
+    /// keep-alive loop) cannot interleave SOFH frames on the wire.
+    /// Latency is applied while holding the lock so total throughput observed
+    /// by the client is the sum, not the max, of concurrent senders.
+    /// </summary>
+    private async Task SendFrameAsync(Stream stream, ConnectionState state, byte[] buffer, int totalSize, CancellationToken ct)
+    {
+        await state.SendLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await ApplyLatencyAsync(ct).ConfigureAwait(false);
+            await stream.WriteAsync(buffer.AsMemory(0, totalSize), ct).ConfigureAwait(false);
+            await stream.FlushAsync(ct).ConfigureAwait(false);
+        }
+        catch (IOException) { }
+        finally
+        {
+            try { state.SendLock.Release(); } catch (ObjectDisposedException) { }
+        }
     }
 
     private async Task HandleConnectionAsync(TcpClient tcp, CancellationToken ct)
@@ -149,29 +173,29 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
                                 // Credentials map configured and firm not allowed → close cold.
                                 return;
                             }
-                            await SendNegotiateResponseAsync(stream, frame, ct).ConfigureAwait(false);
+                            await SendNegotiateResponseAsync(stream, frame, state, ct).ConfigureAwait(false);
                             break;
                         case EstablishData.MESSAGE_ID:
                             await SendEstablishAckAsync(stream, frame, state, ct).ConfigureAwait(false);
                             break;
                         case TerminateData.MESSAGE_ID:
                             state.KeepAliveCts?.Cancel();
-                            await SendTerminateEchoAsync(stream, frame, ct).ConfigureAwait(false);
+                            await SendTerminateEchoAsync(stream, frame, state, ct).ConfigureAwait(false);
                             return;
                         case NewOrderSingleData.MESSAGE_ID:
                             await DispatchNewOrderAsync(stream, frame, state, ct).ConfigureAwait(false);
                             break;
                         case OrderCancelRequestData.MESSAGE_ID:
-                            await SendExecutionReportCancelAsync(stream, frame, state, ct).ConfigureAwait(false);
+                            await DispatchCancelAsync(stream, frame, state, ct).ConfigureAwait(false);
                             break;
                         case OrderCancelReplaceRequestData.MESSAGE_ID:
-                            await SendExecutionReportModifyAsync(stream, frame, state, ct).ConfigureAwait(false);
+                            await DispatchModifyAsync(stream, frame, state, ct).ConfigureAwait(false);
                             break;
                         case OrderMassActionRequestData.MESSAGE_ID:
                             await SendOrderMassActionReportAsync(stream, frame, state, ct).ConfigureAwait(false);
                             break;
                         case RetransmitRequestData.MESSAGE_ID:
-                            await SendRetransmissionAsync(stream, frame, ct).ConfigureAwait(false);
+                            await SendRetransmissionAsync(stream, frame, state, ct).ConfigureAwait(false);
                             break;
                         default:
                             // Application or session-layer messages we don't model — swallow.
@@ -217,24 +241,29 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         if (!NewOrderSingleData.TryParse(payload, out var reader))
             return;
         ref readonly var req = ref reader.Data;
+        var orderQty = req.OrderQty.Value;
+        var priceMantissa = req.Price.Mantissa; // optional → null for market
+        decimal? reqPrice = priceMantissa.HasValue ? MantissaToDecimal(priceMantissa.GetValueOrDefault()) : null;
         var ctx = new NewOrderContext(
             SessionId: req.BusinessHeader.SessionID.Value,
             EnteringFirm: 0u, // SBE NewOrderSingle does not carry EnteringFirm; reserved for future.
             SecurityId: req.SecurityID.Value,
-            ClOrdId: req.ClOrdID.Value.ToString());
+            ClOrdId: req.ClOrdID.Value.ToString())
+        {
+            OrderQty = orderQty,
+            Price = reqPrice,
+            Side = req.Side,
+            MsgSeqNum = req.BusinessHeader.MsgSeqNum.Value,
+        };
         var response = _options.Scenario.OnNewOrder(ctx);
         switch (response)
         {
             case NewOrderResponse.RejectBusiness rej:
-                // BusinessReject not yet wired in this peer — emit nothing, the
-                // client-side BusinessReject path is exercised in unit tests via
-                // hand-crafted frames. Surface the reason via the event so
-                // downstream tests can assert.
-                _ = rej; // intentional: see ITestPeerScenario doc-comment.
+                await SendBusinessMessageRejectAsync(stream, ctx, rej, state, ct).ConfigureAwait(false);
                 break;
-            case NewOrderResponse.AcceptAndFill:
+            case NewOrderResponse.AcceptAndFill fill:
                 await SendExecutionReportNewAsync(stream, frame, state, ct).ConfigureAwait(false);
-                // Trade ER not yet implemented — see ITestPeerScenario doc-comment.
+                await SendExecutionReportTradeAsync(stream, frame, ctx, fill, state, ct).ConfigureAwait(false);
                 break;
             case NewOrderResponse.AcceptAsNew:
             default:
@@ -243,6 +272,64 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         }
     }
 
+    private async Task DispatchCancelAsync(Stream stream, byte[] frame, ConnectionState state, CancellationToken ct)
+    {
+        var payload = frame.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE);
+        if (!OrderCancelRequestData.TryParse(payload, out var reader))
+            return;
+        ref readonly var req = ref reader.Data;
+        var ctx = new CancelContext(
+            SessionId: req.BusinessHeader.SessionID.Value,
+            SecurityId: req.SecurityID.Value,
+            ClOrdId: req.ClOrdID.Value.ToString(),
+            OrigClOrdId: (req.OrigClOrdID ?? 0UL).ToString(System.Globalization.CultureInfo.InvariantCulture))
+        {
+            MsgSeqNum = req.BusinessHeader.MsgSeqNum.Value,
+        };
+        var response = _options.Scenario.OnCancel(ctx);
+        switch (response)
+        {
+            case CancelResponse.Reject rej:
+                await SendExecutionReportRejectAsync(stream, frame, req.BusinessHeader.SessionID, req.ClOrdID, req.SecurityID, req.Side, CxlRejResponseTo.CANCEL, rej.Reason, rej.RejReason, state, ct).ConfigureAwait(false);
+                break;
+            case CancelResponse.Accept:
+            default:
+                await SendExecutionReportCancelAsync(stream, frame, state, ct).ConfigureAwait(false);
+                break;
+        }
+    }
+
+    private async Task DispatchModifyAsync(Stream stream, byte[] frame, ConnectionState state, CancellationToken ct)
+    {
+        var payload = frame.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE);
+        if (!OrderCancelReplaceRequestData.TryParse(payload, out var reader))
+            return;
+        ref readonly var req = ref reader.Data;
+        var ctx = new ModifyContext(
+            SessionId: req.BusinessHeader.SessionID.Value,
+            SecurityId: req.SecurityID.Value,
+            ClOrdId: req.ClOrdID.Value.ToString(),
+            OrigClOrdId: (req.OrigClOrdID ?? 0UL).ToString(System.Globalization.CultureInfo.InvariantCulture))
+        {
+            OrderQty = req.OrderQty.Value,
+            Price = req.Price.Mantissa.HasValue ? MantissaToDecimal(req.Price.Mantissa.GetValueOrDefault()) : null,
+            MsgSeqNum = req.BusinessHeader.MsgSeqNum.Value,
+        };
+        var response = _options.Scenario.OnModify(ctx);
+        switch (response)
+        {
+            case ModifyResponse.Reject rej:
+                await SendExecutionReportRejectAsync(stream, frame, req.BusinessHeader.SessionID, req.ClOrdID, req.SecurityID, req.Side, CxlRejResponseTo.REPLACE, rej.Reason, rej.RejReason, state, ct).ConfigureAwait(false);
+                break;
+            case ModifyResponse.Accept:
+            default:
+                await SendExecutionReportModifyAsync(stream, frame, state, ct).ConfigureAwait(false);
+                break;
+        }
+    }
+
+    private static decimal MantissaToDecimal(long mantissa) => (decimal)mantissa / 10000m;
+
     private async Task ApplyLatencyAsync(CancellationToken ct)
     {
         var latency = _options.ResponseLatency;
@@ -250,7 +337,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
             try { await Task.Delay(latency, ct).ConfigureAwait(false); } catch (OperationCanceledException) { }
     }
 
-    private async Task SendNegotiateResponseAsync(Stream stream, byte[] requestFrame, CancellationToken ct)
+    private async Task SendNegotiateResponseAsync(Stream stream, byte[] requestFrame, ConnectionState state, CancellationToken ct)
     {
         if (!NegotiateData.TryParse(requestFrame.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out var reader))
             return;
@@ -271,9 +358,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         if (!resp.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
             return;
 
-        await ApplyLatencyAsync(ct).ConfigureAwait(false);
-        await stream.WriteAsync(buffer, ct).ConfigureAwait(false);
-        await stream.FlushAsync(ct).ConfigureAwait(false);
+        await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
     }
 
     private async Task SendEstablishAckAsync(Stream stream, byte[] requestFrame, ConnectionState state, CancellationToken ct)
@@ -300,9 +385,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         if (!ack.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
             return;
 
-        await ApplyLatencyAsync(ct).ConfigureAwait(false);
-        await stream.WriteAsync(buffer, ct).ConfigureAwait(false);
-        await stream.FlushAsync(ct).ConfigureAwait(false);
+        await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
 
         // Spec §4.6: peer-side keep-alive. Emit Sequence frames at the
         // negotiated interval so the client can observe inbound heartbeats.
@@ -327,9 +410,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
                 var seq = new SequenceData { NextSeqNo = new SeqNum(state.OutSeq) };
                 if (!seq.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
                     return;
-                await ApplyLatencyAsync(ct).ConfigureAwait(false);
-                await stream.WriteAsync(buffer, ct).ConfigureAwait(false);
-                await stream.FlushAsync(ct).ConfigureAwait(false);
+                await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException) { }
@@ -337,7 +418,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         catch (ObjectDisposedException) { }
     }
 
-    private async Task SendTerminateEchoAsync(Stream stream, byte[] requestFrame, CancellationToken ct)
+    private async Task SendTerminateEchoAsync(Stream stream, byte[] requestFrame, ConnectionState state, CancellationToken ct)
     {
         if (!TerminateData.TryParse(requestFrame.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out var reader))
             return;
@@ -357,13 +438,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         if (!echo.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
             return;
 
-        try
-        {
-            await ApplyLatencyAsync(ct).ConfigureAwait(false);
-            await stream.WriteAsync(buffer, ct).ConfigureAwait(false);
-            await stream.FlushAsync(ct).ConfigureAwait(false);
-        }
-        catch (IOException) { }
+        await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
     }
 
     private async Task SendExecutionReportNewAsync(Stream stream, byte[] requestFrame, ConnectionState state, CancellationToken ct)
@@ -388,7 +463,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
             TransactTime = new UTCTimestampNanos { Time = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL },
         };
 
-        await SendAppFrameAsync(stream, ExecutionReport_NewData.MESSAGE_ID, ExecutionReport_NewData.MESSAGE_SIZE,
+        await SendAppFrameAsync(stream, state, ExecutionReport_NewData.MESSAGE_ID, ExecutionReport_NewData.MESSAGE_SIZE,
             (Span<byte> buf, out int bw) => ExecutionReport_NewData.TryEncode(msg, buf, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, out bw),
             ct).ConfigureAwait(false);
     }
@@ -416,7 +491,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         };
         msg.SetOrigClOrdID(req.OrigClOrdID);
 
-        await SendAppFrameAsync(stream, ExecutionReport_CancelData.MESSAGE_ID, ExecutionReport_CancelData.MESSAGE_SIZE,
+        await SendAppFrameAsync(stream, state, ExecutionReport_CancelData.MESSAGE_ID, ExecutionReport_CancelData.MESSAGE_SIZE,
             (Span<byte> buf, out int bw) => ExecutionReport_CancelData.TryEncode(msg, buf, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, out bw),
             ct).ConfigureAwait(false);
     }
@@ -444,7 +519,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         };
         msg.SetOrigClOrdID(req.OrigClOrdID);
 
-        await SendAppFrameAsync(stream, ExecutionReport_ModifyData.MESSAGE_ID, ExecutionReport_ModifyData.MESSAGE_SIZE,
+        await SendAppFrameAsync(stream, state, ExecutionReport_ModifyData.MESSAGE_ID, ExecutionReport_ModifyData.MESSAGE_SIZE,
             (Span<byte> buf, out int bw) => ExecutionReport_ModifyData.TryEncode(msg, buf, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, out bw),
             ct).ConfigureAwait(false);
     }
@@ -471,12 +546,125 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         };
         msg.SetMassActionScope(req.MassActionScope);
 
-        await SendAppFrameAsync(stream, OrderMassActionReportData.MESSAGE_ID, OrderMassActionReportData.MESSAGE_SIZE,
+        await SendAppFrameAsync(stream, state, OrderMassActionReportData.MESSAGE_ID, OrderMassActionReportData.MESSAGE_SIZE,
             (Span<byte> buf, out int bw) => msg.TryEncode(buf, out bw),
             ct).ConfigureAwait(false);
     }
 
-    private async Task SendRetransmissionAsync(Stream stream, byte[] requestFrame, CancellationToken ct)
+    private async Task SendExecutionReportTradeAsync(Stream stream, byte[] requestFrame, NewOrderContext ctx, NewOrderResponse.AcceptAndFill fill, ConnectionState state, CancellationToken ct)
+    {
+        var payload = requestFrame.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE);
+        if (!NewOrderSingleData.TryParse(payload, out var reader))
+            return;
+        ref readonly var req = ref reader.Data;
+
+        var orderQty = ctx.OrderQty ?? req.OrderQty.Value;
+        var requestedFill = fill.FillQty ?? orderQty;
+        var fillQty = requestedFill > orderQty ? orderQty : requestedFill;
+        var isPartial = fillQty < orderQty;
+        var leavesQty = orderQty - fillQty;
+
+        var fillPx = fill.FillPrice ?? ctx.Price ?? 1.0m;
+        var pxMantissa = (long)decimal.Round(fillPx * 10000m);
+        var execId = (ulong)System.Threading.Interlocked.Increment(ref _orderIdSeq);
+        var orderId = (ulong)System.Threading.Interlocked.Increment(ref _orderIdSeq);
+        var tradeId = (ulong)System.Threading.Interlocked.Increment(ref _orderIdSeq);
+        var nowNanos = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
+
+        var msg = new ExecutionReport_TradeData
+        {
+            BusinessHeader = new OutboundBusinessHeader
+            {
+                SessionID = req.BusinessHeader.SessionID,
+                MsgSeqNum = new SeqNum(state.OutSeq++),
+            },
+            Side = req.Side,
+            OrdStatus = isPartial ? OrdStatus.PARTIALLY_FILLED : OrdStatus.FILLED,
+            SecurityID = req.SecurityID,
+            LastQty = new Quantity(fillQty),
+            LastPx = new Price { Mantissa = pxMantissa },
+            ExecID = new ExecID(execId),
+            TransactTime = new UTCTimestampNanos { Time = nowNanos },
+            LeavesQty = new Quantity(leavesQty),
+            CumQty = new Quantity(fillQty),
+            ExecType = ExecType.TRADE,
+            TradeID = new TradeID((uint)(tradeId & 0xFFFFFFFFu)),
+            OrderID = new OrderID(orderId),
+        };
+        msg.SetClOrdID(req.ClOrdID.Value);
+
+        await SendAppFrameAsync(stream, state, ExecutionReport_TradeData.MESSAGE_ID, ExecutionReport_TradeData.MESSAGE_SIZE,
+            (Span<byte> buf, out int bw) => ExecutionReport_TradeData.TryEncode(msg, buf, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, out bw),
+            ct).ConfigureAwait(false);
+    }
+
+    private async Task SendBusinessMessageRejectAsync(Stream stream, NewOrderContext ctx, NewOrderResponse.RejectBusiness rej, ConnectionState state, CancellationToken ct)
+    {
+        // Schema bound: TextEncoding length prefix is 1 byte → 255 max; B3 caps at 250.
+        const int MaxTextBytes = 250;
+        var reasonBytes = rej.Reason is { Length: > 0 }
+            ? System.Text.Encoding.ASCII.GetBytes(rej.Reason)
+            : Array.Empty<byte>();
+        if (reasonBytes.Length > MaxTextBytes)
+            Array.Resize(ref reasonBytes, MaxTextBytes);
+
+        var nowNanos = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
+        var msg = new BusinessMessageRejectData
+        {
+            BusinessHeader = new OutboundBusinessHeader
+            {
+                SessionID = new SessionID(ctx.SessionId),
+                MsgSeqNum = new SeqNum(state.OutSeq++),
+
+            },
+            RefMsgType = MessageType.NewOrderSingle,
+            RefSeqNum = new SeqNum(ctx.MsgSeqNum),
+            BusinessRejectReason = new RejReason(rej.RejReason ?? 99u),
+        };
+
+        var reasonMemory = new ReadOnlyMemory<byte>(reasonBytes);
+        await SendAppFrameAsync(stream, state, BusinessMessageRejectData.MESSAGE_ID, BusinessMessageRejectData.MESSAGE_SIZE,
+            (Span<byte> buf, out int bw) => BusinessMessageRejectData.TryEncode(msg, buf, ReadOnlySpan<byte>.Empty, reasonBytes, out bw),
+            new[] { ReadOnlyMemory<byte>.Empty, reasonMemory }, ct).ConfigureAwait(false);
+    }
+
+    private async Task SendExecutionReportRejectAsync(Stream stream, byte[] requestFrame, SessionID sessionId, ClOrdID clOrdId, SecurityID securityId, Side side,
+        CxlRejResponseTo responseTo, string reason, uint? rejReasonCode, ConnectionState state, CancellationToken ct)
+    {
+        _ = requestFrame;
+        const int MaxTextBytes = 250;
+        var reasonBytes = reason is { Length: > 0 }
+            ? System.Text.Encoding.ASCII.GetBytes(reason)
+            : Array.Empty<byte>();
+        if (reasonBytes.Length > MaxTextBytes)
+            Array.Resize(ref reasonBytes, MaxTextBytes);
+
+        var nowNanos = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
+        var execId = (ulong)System.Threading.Interlocked.Increment(ref _orderIdSeq);
+        var msg = new ExecutionReport_RejectData
+        {
+            BusinessHeader = new OutboundBusinessHeader
+            {
+                SessionID = sessionId,
+                MsgSeqNum = new SeqNum(state.OutSeq++),
+
+            },
+            Side = side,
+            CxlRejResponseTo = responseTo,
+            ClOrdID = clOrdId,
+            SecurityID = securityId,
+            OrdRejReason = new RejReason(rejReasonCode ?? 99u),
+            TransactTime = new UTCTimestampNanos { Time = nowNanos },
+            ExecID = new ExecID(execId),
+        };
+
+        var reasonMemory = new ReadOnlyMemory<byte>(reasonBytes);
+        await SendAppFrameAsync(stream, state, ExecutionReport_RejectData.MESSAGE_ID, ExecutionReport_RejectData.MESSAGE_SIZE,
+            (Span<byte> buf, out int bw) => ExecutionReport_RejectData.TryEncode(msg, buf, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, reasonBytes, out bw),
+            new[] { ReadOnlyMemory<byte>.Empty, ReadOnlyMemory<byte>.Empty, reasonMemory }, ct).ConfigureAwait(false);
+    }
+
+    private async Task SendRetransmissionAsync(Stream stream, byte[] requestFrame, ConnectionState state, CancellationToken ct)
     {
         if (!RetransmitRequestData.TryParse(requestFrame.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out var reader))
             return;
@@ -499,22 +687,30 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         if (!msg.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
             return;
 
-        try
-        {
-            await ApplyLatencyAsync(ct).ConfigureAwait(false);
-            await stream.WriteAsync(buffer, ct).ConfigureAwait(false);
-            await stream.FlushAsync(ct).ConfigureAwait(false);
-        }
-        catch (IOException) { }
+        await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
     }
 
     private static long _orderIdSeq;
 
-    private async Task SendAppFrameAsync(Stream stream, ushort templateId, int payloadSize, EncodeDelegate encode, CancellationToken ct)
+    /// <summary>
+    /// Encodes and sends an application frame. The buffer is sized to fit the
+    /// fixed payload plus all caller-supplied variable-length data sections,
+    /// each prefixed by its 1-byte length. Pass empty spans for sections you
+    /// don't intend to populate — every section the message defines must be
+    /// listed so its length-prefix byte is reserved.
+    /// </summary>
+    private async Task SendAppFrameAsync(Stream stream, ConnectionState state, ushort templateId, int payloadSize, EncodeDelegate encode,
+        ReadOnlyMemory<byte>[] varDataSections, CancellationToken ct)
     {
-        // Allocate generous trailing room for var-data sections (DeskID, Memo, etc.).
-        const int VarDataPad = 16;
-        var maxTotal = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + payloadSize + VarDataPad;
+        // Each var-data section on the wire is `byte length + payload`, even
+        // when payload is empty (length prefix is always emitted by the encoder).
+        var varTotal = 0;
+        for (int i = 0; i < varDataSections.Length; i++)
+            varTotal += 1 + varDataSections[i].Length;
+        // Floor at 4 bytes so messages whose var-data sections aren't all
+        // listed by the caller still don't overrun.
+        var varReserve = Math.Max(varTotal, 4);
+        var maxTotal = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + payloadSize + varReserve;
         var buffer = new byte[maxTotal];
         System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(SofhFrameReader.HeaderSize), (ushort)payloadSize);
         System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(SofhFrameReader.HeaderSize + 2), templateId);
@@ -522,14 +718,11 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
             return;
         var totalSize = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + bytesWritten;
         SofhFrameWriter.WriteHeader(buffer.AsSpan(0, totalSize), checked((ushort)totalSize));
-        try
-        {
-            await ApplyLatencyAsync(ct).ConfigureAwait(false);
-            await stream.WriteAsync(buffer.AsMemory(0, totalSize), ct).ConfigureAwait(false);
-            await stream.FlushAsync(ct).ConfigureAwait(false);
-        }
-        catch (IOException) { }
+        await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
     }
+
+    private Task SendAppFrameAsync(Stream stream, ConnectionState state, ushort templateId, int payloadSize, EncodeDelegate encode, CancellationToken ct)
+        => SendAppFrameAsync(stream, state, templateId, payloadSize, encode, Array.Empty<ReadOnlyMemory<byte>>(), ct);
 
     private delegate bool EncodeDelegate(Span<byte> buffer, out int bytesWritten);
 

--- a/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
@@ -1,1 +1,133 @@
 #nullable enable
+B3.EntryPoint.Client.TestPeer.CancelContext
+B3.EntryPoint.Client.TestPeer.CancelContext.CancelContext() -> void
+B3.EntryPoint.Client.TestPeer.CancelContext.CancelContext(uint SessionId, ulong SecurityId, string! ClOrdId, string! OrigClOrdId) -> void
+B3.EntryPoint.Client.TestPeer.CancelContext.ClOrdId.get -> string!
+B3.EntryPoint.Client.TestPeer.CancelContext.ClOrdId.init -> void
+B3.EntryPoint.Client.TestPeer.CancelContext.Deconstruct(out uint SessionId, out ulong SecurityId, out string! ClOrdId, out string! OrigClOrdId) -> void
+B3.EntryPoint.Client.TestPeer.CancelContext.Equals(B3.EntryPoint.Client.TestPeer.CancelContext other) -> bool
+B3.EntryPoint.Client.TestPeer.CancelContext.MsgSeqNum.get -> uint
+B3.EntryPoint.Client.TestPeer.CancelContext.MsgSeqNum.init -> void
+B3.EntryPoint.Client.TestPeer.CancelContext.OrigClOrdId.get -> string!
+B3.EntryPoint.Client.TestPeer.CancelContext.OrigClOrdId.init -> void
+B3.EntryPoint.Client.TestPeer.CancelContext.SecurityId.get -> ulong
+B3.EntryPoint.Client.TestPeer.CancelContext.SecurityId.init -> void
+B3.EntryPoint.Client.TestPeer.CancelContext.SessionId.get -> uint
+B3.EntryPoint.Client.TestPeer.CancelContext.SessionId.init -> void
+B3.EntryPoint.Client.TestPeer.CancelResponse
+B3.EntryPoint.Client.TestPeer.CancelResponse.Accept
+B3.EntryPoint.Client.TestPeer.CancelResponse.Accept.Accept() -> void
+B3.EntryPoint.Client.TestPeer.CancelResponse.Accept.Equals(B3.EntryPoint.Client.TestPeer.CancelResponse.Accept? other) -> bool
+B3.EntryPoint.Client.TestPeer.CancelResponse.CancelResponse(B3.EntryPoint.Client.TestPeer.CancelResponse! original) -> void
+B3.EntryPoint.Client.TestPeer.CancelResponse.Reject
+B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.Deconstruct(out string! Reason) -> void
+B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.Equals(B3.EntryPoint.Client.TestPeer.CancelResponse.Reject? other) -> bool
+B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.Reason.get -> string!
+B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.Reason.init -> void
+B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.RejReason.get -> uint?
+B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.RejReason.init -> void
+B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.Reject(string! Reason) -> void
+B3.EntryPoint.Client.TestPeer.ITestPeerScenario.OnCancel(B3.EntryPoint.Client.TestPeer.CancelContext context) -> B3.EntryPoint.Client.TestPeer.CancelResponse!
+B3.EntryPoint.Client.TestPeer.ITestPeerScenario.OnModify(B3.EntryPoint.Client.TestPeer.ModifyContext context) -> B3.EntryPoint.Client.TestPeer.ModifyResponse!
+B3.EntryPoint.Client.TestPeer.ModifyContext
+B3.EntryPoint.Client.TestPeer.ModifyContext.ClOrdId.get -> string!
+B3.EntryPoint.Client.TestPeer.ModifyContext.ClOrdId.init -> void
+B3.EntryPoint.Client.TestPeer.ModifyContext.Deconstruct(out uint SessionId, out ulong SecurityId, out string! ClOrdId, out string! OrigClOrdId) -> void
+B3.EntryPoint.Client.TestPeer.ModifyContext.Equals(B3.EntryPoint.Client.TestPeer.ModifyContext other) -> bool
+B3.EntryPoint.Client.TestPeer.ModifyContext.ModifyContext() -> void
+B3.EntryPoint.Client.TestPeer.ModifyContext.ModifyContext(uint SessionId, ulong SecurityId, string! ClOrdId, string! OrigClOrdId) -> void
+B3.EntryPoint.Client.TestPeer.ModifyContext.MsgSeqNum.get -> uint
+B3.EntryPoint.Client.TestPeer.ModifyContext.MsgSeqNum.init -> void
+B3.EntryPoint.Client.TestPeer.ModifyContext.OrderQty.get -> ulong?
+B3.EntryPoint.Client.TestPeer.ModifyContext.OrderQty.init -> void
+B3.EntryPoint.Client.TestPeer.ModifyContext.OrigClOrdId.get -> string!
+B3.EntryPoint.Client.TestPeer.ModifyContext.OrigClOrdId.init -> void
+B3.EntryPoint.Client.TestPeer.ModifyContext.Price.get -> decimal?
+B3.EntryPoint.Client.TestPeer.ModifyContext.Price.init -> void
+B3.EntryPoint.Client.TestPeer.ModifyContext.SecurityId.get -> ulong
+B3.EntryPoint.Client.TestPeer.ModifyContext.SecurityId.init -> void
+B3.EntryPoint.Client.TestPeer.ModifyContext.SessionId.get -> uint
+B3.EntryPoint.Client.TestPeer.ModifyContext.SessionId.init -> void
+B3.EntryPoint.Client.TestPeer.ModifyResponse
+B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept
+B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept.Accept() -> void
+B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept.Equals(B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept? other) -> bool
+B3.EntryPoint.Client.TestPeer.ModifyResponse.ModifyResponse(B3.EntryPoint.Client.TestPeer.ModifyResponse! original) -> void
+B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject
+B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.Deconstruct(out string! Reason) -> void
+B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.Equals(B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject? other) -> bool
+B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.Reason.get -> string!
+B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.Reason.init -> void
+B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.RejReason.get -> uint?
+B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.RejReason.init -> void
+B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.Reject(string! Reason) -> void
+B3.EntryPoint.Client.TestPeer.NewOrderContext.MsgSeqNum.get -> uint
+B3.EntryPoint.Client.TestPeer.NewOrderContext.MsgSeqNum.init -> void
+B3.EntryPoint.Client.TestPeer.NewOrderContext.OrderQty.get -> ulong?
+B3.EntryPoint.Client.TestPeer.NewOrderContext.OrderQty.init -> void
+B3.EntryPoint.Client.TestPeer.NewOrderContext.Price.get -> decimal?
+B3.EntryPoint.Client.TestPeer.NewOrderContext.Price.init -> void
+B3.EntryPoint.Client.TestPeer.NewOrderContext.Side.get -> B3.Entrypoint.Fixp.Sbe.V6.Side?
+B3.EntryPoint.Client.TestPeer.NewOrderContext.Side.init -> void
+B3.EntryPoint.Client.TestPeer.NewOrderResponse.AcceptAndFill.FillPrice.get -> decimal?
+B3.EntryPoint.Client.TestPeer.NewOrderResponse.AcceptAndFill.FillPrice.init -> void
+B3.EntryPoint.Client.TestPeer.NewOrderResponse.AcceptAndFill.FillQty.get -> ulong?
+B3.EntryPoint.Client.TestPeer.NewOrderResponse.AcceptAndFill.FillQty.init -> void
+B3.EntryPoint.Client.TestPeer.NewOrderResponse.RejectBusiness.RejReason.get -> uint?
+B3.EntryPoint.Client.TestPeer.NewOrderResponse.RejectBusiness.RejReason.init -> void
+abstract B3.EntryPoint.Client.TestPeer.CancelResponse.<Clone>$() -> B3.EntryPoint.Client.TestPeer.CancelResponse!
+abstract B3.EntryPoint.Client.TestPeer.ModifyResponse.<Clone>$() -> B3.EntryPoint.Client.TestPeer.ModifyResponse!
+override B3.EntryPoint.Client.TestPeer.CancelContext.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.CancelResponse.Accept.<Clone>$() -> B3.EntryPoint.Client.TestPeer.CancelResponse.Accept!
+override B3.EntryPoint.Client.TestPeer.CancelResponse.Accept.Equals(object? obj) -> bool
+override B3.EntryPoint.Client.TestPeer.CancelResponse.Accept.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.CancelResponse.Accept.ToString() -> string!
+override B3.EntryPoint.Client.TestPeer.CancelResponse.Equals(object? obj) -> bool
+override B3.EntryPoint.Client.TestPeer.CancelResponse.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.<Clone>$() -> B3.EntryPoint.Client.TestPeer.CancelResponse.Reject!
+override B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.Equals(object? obj) -> bool
+override B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.ToString() -> string!
+override B3.EntryPoint.Client.TestPeer.CancelResponse.ToString() -> string!
+override B3.EntryPoint.Client.TestPeer.ModifyContext.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept.<Clone>$() -> B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept!
+override B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept.Equals(object? obj) -> bool
+override B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept.ToString() -> string!
+override B3.EntryPoint.Client.TestPeer.ModifyResponse.Equals(object? obj) -> bool
+override B3.EntryPoint.Client.TestPeer.ModifyResponse.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.<Clone>$() -> B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject!
+override B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.Equals(object? obj) -> bool
+override B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.ToString() -> string!
+override B3.EntryPoint.Client.TestPeer.ModifyResponse.ToString() -> string!
+override sealed B3.EntryPoint.Client.TestPeer.CancelResponse.Accept.Equals(B3.EntryPoint.Client.TestPeer.CancelResponse? other) -> bool
+override sealed B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.Equals(B3.EntryPoint.Client.TestPeer.CancelResponse? other) -> bool
+override sealed B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept.Equals(B3.EntryPoint.Client.TestPeer.ModifyResponse? other) -> bool
+override sealed B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.Equals(B3.EntryPoint.Client.TestPeer.ModifyResponse? other) -> bool
+static B3.EntryPoint.Client.TestPeer.CancelContext.operator !=(B3.EntryPoint.Client.TestPeer.CancelContext left, B3.EntryPoint.Client.TestPeer.CancelContext right) -> bool
+static B3.EntryPoint.Client.TestPeer.CancelContext.operator ==(B3.EntryPoint.Client.TestPeer.CancelContext left, B3.EntryPoint.Client.TestPeer.CancelContext right) -> bool
+static B3.EntryPoint.Client.TestPeer.CancelResponse.Accept.operator !=(B3.EntryPoint.Client.TestPeer.CancelResponse.Accept? left, B3.EntryPoint.Client.TestPeer.CancelResponse.Accept? right) -> bool
+static B3.EntryPoint.Client.TestPeer.CancelResponse.Accept.operator ==(B3.EntryPoint.Client.TestPeer.CancelResponse.Accept? left, B3.EntryPoint.Client.TestPeer.CancelResponse.Accept? right) -> bool
+static B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.operator !=(B3.EntryPoint.Client.TestPeer.CancelResponse.Reject? left, B3.EntryPoint.Client.TestPeer.CancelResponse.Reject? right) -> bool
+static B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.operator ==(B3.EntryPoint.Client.TestPeer.CancelResponse.Reject? left, B3.EntryPoint.Client.TestPeer.CancelResponse.Reject? right) -> bool
+static B3.EntryPoint.Client.TestPeer.CancelResponse.operator !=(B3.EntryPoint.Client.TestPeer.CancelResponse? left, B3.EntryPoint.Client.TestPeer.CancelResponse? right) -> bool
+static B3.EntryPoint.Client.TestPeer.CancelResponse.operator ==(B3.EntryPoint.Client.TestPeer.CancelResponse? left, B3.EntryPoint.Client.TestPeer.CancelResponse? right) -> bool
+static B3.EntryPoint.Client.TestPeer.ModifyContext.operator !=(B3.EntryPoint.Client.TestPeer.ModifyContext left, B3.EntryPoint.Client.TestPeer.ModifyContext right) -> bool
+static B3.EntryPoint.Client.TestPeer.ModifyContext.operator ==(B3.EntryPoint.Client.TestPeer.ModifyContext left, B3.EntryPoint.Client.TestPeer.ModifyContext right) -> bool
+static B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept.operator !=(B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept? left, B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept? right) -> bool
+static B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept.operator ==(B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept? left, B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept? right) -> bool
+static B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.operator !=(B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject? left, B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject? right) -> bool
+static B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject.operator ==(B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject? left, B3.EntryPoint.Client.TestPeer.ModifyResponse.Reject? right) -> bool
+static B3.EntryPoint.Client.TestPeer.ModifyResponse.operator !=(B3.EntryPoint.Client.TestPeer.ModifyResponse? left, B3.EntryPoint.Client.TestPeer.ModifyResponse? right) -> bool
+static B3.EntryPoint.Client.TestPeer.ModifyResponse.operator ==(B3.EntryPoint.Client.TestPeer.ModifyResponse? left, B3.EntryPoint.Client.TestPeer.ModifyResponse? right) -> bool
+virtual B3.EntryPoint.Client.TestPeer.CancelResponse.EqualityContract.get -> System.Type!
+virtual B3.EntryPoint.Client.TestPeer.CancelResponse.Equals(B3.EntryPoint.Client.TestPeer.CancelResponse? other) -> bool
+virtual B3.EntryPoint.Client.TestPeer.CancelResponse.PrintMembers(System.Text.StringBuilder! builder) -> bool
+virtual B3.EntryPoint.Client.TestPeer.ModifyResponse.EqualityContract.get -> System.Type!
+virtual B3.EntryPoint.Client.TestPeer.ModifyResponse.Equals(B3.EntryPoint.Client.TestPeer.ModifyResponse? other) -> bool
+virtual B3.EntryPoint.Client.TestPeer.ModifyResponse.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~override B3.EntryPoint.Client.TestPeer.CancelContext.Equals(object obj) -> bool
+~override B3.EntryPoint.Client.TestPeer.CancelContext.ToString() -> string
+~override B3.EntryPoint.Client.TestPeer.ModifyContext.Equals(object obj) -> bool
+~override B3.EntryPoint.Client.TestPeer.ModifyContext.ToString() -> string

--- a/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
@@ -199,13 +199,32 @@ internal static class InboundDecoder
 
     private static ClientBusinessReject DecodeBmr(ReadOnlySpan<byte> payload)
     {
-        ref readonly var msg = ref MemoryMarshal.AsRef<SbeBmr>(payload);
+        // BMR has variable-length sections (Memo, Text). Use TryParse to get a
+        // reader, then access the Text accessor which slices past Memo.
+        if (!SbeBmr.TryParse(payload, out var reader))
+        {
+            // Fall back to fixed-payload-only decode (older peers / truncated frames).
+            ref readonly var fallback = ref MemoryMarshal.AsRef<SbeBmr>(payload);
+            return new ClientBusinessReject
+            {
+                SeqNum = fallback.BusinessHeader.MsgSeqNum.Value,
+                SendingTime = ToDateTime(fallback.BusinessHeader.SendingTime.Time),
+                RefSeqNum = fallback.RefSeqNum.Value,
+                RejectReason = (ushort)fallback.BusinessRejectReason.Value,
+            };
+        }
+        ref readonly var msg = ref reader.Data;
+        var textSeg = reader.Text;
+        string? text = textSeg.Length > 0
+            ? System.Text.Encoding.ASCII.GetString(textSeg.VarData)
+            : null;
         return new ClientBusinessReject
         {
             SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
             SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
             RefSeqNum = msg.RefSeqNum.Value,
             RejectReason = (ushort)msg.BusinessRejectReason.Value,
+            Text = text,
         };
     }
 

--- a/tests/B3.EntryPoint.Client.Tests/TestPeerScenarioTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/TestPeerScenarioTests.cs
@@ -116,4 +116,204 @@ public class TestPeerScenarioTests
         Assert.NotNull(TestPeerScenarios.FillImmediately);
         Assert.NotNull(TestPeerScenarios.RejectAll());
     }
+
+    private static async Task SubmitOrderAsync(EntryPointClient client, ulong clOrdId, ulong securityId, ulong qty, decimal price, CancellationToken ct)
+    {
+        try
+        {
+            await client.SubmitAsync(new NewOrderRequest
+            {
+                ClOrdID = (ClOrdID)clOrdId,
+                SecurityId = securityId,
+                Side = Side.Buy,
+                OrderType = OrderType.Limit,
+                Price = price,
+                OrderQty = qty,
+            }, ct);
+        }
+        catch (NotImplementedException) { /* submit path not yet wired in some builds */ }
+    }
+
+    private static async Task<List<EntryPointEvent>> DrainAsync(EntryPointClient client, int expected, TimeSpan timeout)
+    {
+        var events = new List<EntryPointEvent>();
+        using var cts = new CancellationTokenSource(timeout);
+        try
+        {
+            await foreach (var ev in client.Events().WithCancellation(cts.Token))
+            {
+                events.Add(ev);
+                if (events.Count >= expected) break;
+            }
+        }
+        catch (OperationCanceledException) { }
+        return events;
+    }
+
+    [Fact]
+    public async Task FillImmediately_EmitsAcceptedThenTrade_FullFill()
+    {
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions { Scenario = TestPeerScenarios.FillImmediately });
+        peer.Start();
+
+        await using var client = new EntryPointClient(ClientOptions(peer));
+        using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(connectCts.Token);
+
+        await SubmitOrderAsync(client, 555UL, 1001UL, qty: 10UL, price: 12.5m, connectCts.Token);
+
+        var events = await DrainAsync(client, expected: 2, TimeSpan.FromSeconds(2));
+        var trade = events.OfType<OrderTrade>().FirstOrDefault();
+        Assert.NotNull(trade);
+        Assert.Equal(OrderStatus.Filled, trade!.OrderStatus);
+        Assert.Equal(10UL, trade.LastQty);
+        Assert.Equal(0UL, trade.LeavesQty);
+        Assert.Equal(10UL, trade.CumQty);
+        Assert.Equal(12.5m, trade.LastPx);
+        Assert.Contains(events, e => e is OrderAccepted);
+    }
+
+    [Fact]
+    public async Task FillImmediately_PartialFill_UsesProvidedFillQty()
+    {
+        var scenario = new PartialFillScenario(fillQty: 4UL, fillPrice: 11.0m);
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions { Scenario = scenario });
+        peer.Start();
+
+        await using var client = new EntryPointClient(ClientOptions(peer));
+        using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(connectCts.Token);
+
+        await SubmitOrderAsync(client, 600UL, 1002UL, qty: 10UL, price: 9.9m, connectCts.Token);
+
+        var events = await DrainAsync(client, expected: 2, TimeSpan.FromSeconds(2));
+        var trade = events.OfType<OrderTrade>().FirstOrDefault();
+        Assert.NotNull(trade);
+        Assert.Equal(OrderStatus.PartiallyFilled, trade!.OrderStatus);
+        Assert.Equal(4UL, trade.LastQty);
+        Assert.Equal(6UL, trade.LeavesQty);
+        Assert.Equal(4UL, trade.CumQty);
+        Assert.Equal(11.0m, trade.LastPx);
+    }
+
+    [Fact]
+    public async Task RejectAll_EmitsBusinessRejectWithText()
+    {
+        const string Reason = "test peer rejecting NewOrder";
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions { Scenario = TestPeerScenarios.RejectAll(Reason) });
+        peer.Start();
+
+        await using var client = new EntryPointClient(ClientOptions(peer));
+        using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(connectCts.Token);
+
+        await SubmitOrderAsync(client, 700UL, 1003UL, qty: 5UL, price: 1.0m, connectCts.Token);
+
+        var events = await DrainAsync(client, expected: 1, TimeSpan.FromSeconds(2));
+        var bmr = events.OfType<BusinessReject>().FirstOrDefault();
+        Assert.NotNull(bmr);
+        Assert.Equal(Reason, bmr!.Text);
+        // Default RejReason for RejectBusiness without explicit code = 99 (Other).
+        Assert.Equal((ushort)99, bmr.RejectReason);
+    }
+
+    [Fact]
+    public async Task RejectAll_RejectsCancelWithExecutionReportReject()
+    {
+        const string Reason = "cancel rejected";
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions { Scenario = TestPeerScenarios.RejectAll(Reason) });
+        peer.Start();
+
+        await using var client = new EntryPointClient(ClientOptions(peer));
+        using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(connectCts.Token);
+
+        try
+        {
+            await client.CancelAsync(new CancelOrderRequest
+            {
+                ClOrdID = (ClOrdID)801UL,
+                OrigClOrdID = (ClOrdID)800UL,
+                SecurityId = 2001UL,
+                Side = Side.Buy,
+            }, connectCts.Token);
+        }
+        catch (NotImplementedException) { }
+
+        var events = await DrainAsync(client, expected: 1, TimeSpan.FromSeconds(2));
+        var rejected = events.OfType<OrderRejected>().FirstOrDefault();
+        Assert.NotNull(rejected);
+        Assert.Equal((ushort)99, rejected!.RejectCode);
+    }
+
+    [Fact]
+    public async Task FillImmediatelyScenario_DoesNotRejectCancel()
+    {
+        // Sanity: built-in FillImmediately scenario does not override OnCancel,
+        // so DIM default (Accept) must be exercised via the test peer, producing
+        // an OrderCancelled event rather than an OrderRejected.
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions { Scenario = TestPeerScenarios.FillImmediately });
+        peer.Start();
+
+        await using var client = new EntryPointClient(ClientOptions(peer));
+        using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(connectCts.Token);
+
+        try
+        {
+            await client.CancelAsync(new CancelOrderRequest
+            {
+                ClOrdID = (ClOrdID)901UL,
+                OrigClOrdID = (ClOrdID)900UL,
+                SecurityId = 3001UL,
+                Side = Side.Sell,
+            }, connectCts.Token);
+        }
+        catch (NotImplementedException) { }
+
+        var events = await DrainAsync(client, expected: 1, TimeSpan.FromSeconds(2));
+        Assert.Contains(events, e => e is OrderCancelled);
+        Assert.DoesNotContain(events, e => e is OrderRejected);
+    }
+
+    [Fact]
+    public async Task RejectAll_RejectsModifyWithExecutionReportReject()
+    {
+        const string Reason = "modify rejected";
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions { Scenario = TestPeerScenarios.RejectAll(Reason) });
+        peer.Start();
+
+        await using var client = new EntryPointClient(ClientOptions(peer));
+        using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(connectCts.Token);
+
+        try
+        {
+            await client.ReplaceAsync(new ReplaceOrderRequest
+            {
+                ClOrdID = (ClOrdID)1101UL,
+                OrigClOrdID = (ClOrdID)1100UL,
+                SecurityId = 4001UL,
+                Side = Side.Buy,
+                OrderType = OrderType.Limit,
+                Price = 12.34m,
+                OrderQty = 10UL,
+            }, connectCts.Token);
+        }
+        catch (NotImplementedException) { }
+
+        var events = await DrainAsync(client, expected: 1, TimeSpan.FromSeconds(2));
+        var rejected = events.OfType<OrderRejected>().FirstOrDefault();
+        Assert.NotNull(rejected);
+        Assert.Equal((ushort)99, rejected!.RejectCode);
+    }
+
+    private sealed class PartialFillScenario : ITestPeerScenario
+    {
+        private readonly ulong _fillQty;
+        private readonly decimal _fillPrice;
+        public PartialFillScenario(ulong fillQty, decimal fillPrice) { _fillQty = fillQty; _fillPrice = fillPrice; }
+        public NewOrderResponse OnNewOrder(NewOrderContext context) =>
+            new NewOrderResponse.AcceptAndFill { FillQty = _fillQty, FillPrice = _fillPrice };
+    }
 }


### PR DESCRIPTION
Closes #105, #106, #107.

## Summary
v0.9.0 of `B3.EntryPoint.Client.TestPeer` — feedback from B3TradingPlatform Phase 7 turned into real wire-format completeness.

### #105 — Real `ExecutionReport_Trade`
`AcceptAndFill` now emits a real ER_Trade (template 203) with full/partial-fill semantics: `FillQty`/`FillPrice` honored, `LeavesQty` derived, status `FILLED` or `PARTIALLY_FILLED`.

### #106 — Real `BusinessMessageReject` with text
`RejectBusiness` emits a real BMR (template 206) with `Text` and bounded `BusinessRejectReason`. `InboundDecoder.DecodeBmr` now decodes the `Text` var-data via `SbeBmr.TryParse` into `BusinessReject.Text`.

### #107 — Cancel/Modify scenario hooks
`ITestPeerScenario` gains `OnCancel(CancelContext)` and `OnModify(ModifyContext)` DIM hooks. `RejectAll` rejects cancels/modifies via `ExecutionReport_Reject` (template 204) with `CxlRejResponseTo` set accordingly.

### Foundation (refactor)
- Per-connection `SemaphoreSlim` + central `SendFrameAsync` helper (removes outbound write race).
- Dynamic var-data buffer sizing — one length-prefix byte per section, instead of a fixed pad. Fixes oversized buffers and accommodates messages with 3 var-data sections (ER_Reject).
- `NewOrderContext` extended with `OrderQty`/`Price`/`Side`/`MsgSeqNum` (additive init properties).

## Tests
- 131 unit tests passing (5 new TestPeerScenarioTests covering full-fill, partial-fill, BMR-with-text, cancel-reject, modify-reject, plus the FillImmediately doesn't-reject-cancel sanity check).
- 8 conformance tests passing (`ENTRYPOINT_TESTPEER=1`).
- 1 sample test passing.
- `dotnet format` clean.

## Public API
`PublicAPI.Unshipped.txt` updated for TestPeer (cancel/modify response unions, contexts, DIM hooks, NewOrderContext init props, RejReason/FillPrice/FillQty additions). All additive — no removals.