### PR TITLE
feat(testpeer): DI extensions AddInProcessFixpTestPeer[Hosted] (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `B3.EntryPoint.Client.TestPeer.DependencyInjection` namespace (#104) with `AddInProcessFixpTestPeer(IServiceCollection, Action<TestPeerOptions>)` (singleton registration via the standard Options pattern) and `AddInProcessFixpTestPeerHosted(IServiceCollection, Action<TestPeerOptions>)` (registers an `IHostedService` that drives `peer.Start()`/`peer.StopAsync(ct)` from the generic-host lifecycle). New package references on TestPeer: `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Hosting.Abstractions` (10.0.7). `docs/TEST-PEER.md` gets a "Use from a generic host" snippet and a working sample test in `tests/Samples/B3.EntryPoint.Client.TestPeer.Sample/HostedSample.cs`.
+
 ## [0.9.0] - 2026-05-02
 
 ### Added

--- a/docs/TEST-PEER.md
+++ b/docs/TEST-PEER.md
@@ -85,14 +85,62 @@ peer.MessageReceived += (_, e) =>
 
 The handler runs on the peer's connection task — keep it cheap, don't block.
 
-## Limitations (v0.8.0)
+## Use from a generic host
 
-- `AcceptAndFill` currently emits a single `ExecutionReport_New`; the
-  follow-up `ExecutionReport_Trade` is on the roadmap.
-- `RejectBusiness` does not yet emit a `BusinessMessageReject` frame; the
-  reason is surfaced via the scenario callback for assertion only.
+For integration tests that already wire everything through DI, the
+`B3.EntryPoint.Client.TestPeer.DependencyInjection` namespace ships two
+extension methods:
+
+```csharp
+using B3.EntryPoint.Client.TestPeer.DependencyInjection;
+
+// Bare registration: caller controls Start()/StopAsync.
+services.AddInProcessFixpTestPeer(o => o.Scenario = TestPeerScenarios.AcceptAll);
+
+// Hosted: an IHostedService starts the peer on host.StartAsync()
+// and stops it on host.StopAsync().
+services.AddInProcessFixpTestPeerHosted(o => o.Scenario = TestPeerScenarios.AcceptAll);
+```
+
+The hosted variant is the recommended shape for fixtures that resolve
+the EntryPoint client against the peer's bound endpoint. Wiring is
+two-phase — the listener only binds inside `host.StartAsync()`, so the
+client must be configured *after* the host has started:
+
+```csharp
+var peerHost = Host.CreateApplicationBuilder();
+peerHost.Services.AddInProcessFixpTestPeerHosted(o =>
+    o.Scenario = TestPeerScenarios.AcceptAll);
+
+using var host = peerHost.Build();
+await host.StartAsync(ct);
+
+var peer = host.Services.GetRequiredService<InProcessFixpTestPeer>();
+// peer.LocalEndpoint is non-null here.
+
+var clientServices = new ServiceCollection();
+clientServices.AddEntryPointClient(o =>
+{
+    o.Endpoint = peer.LocalEndpoint;
+    o.SessionId = 1u;
+    o.SessionVerId = 1u;
+    o.EnteringFirm = 1234u;
+    o.Credentials = Credentials.FromUtf8("demo-key");
+});
+await using var clientProvider = clientServices.BuildServiceProvider();
+var client = clientProvider.GetRequiredService<IEntryPointClient>();
+
+await client.ConnectAsync(ct);
+// ... exercise the client ...
+await host.StopAsync(ct); // hosted service calls peer.StopAsync(ct).
+```
+
+A working sample lives in `tests/Samples/B3.EntryPoint.Client.TestPeer.Sample/HostedSample.cs`.
+
+## Limitations
+
 - Drop / sequence-gap injection is not yet implemented; only
-  `ResponseLatency` is wired in this release.
+  `ResponseLatency` is wired today.
 
 These will land in subsequent versions without changing the public API
 shape established here.

--- a/src/B3.EntryPoint.Client.TestPeer/B3.EntryPoint.Client.TestPeer.csproj
+++ b/src/B3.EntryPoint.Client.TestPeer/B3.EntryPoint.Client.TestPeer.csproj
@@ -15,6 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.11.0-beta1.23472.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/B3.EntryPoint.Client.TestPeer/DependencyInjection/InProcessFixpTestPeerHostedService.cs
+++ b/src/B3.EntryPoint.Client.TestPeer/DependencyInjection/InProcessFixpTestPeerHostedService.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Hosting;
+
+namespace B3.EntryPoint.Client.TestPeer.DependencyInjection;
+
+/// <summary>
+/// Adapter that drives <see cref="InProcessFixpTestPeer"/> from the generic
+/// host lifecycle: <c>Start()</c> on <see cref="StartAsync"/>,
+/// <c>StopAsync(ct)</c> on <see cref="StopAsync"/>.
+/// </summary>
+internal sealed class InProcessFixpTestPeerHostedService : IHostedService
+{
+    private readonly InProcessFixpTestPeer _peer;
+
+    public InProcessFixpTestPeerHostedService(InProcessFixpTestPeer peer)
+    {
+        ArgumentNullException.ThrowIfNull(peer);
+        _peer = peer;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _peer.Start();
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+        => _peer.StopAsync(cancellationToken);
+}

--- a/src/B3.EntryPoint.Client.TestPeer/DependencyInjection/InProcessFixpTestPeerServiceCollectionExtensions.cs
+++ b/src/B3.EntryPoint.Client.TestPeer/DependencyInjection/InProcessFixpTestPeerServiceCollectionExtensions.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace B3.EntryPoint.Client.TestPeer.DependencyInjection;
+
+/// <summary>
+/// <see cref="IServiceCollection"/> helpers that register
+/// <see cref="InProcessFixpTestPeer"/> via the standard Options pattern.
+/// </summary>
+/// <remarks>
+/// The peer holds a long-lived listening socket and is registered as a
+/// singleton. Use <see cref="AddInProcessFixpTestPeerHosted"/> when running
+/// inside a generic host so the peer is started/stopped automatically with
+/// the host lifecycle. Use the bare <see cref="AddInProcessFixpTestPeer"/>
+/// when the test fixture controls Start/Stop manually.
+/// </remarks>
+public static class InProcessFixpTestPeerServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a singleton <see cref="InProcessFixpTestPeer"/> configured
+    /// via <paramref name="configure"/>. The caller is responsible for
+    /// invoking <see cref="InProcessFixpTestPeer.Start"/> and
+    /// <see cref="InProcessFixpTestPeer.StopAsync"/>; the singleton is
+    /// disposed by the container on shutdown.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">If any argument is null.</exception>
+    public static IServiceCollection AddInProcessFixpTestPeer(
+        this IServiceCollection services,
+        Action<TestPeerOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.AddOptions<TestPeerOptions>().Configure(configure);
+        services.TryAddSingleton(static sp =>
+            new InProcessFixpTestPeer(sp.GetRequiredService<IOptions<TestPeerOptions>>().Value));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a singleton <see cref="InProcessFixpTestPeer"/> plus an
+    /// <see cref="IHostedService"/> that calls
+    /// <see cref="InProcessFixpTestPeer.Start"/> on
+    /// <see cref="IHostedService.StartAsync"/> and
+    /// <see cref="InProcessFixpTestPeer.StopAsync"/> on
+    /// <see cref="IHostedService.StopAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// After <c>host.StartAsync()</c> returns, <c>peer.LocalEndpoint</c> is
+    /// non-null and can be read to configure an
+    /// <see cref="EntryPointClient"/> against it. See
+    /// <c>docs/TEST-PEER.md</c> for an end-to-end snippet.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">If any argument is null.</exception>
+    public static IServiceCollection AddInProcessFixpTestPeerHosted(
+        this IServiceCollection services,
+        Action<TestPeerOptions> configure)
+    {
+        services.AddInProcessFixpTestPeer(configure);
+        services.AddHostedService<InProcessFixpTestPeerHostedService>();
+        return services;
+    }
+}

--- a/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+B3.EntryPoint.Client.TestPeer.DependencyInjection.InProcessFixpTestPeerServiceCollectionExtensions
+static B3.EntryPoint.Client.TestPeer.DependencyInjection.InProcessFixpTestPeerServiceCollectionExtensions.AddInProcessFixpTestPeer(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<B3.EntryPoint.Client.TestPeer.TestPeerOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static B3.EntryPoint.Client.TestPeer.DependencyInjection.InProcessFixpTestPeerServiceCollectionExtensions.AddInProcessFixpTestPeerHosted(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<B3.EntryPoint.Client.TestPeer.TestPeerOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/tests/Samples/B3.EntryPoint.Client.TestPeer.Sample/B3.EntryPoint.Client.TestPeer.Sample.csproj
+++ b/tests/Samples/B3.EntryPoint.Client.TestPeer.Sample/B3.EntryPoint.Client.TestPeer.Sample.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/tests/Samples/B3.EntryPoint.Client.TestPeer.Sample/HostedSample.cs
+++ b/tests/Samples/B3.EntryPoint.Client.TestPeer.Sample/HostedSample.cs
@@ -1,0 +1,68 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.DependencyInjection;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Client.TestPeer;
+using B3.EntryPoint.Client.TestPeer.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace B3.EntryPoint.Client.TestPeer.Sample;
+
+/// <summary>
+/// Demonstrates the recommended generic-host wiring for downstream
+/// integration test fixtures: the test peer is registered as a hosted
+/// service so it starts/stops with the host, then the EntryPoint client
+/// is registered against the peer's bound endpoint.
+///
+/// The wiring is intentionally two-phase — host.StartAsync() must
+/// complete before LocalEndpoint can be read — which is the only
+/// timing constraint callers need to know about.
+/// </summary>
+public class HostedSample
+{
+    [Fact]
+    public async Task GenericHost_WiresPeerAndClient_RoundTrip()
+    {
+        // Phase 1: build a host that owns the test peer's lifecycle.
+        // We deliberately do NOT register the EntryPointClient here —
+        // the client needs the peer's LocalEndpoint, which only exists
+        // after Start() has bound the listener.
+        var peerHost = Host.CreateApplicationBuilder();
+        peerHost.Services.AddInProcessFixpTestPeerHosted(o =>
+        {
+            o.Scenario = TestPeerScenarios.AcceptAll;
+        });
+
+        using var ctx = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var host = peerHost.Build();
+        await host.StartAsync(ctx.Token);
+
+        var peer = host.Services.GetRequiredService<InProcessFixpTestPeer>();
+        Assert.NotNull(peer.LocalEndpoint);
+
+        // Phase 2: with the listener bound, register and resolve the
+        // client against peer.LocalEndpoint.
+        var clientServices = new ServiceCollection();
+        clientServices.AddEntryPointClient(o =>
+        {
+            o.Endpoint = peer.LocalEndpoint;
+            o.SessionId = 1u;
+            o.SessionVerId = 1u;
+            o.EnteringFirm = 1234u;
+            o.Credentials = Credentials.FromUtf8("demo-key");
+            o.KeepAliveIntervalMs = 60_000u;
+        });
+        await using var clientProvider = clientServices.BuildServiceProvider();
+        var client = clientProvider.GetRequiredService<IEntryPointClient>();
+
+        await client.ConnectAsync(ctx.Token);
+        Assert.Equal(FixpClientState.Established, client.State);
+
+        await client.TerminateAsync(TerminationCode.Finished, ctx.Token);
+
+        // Phase 3: explicitly verify the hosted-service path stops the peer.
+        await host.StopAsync(ctx.Token);
+    }
+}


### PR DESCRIPTION
Closes #104.

Adds the `B3.EntryPoint.Client.TestPeer.DependencyInjection` namespace, mirroring the existing `B3.EntryPoint.Client.DependencyInjection` shape:

- `AddInProcessFixpTestPeer(IServiceCollection, Action<TestPeerOptions>)` — singleton registration via the standard Options pattern. Caller owns Start/StopAsync.
- `AddInProcessFixpTestPeerHosted(IServiceCollection, Action<TestPeerOptions>)` — same registration plus an internal `IHostedService` that calls `peer.Start()` on `StartAsync` and `peer.StopAsync(ct)` on `StopAsync`.

## Wiring (two-phase)

The listener only binds inside `host.StartAsync()`, so the EntryPoint client must be configured *after* the host has started. `docs/TEST-PEER.md` gets a "Use from a generic host" section with the recommended pattern, and `tests/Samples/.../HostedSample.cs` exercises it end-to-end.

## New transitive deps (TestPeer NuGet)

- `Microsoft.Extensions.DependencyInjection.Abstractions` 10.0.7
- `Microsoft.Extensions.Options` 10.0.7
- `Microsoft.Extensions.Hosting.Abstractions` 10.0.7

## Tests
- 132 unit + 2 sample tests passing (added 1 new `HostedSample` test).
- 8 conformance passing under `ENTRYPOINT_TESTPEER=1`.
- Format clean.

## Public API
- 3 additive symbols on TestPeer (`InProcessFixpTestPeerServiceCollectionExtensions` + 2 extension methods) tracked in `PublicAPI.Unshipped.txt`.