### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-02
+
 ### Added
 - `B3.EntryPoint.Client.TestPeer.DependencyInjection` namespace (#104) with `AddInProcessFixpTestPeer(IServiceCollection, Action<TestPeerOptions>)` (singleton registration via the standard Options pattern) and `AddInProcessFixpTestPeerHosted(IServiceCollection, Action<TestPeerOptions>)` (registers an `IHostedService` that drives `peer.Start()`/`peer.StopAsync(ct)` from the generic-host lifecycle). New package references on TestPeer: `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Options`, `Microsoft.Extensions.Hosting.Abstractions` (10.0.7). `docs/TEST-PEER.md` gets a "Use from a generic host" snippet and a working sample test in `tests/Samples/B3.EntryPoint.Client.TestPeer.Sample/HostedSample.cs`.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- NuGet metadata shared by all packable projects. -->
-    <Version>0.9.0</Version>
+    <Version>0.10.0</Version>
     <Authors>pedrosakuma</Authors>
     <Company>pedrosakuma</Company>
     <Copyright>Copyright (c) pedrosakuma</Copyright>

--- a/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Shipped.txt
+++ b/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Shipped.txt
@@ -27,6 +27,7 @@ B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.Reason.init -> void
 B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.RejReason.get -> uint?
 B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.RejReason.init -> void
 B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.Reject(string! Reason) -> void
+B3.EntryPoint.Client.TestPeer.DependencyInjection.InProcessFixpTestPeerServiceCollectionExtensions
 B3.EntryPoint.Client.TestPeer.ITestPeerScenario
 B3.EntryPoint.Client.TestPeer.ITestPeerScenario.OnCancel(B3.EntryPoint.Client.TestPeer.CancelContext context) -> B3.EntryPoint.Client.TestPeer.CancelResponse!
 B3.EntryPoint.Client.TestPeer.ITestPeerScenario.OnModify(B3.EntryPoint.Client.TestPeer.ModifyContext context) -> B3.EntryPoint.Client.TestPeer.ModifyResponse!
@@ -188,6 +189,8 @@ static B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.operator !=(B3.EntryP
 static B3.EntryPoint.Client.TestPeer.CancelResponse.Reject.operator ==(B3.EntryPoint.Client.TestPeer.CancelResponse.Reject? left, B3.EntryPoint.Client.TestPeer.CancelResponse.Reject? right) -> bool
 static B3.EntryPoint.Client.TestPeer.CancelResponse.operator !=(B3.EntryPoint.Client.TestPeer.CancelResponse? left, B3.EntryPoint.Client.TestPeer.CancelResponse? right) -> bool
 static B3.EntryPoint.Client.TestPeer.CancelResponse.operator ==(B3.EntryPoint.Client.TestPeer.CancelResponse? left, B3.EntryPoint.Client.TestPeer.CancelResponse? right) -> bool
+static B3.EntryPoint.Client.TestPeer.DependencyInjection.InProcessFixpTestPeerServiceCollectionExtensions.AddInProcessFixpTestPeer(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<B3.EntryPoint.Client.TestPeer.TestPeerOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static B3.EntryPoint.Client.TestPeer.DependencyInjection.InProcessFixpTestPeerServiceCollectionExtensions.AddInProcessFixpTestPeerHosted(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<B3.EntryPoint.Client.TestPeer.TestPeerOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static B3.EntryPoint.Client.TestPeer.ModifyContext.operator !=(B3.EntryPoint.Client.TestPeer.ModifyContext left, B3.EntryPoint.Client.TestPeer.ModifyContext right) -> bool
 static B3.EntryPoint.Client.TestPeer.ModifyContext.operator ==(B3.EntryPoint.Client.TestPeer.ModifyContext left, B3.EntryPoint.Client.TestPeer.ModifyContext right) -> bool
 static B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept.operator !=(B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept? left, B3.EntryPoint.Client.TestPeer.ModifyResponse.Accept? right) -> bool

--- a/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
@@ -1,4 +1,1 @@
 #nullable enable
-B3.EntryPoint.Client.TestPeer.DependencyInjection.InProcessFixpTestPeerServiceCollectionExtensions
-static B3.EntryPoint.Client.TestPeer.DependencyInjection.InProcessFixpTestPeerServiceCollectionExtensions.AddInProcessFixpTestPeer(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<B3.EntryPoint.Client.TestPeer.TestPeerOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static B3.EntryPoint.Client.TestPeer.DependencyInjection.InProcessFixpTestPeerServiceCollectionExtensions.AddInProcessFixpTestPeerHosted(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<B3.EntryPoint.Client.TestPeer.TestPeerOptions!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!


### PR DESCRIPTION
Release v0.10.0 — TestPeer DI extensions (#104).

## Mechanical
- Directory.Build.props: 0.9.0 → 0.10.0
- Promote 3 TestPeer DI symbols (`InProcessFixpTestPeerServiceCollectionExtensions` + 2 ext methods) to Shipped
- CHANGELOG: stamp `[0.10.0] - 2026-05-02`

After merge: tag v0.10.0 + watch publish workflow + GitHub Release.