### PR TITLE
chore(release): v0.10.1 — doc cleanup + remove dead NotImpl catches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-05-02
+
+### Changed
+- Documentation cleanup: removed stale `<remarks>` blocks on `ISubmitOrder`, `IReplaceOrder`, `ICancelOrder`, `IKeepAliveScheduler`, `IRetransmitRequestHandler`, `FixpClientSession`, `FixpClientState`, `FixpClientStateMachine`, `NewOrderRequest`, `EntryPointClient.TerminateAsync`, `EntryPointClient.Events`, and `EntryPointClient.RaiseTerminated` that referred to wire-up as "follow-up PR" / "API surface only" — those features have been live since v0.5.0–v0.7.0. The new prose describes current behavior. No public API change.
+
+### Tests
+- Removed dead `catch (NotImplementedException)` swallows in `TestPeerScenarioTests`, `EndToEndSample`, and the `SubmitOrderAsync`/`CancelAsync`/`ReplaceAsync` paths — `SubmitAsync`/`CancelAsync`/`ReplaceAsync` have been wired since v0.5.0 and the catches were masking potential regressions.
+
 ## [0.10.0] - 2026-05-02
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- NuGet metadata shared by all packable projects. -->
-    <Version>0.10.0</Version>
+    <Version>0.10.1</Version>
     <Authors>pedrosakuma</Authors>
     <Company>pedrosakuma</Company>
     <Copyright>Copyright (c) pedrosakuma</Copyright>

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -597,7 +597,9 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
 
     /// <summary>
     /// Send a graceful <c>Terminate</c> to the peer and tear down the session.
-    /// API surface only — the wire-level encode lands in a follow-up PR (issue #6).
+    /// Records an <c>entrypoint.terminate</c> activity, increments the
+    /// terminations counter, and raises the <see cref="Terminated"/> event
+    /// before returning.
     /// </summary>
     public async Task TerminateAsync(TerminationCode code, CancellationToken ct = default)
     {
@@ -656,9 +658,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     }
 
     /// <summary>
-    /// Async stream of unsolicited events (ER/Reject/BusinessReject). The
-    /// typed event family lands with issue #9; today the stream completes
-    /// immediately.
+    /// Async stream of unsolicited events from the peer
+    /// (<see cref="OrderAccepted"/>, <see cref="OrderRejected"/>,
+    /// <see cref="OrderTrade"/>, <see cref="OrderCancelled"/>,
+    /// <see cref="OrderModified"/>, <see cref="BusinessReject"/>, etc.).
+    /// Backed by a bounded channel; consumers that fall behind block the
+    /// inbound decoder, so drain promptly.
     /// </summary>
     public async IAsyncEnumerable<EntryPointEvent> Events([EnumeratorCancellation] CancellationToken ct = default)
     {
@@ -687,9 +692,9 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     }
 
     /// <summary>
-    /// Test/internal hook — surface a <see cref="Terminated"/> notification
-    /// through the public event. Replaced by the real wire-level handler in
-    /// the follow-up implementation PR.
+    /// Internal hook used by <see cref="TerminateAsync"/> and the inbound
+    /// <c>Terminate</c> handler to surface a <see cref="Terminated"/>
+    /// notification through the public event.
     /// </summary>
     internal void RaiseTerminated(TerminationCode code, string? reason, bool initiatedByClient) =>
         Terminated?.Invoke(this, new TerminatedEventArgs(code, reason, initiatedByClient));

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -18,11 +18,6 @@ namespace B3.EntryPoint.Client.Fixp;
 /// pure <see cref="FixpClientStateMachine"/>, and exposes async hooks for the
 /// outer <see cref="EntryPointClient"/>.
 /// </summary>
-/// <remarks>
-/// Bootstrap scope: only Negotiate→NegotiateResponse and Establish→EstablishmentAck
-/// are implemented end-to-end. Heartbeats, Sequence/Retransmit, and the
-/// application-message flow ride on top of this in follow-up issues.
-/// </remarks>
 internal sealed class FixpClientSession : IAsyncDisposable
 {
     private const int SofhSize = SofhFrameReader.HeaderSize;

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientState.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientState.cs
@@ -2,9 +2,6 @@ namespace B3.EntryPoint.Client.Fixp;
 
 /// <summary>
 /// Client-side FIXP session state per B3 EntryPoint spec §4.5–§4.10.
-/// The bootstrap implementation models the path up to <see cref="Established"/>;
-/// <see cref="Suspended"/> handling and the full retransmission flow are tracked in
-/// follow-up issues.
 /// </summary>
 public enum FixpClientState
 {

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientStateMachine.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientStateMachine.cs
@@ -6,12 +6,6 @@ namespace B3.EntryPoint.Client.Fixp;
 /// transitions throw <see cref="InvalidFixpTransitionException"/> — callers that
 /// want lenient behavior should query <see cref="CanFire"/> first.
 /// </summary>
-/// <remarks>
-/// Implements the subset of the spec required for the bootstrap acceptance
-/// (Disconnected → TcpConnected → Negotiating → Negotiated → Establishing →
-/// Established, plus Terminate from any state). Suspended/recovery flow is
-/// modeled as a state but transitions into/out of it land in follow-up issues.
-/// </remarks>
 public sealed class FixpClientStateMachine
 {
     public FixpClientState State { get; private set; } = FixpClientState.Disconnected;

--- a/src/B3.EntryPoint.Client/Fixp/IKeepAliveScheduler.cs
+++ b/src/B3.EntryPoint.Client/Fixp/IKeepAliveScheduler.cs
@@ -7,10 +7,6 @@ namespace B3.EntryPoint.Client.Fixp;
 /// frames, and is the natural place to detect peer keep-alive timeouts and
 /// hand off to the §4.7 retransmit handler when a gap is detected.
 /// </summary>
-/// <remarks>
-/// API surface only — the wire-level send/receive loop is wired in a
-/// follow-up PR. See issue #3.
-/// </remarks>
 public interface IKeepAliveScheduler
 {
     /// <summary>Interval used for outbound <c>Sequence</c> frames.</summary>

--- a/src/B3.EntryPoint.Client/Fixp/IRetransmitRequestHandler.cs
+++ b/src/B3.EntryPoint.Client/Fixp/IRetransmitRequestHandler.cs
@@ -6,9 +6,6 @@ namespace B3.EntryPoint.Client.Fixp;
 /// <c>NotApplied</c> notifications from the peer. The §4.6 keep-alive scheduler
 /// drives gap detection and calls <see cref="RequestRetransmitAsync"/>.
 /// </summary>
-/// <remarks>
-/// API surface only — wire-level send/receive lands in a follow-up PR (issue #5).
-/// </remarks>
 public interface IRetransmitRequestHandler
 {
     event EventHandler<RetransmitRequestedEventArgs>? RetransmitRequested;

--- a/src/B3.EntryPoint.Client/ICancelOrder.cs
+++ b/src/B3.EntryPoint.Client/ICancelOrder.cs
@@ -6,9 +6,6 @@ namespace B3.EntryPoint.Client;
 /// Cancel previously submitted orders, individually or via mass action.
 /// Implemented by <see cref="EntryPointClient"/>.
 /// </summary>
-/// <remarks>
-/// API surface only — the SBE encoding lands in a follow-up PR (issue #8).
-/// </remarks>
 public interface ICancelOrder
 {
     /// <summary>Submit an <c>OrderCancelRequest</c>.</summary>

--- a/src/B3.EntryPoint.Client/IReplaceOrder.cs
+++ b/src/B3.EntryPoint.Client/IReplaceOrder.cs
@@ -7,9 +7,6 @@ namespace B3.EntryPoint.Client;
 /// Replace previously submitted orders. Implemented by
 /// <see cref="EntryPointClient"/>.
 /// </summary>
-/// <remarks>
-/// API surface only — the SBE encoding lands in a follow-up PR (issue #7).
-/// </remarks>
 public interface IReplaceOrder
 {
     /// <summary>Submit an <c>OrderCancelReplaceRequest</c>.</summary>

--- a/src/B3.EntryPoint.Client/ISubmitOrder.cs
+++ b/src/B3.EntryPoint.Client/ISubmitOrder.cs
@@ -8,10 +8,6 @@ namespace B3.EntryPoint.Client;
 /// <see cref="EntryPointClient"/> when the session profile is
 /// <c>SessionProfile.OrderEntry</c>.
 /// </summary>
-/// <remarks>
-/// API surface only — the SBE encoding and outbound sequencing land in a
-/// follow-up PR (issue #4).
-/// </remarks>
 public interface ISubmitOrder
 {
     /// <summary>Submit a <c>NewOrderSingle</c>.</summary>

--- a/src/B3.EntryPoint.Client/Models/OrderModels.cs
+++ b/src/B3.EntryPoint.Client/Models/OrderModels.cs
@@ -56,9 +56,10 @@ public enum AccountType : byte
 }
 
 /// <summary>
-/// Logical request shape for <c>NewOrderSingle</c> (schema §6). The library
-/// converts user-friendly fields (decimal <see cref="Price"/>) to wire
-/// encodings (price /10000 mantissa) when the SBE wiring lands.
+/// Logical request shape for <c>NewOrderSingle</c> (schema §6). The client
+/// converts user-friendly fields (decimal <see cref="Price"/>) to the wire
+/// encoding (fixed-point mantissa with exponent -4, i.e. <c>price × 10_000</c>)
+/// when serialising the SBE message.
 /// </summary>
 public sealed record NewOrderRequest
 {

--- a/tests/B3.EntryPoint.Client.Tests/TestPeerScenarioTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/TestPeerScenarioTests.cs
@@ -83,19 +83,15 @@ public class TestPeerScenarioTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await client.ConnectAsync(cts.Token);
 
-        try
+        await client.SubmitAsync(new NewOrderRequest
         {
-            await client.SubmitAsync(new NewOrderRequest
-            {
-                ClOrdID = (ClOrdID)123UL,
-                SecurityId = 1001,
-                Side = Side.Buy,
-                OrderType = OrderType.Limit,
-                Price = 10m,
-                OrderQty = 10,
-            }, cts.Token);
-        }
-        catch (NotImplementedException) { /* submit path not yet wired in some builds */ }
+            ClOrdID = (ClOrdID)123UL,
+            SecurityId = 1001,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            Price = 10m,
+            OrderQty = 10,
+        }, cts.Token);
 
         var drainCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
         var saw = false;
@@ -117,22 +113,16 @@ public class TestPeerScenarioTests
         Assert.NotNull(TestPeerScenarios.RejectAll());
     }
 
-    private static async Task SubmitOrderAsync(EntryPointClient client, ulong clOrdId, ulong securityId, ulong qty, decimal price, CancellationToken ct)
-    {
-        try
+    private static Task SubmitOrderAsync(EntryPointClient client, ulong clOrdId, ulong securityId, ulong qty, decimal price, CancellationToken ct)
+        => client.SubmitAsync(new NewOrderRequest
         {
-            await client.SubmitAsync(new NewOrderRequest
-            {
-                ClOrdID = (ClOrdID)clOrdId,
-                SecurityId = securityId,
-                Side = Side.Buy,
-                OrderType = OrderType.Limit,
-                Price = price,
-                OrderQty = qty,
-            }, ct);
-        }
-        catch (NotImplementedException) { /* submit path not yet wired in some builds */ }
-    }
+            ClOrdID = (ClOrdID)clOrdId,
+            SecurityId = securityId,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            Price = price,
+            OrderQty = qty,
+        }, ct);
 
     private static async Task<List<EntryPointEvent>> DrainAsync(EntryPointClient client, int expected, TimeSpan timeout)
     {
@@ -228,17 +218,13 @@ public class TestPeerScenarioTests
         using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await client.ConnectAsync(connectCts.Token);
 
-        try
+        await client.CancelAsync(new CancelOrderRequest
         {
-            await client.CancelAsync(new CancelOrderRequest
-            {
-                ClOrdID = (ClOrdID)801UL,
-                OrigClOrdID = (ClOrdID)800UL,
-                SecurityId = 2001UL,
-                Side = Side.Buy,
-            }, connectCts.Token);
-        }
-        catch (NotImplementedException) { }
+            ClOrdID = (ClOrdID)801UL,
+            OrigClOrdID = (ClOrdID)800UL,
+            SecurityId = 2001UL,
+            Side = Side.Buy,
+        }, connectCts.Token);
 
         var events = await DrainAsync(client, expected: 1, TimeSpan.FromSeconds(2));
         var rejected = events.OfType<OrderRejected>().FirstOrDefault();
@@ -259,17 +245,13 @@ public class TestPeerScenarioTests
         using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await client.ConnectAsync(connectCts.Token);
 
-        try
+        await client.CancelAsync(new CancelOrderRequest
         {
-            await client.CancelAsync(new CancelOrderRequest
-            {
-                ClOrdID = (ClOrdID)901UL,
-                OrigClOrdID = (ClOrdID)900UL,
-                SecurityId = 3001UL,
-                Side = Side.Sell,
-            }, connectCts.Token);
-        }
-        catch (NotImplementedException) { }
+            ClOrdID = (ClOrdID)901UL,
+            OrigClOrdID = (ClOrdID)900UL,
+            SecurityId = 3001UL,
+            Side = Side.Sell,
+        }, connectCts.Token);
 
         var events = await DrainAsync(client, expected: 1, TimeSpan.FromSeconds(2));
         Assert.Contains(events, e => e is OrderCancelled);
@@ -287,20 +269,16 @@ public class TestPeerScenarioTests
         using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await client.ConnectAsync(connectCts.Token);
 
-        try
+        await client.ReplaceAsync(new ReplaceOrderRequest
         {
-            await client.ReplaceAsync(new ReplaceOrderRequest
-            {
-                ClOrdID = (ClOrdID)1101UL,
-                OrigClOrdID = (ClOrdID)1100UL,
-                SecurityId = 4001UL,
-                Side = Side.Buy,
-                OrderType = OrderType.Limit,
-                Price = 12.34m,
-                OrderQty = 10UL,
-            }, connectCts.Token);
-        }
-        catch (NotImplementedException) { }
+            ClOrdID = (ClOrdID)1101UL,
+            OrigClOrdID = (ClOrdID)1100UL,
+            SecurityId = 4001UL,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            Price = 12.34m,
+            OrderQty = 10UL,
+        }, connectCts.Token);
 
         var events = await DrainAsync(client, expected: 1, TimeSpan.FromSeconds(2));
         var rejected = events.OfType<OrderRejected>().FirstOrDefault();

--- a/tests/Samples/B3.EntryPoint.Client.TestPeer.Sample/EndToEndSample.cs
+++ b/tests/Samples/B3.EntryPoint.Client.TestPeer.Sample/EndToEndSample.cs
@@ -36,20 +36,16 @@ public class EndToEndSample
         await client.ConnectAsync(cts.Token);
         Assert.Equal(FixpClientState.Established, client.State);
 
-        try
+        var clOrdId = await client.SubmitAsync(new NewOrderRequest
         {
-            var clOrdId = await client.SubmitAsync(new NewOrderRequest
-            {
-                ClOrdID = (ClOrdID)42UL,
-                SecurityId = 1001,
-                Side = Side.Buy,
-                OrderType = OrderType.Limit,
-                Price = 12.34m,
-                OrderQty = 100,
-            }, cts.Token);
-            Assert.Equal(42UL, clOrdId.Value);
-        }
-        catch (NotImplementedException) { /* submit path may still be wiring */ }
+            ClOrdID = (ClOrdID)42UL,
+            SecurityId = 1001,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            Price = 12.34m,
+            OrderQty = 100,
+        }, cts.Token);
+        Assert.Equal(42UL, clOrdId.Value);
 
         await client.TerminateAsync(B3.EntryPoint.Client.TerminationCode.Finished, cts.Token);
     }


### PR DESCRIPTION
Patch release; no behaviour change.

## Documentation cleanup
Removed stale `<remarks>API surface only — wire-level lands in follow-up PR` notes that referred to features which have been live since v0.5.0–v0.7.0. Sites cleaned:

- `ISubmitOrder`, `IReplaceOrder`, `ICancelOrder`
- `IKeepAliveScheduler`, `IRetransmitRequestHandler`
- `FixpClientSession`, `FixpClientState`, `FixpClientStateMachine`
- `NewOrderRequest` (doc said decimal→mantissa conversion was future work)
- `EntryPointClient.TerminateAsync`, `EntryPointClient.Events`, `EntryPointClient.RaiseTerminated`

Comments were misleading and generated false 'backlog' signals during code review.

## Dead test catches removed
`SubmitAsync`/`CancelAsync`/`ReplaceAsync` are wired since v0.5.0. Removed dead `catch (NotImplementedException) { }` swallows that masked potential regressions:

- `tests/B3.EntryPoint.Client.Tests/TestPeerScenarioTests.cs` (5 sites)
- `tests/Samples/B3.EntryPoint.Client.TestPeer.Sample/EndToEndSample.cs`

## Tests
- 132 unit + 8 conformance + 2 sample tests passing.
- Format clean.

## Versioning
Patch bump 0.10.0 → 0.10.1. No public API change. After merge: tag v0.10.1, watch publish workflow.