### PR TITLE
feat(testpeer): outbound frame fault-injection hooks (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- TestPeer (#113): `ITestPeerScenario.OnOutboundFrame(OutboundFrameContext)` default-interface hook plus `OutboundFrameAction` discriminated union (`Send` / `Drop` / `SkipSeq` / `DelayThen`) for injecting drops, sequence gaps, and per-frame delays into the peer's outbound app-frame path. `OutboundFrameContext` carries `TemplateId`, `MsgSeqNum`, and `FrameLength`. New `TestPeerScenarios.WithSequenceFaults(inner, schedule)` helper applies a deterministic `Dictionary<int, OutboundFrameAction>` schedule (1-based outbound app-frame ordinal). `docs/TEST-PEER.md` gets a "Sequence-fault simulation" section.
+
 ## [0.10.1] - 2026-05-02
 
 ### Changed

--- a/docs/TEST-PEER.md
+++ b/docs/TEST-PEER.md
@@ -137,10 +137,40 @@ await host.StopAsync(ct); // hosted service calls peer.StopAsync(ct).
 
 A working sample lives in `tests/Samples/B3.EntryPoint.Client.TestPeer.Sample/HostedSample.cs`.
 
+## Sequence-fault simulation
+
+Application frames sent by the peer (ExecutionReports, BusinessReject,
+OrderMassActionReport, …) flow through the
+`ITestPeerScenario.OnOutboundFrame` hook. Returning an
+`OutboundFrameAction.Drop` skips the wire write entirely while still
+advancing the peer's outbound sequence counter, producing a one-message
+gap; `OutboundFrameAction.SkipSeq(n)` widens that gap by `n` more
+sequence numbers; `OutboundFrameAction.DelayThen(delay, inner)` defers
+the action by `delay` before re-evaluating it.
+
+`TestPeerScenarios.WithSequenceFaults` ships a deterministic schedule
+helper that wraps an inner scenario and applies a fault per 1-based
+outbound app-frame ordinal:
+
+```csharp
+var schedule = new Dictionary<int, OutboundFrameAction>
+{
+    [3] = new OutboundFrameAction.Drop(),       // drop the 3rd ER
+    [5] = new OutboundFrameAction.SkipSeq(2),   // create a 3-msg gap
+};
+var scenario = TestPeerScenarios.WithSequenceFaults(
+    TestPeerScenarios.AcceptAll, schedule);
+await using var peer = new InProcessFixpTestPeer(
+    new TestPeerOptions { Scenario = scenario });
+```
+
+Use this to drive `IRetransmitRequestHandler` and `KeepAliveScheduler`
+under realistic loss conditions without touching transport code.
+
 ## Limitations
 
-- Drop / sequence-gap injection is not yet implemented; only
-  `ResponseLatency` is wired today.
+- Inbound sequence-gap injection (forcing the peer to *receive* with gaps)
+  is out of scope; use the §4.7 conformance suite for that path.
 
 These will land in subsequent versions without changing the public API
 shape established here.

--- a/src/B3.EntryPoint.Client.TestPeer/ITestPeerScenario.cs
+++ b/src/B3.EntryPoint.Client.TestPeer/ITestPeerScenario.cs
@@ -40,6 +40,64 @@ public interface ITestPeerScenario
     /// Default: <see cref="ModifyResponse.Accept"/> (emit <c>ExecutionReport_Modify</c>).
     /// </summary>
     ModifyResponse OnModify(ModifyContext context) => new ModifyResponse.Accept();
+
+    /// <summary>
+    /// Decide what the peer does for an outbound application frame. Fires
+    /// after the frame is encoded but before it hits the wire. The default
+    /// is <see cref="OutboundFrameAction.Send"/>; implementations can return
+    /// <see cref="OutboundFrameAction.Drop"/> (silently swallow the frame —
+    /// the next frame will arrive with a <c>MsgSeqNum</c> gap, exercising
+    /// the client's gap-detection / retransmit path) or
+    /// <see cref="OutboundFrameAction.SkipSeq"/> (drop the frame *and*
+    /// advance the peer's outbound seq counter further to widen the gap).
+    /// <para>
+    /// Wrapping with <see cref="OutboundFrameAction.DelayThen"/> applies a
+    /// post-encode delay before evaluating the inner action.
+    /// </para>
+    /// </summary>
+    OutboundFrameAction OnOutboundFrame(OutboundFrameContext context)
+        => new OutboundFrameAction.Send();
+}
+
+/// <summary>Decoded summary of an outbound application frame about to be sent.</summary>
+/// <param name="TemplateId">SBE template id (e.g. 201 for ExecutionReport_New, 203 for ExecutionReport_Trade).</param>
+/// <param name="MsgSeqNum">FIXP <c>MsgSeqNum</c> assigned to this frame.</param>
+/// <param name="FrameLength">Total frame length in bytes (SOFH + SBE header + payload + var-data).</param>
+public readonly record struct OutboundFrameContext(uint TemplateId, ulong MsgSeqNum, int FrameLength);
+
+/// <summary>
+/// Discriminated union describing what <see cref="InProcessFixpTestPeer"/>
+/// does with an outbound application frame after
+/// <see cref="ITestPeerScenario.OnOutboundFrame"/> is invoked.
+/// </summary>
+public abstract record OutboundFrameAction
+{
+    private OutboundFrameAction() { }
+
+    /// <summary>Send the frame as encoded (default behaviour).</summary>
+    public sealed record Send : OutboundFrameAction;
+
+    /// <summary>
+    /// Silently drop the frame. The peer's <c>MsgSeqNum</c> counter has
+    /// already been incremented at the call site, so the next frame will
+    /// arrive at the client with a one-step gap.
+    /// </summary>
+    public sealed record Drop : OutboundFrameAction;
+
+    /// <summary>
+    /// Drop the frame and additionally advance the peer's outbound
+    /// <c>MsgSeqNum</c> counter by <paramref name="Skip"/>. The next frame
+    /// arrives at the client with a gap of <c>1 + Skip</c> messages.
+    /// </summary>
+    /// <param name="Skip">Extra seq numbers to advance after dropping. Must be &gt;= 1.</param>
+    public sealed record SkipSeq(uint Skip) : OutboundFrameAction;
+
+    /// <summary>
+    /// Wait <paramref name="Delay"/> then apply <paramref name="Then"/>.
+    /// Useful to test client-side timeouts or out-of-order arrival relative
+    /// to other frames.
+    /// </summary>
+    public sealed record DelayThen(TimeSpan Delay, OutboundFrameAction Then) : OutboundFrameAction;
 }
 
 /// <summary>Decoded summary of an inbound NewOrderSingle.</summary>
@@ -185,6 +243,28 @@ public static class TestPeerScenarios
     public static ITestPeerScenario RejectAll(string reason = "rejected by test peer") =>
         new RejectAllScenario(reason);
 
+    /// <summary>
+    /// Wraps an <paramref name="inner"/> scenario and applies a deterministic
+    /// outbound fault schedule on top of its app-frame responses. Each entry
+    /// in <paramref name="schedule"/> maps a 1-based outbound app-frame index
+    /// to the <see cref="OutboundFrameAction"/> the peer should apply for
+    /// that frame; frames whose index is not in the map use
+    /// <see cref="OutboundFrameAction.Send"/>.
+    /// <para>
+    /// The frame index counts only application messages emitted by the peer
+    /// (those routed through the <see cref="ITestPeerScenario.OnOutboundFrame"/>
+    /// hook), so a schedule of <c>{ 2 = Drop }</c> drops the second app
+    /// frame regardless of session-layer Negotiate/Establish/Sequence
+    /// traffic.
+    /// </para>
+    /// </summary>
+    public static ITestPeerScenario WithSequenceFaults(ITestPeerScenario inner, IReadOnlyDictionary<int, OutboundFrameAction> schedule)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(schedule);
+        return new SequenceFaultScenario(inner, schedule);
+    }
+
     private sealed class AcceptAllScenario : ITestPeerScenario
     {
         public NewOrderResponse OnNewOrder(NewOrderContext context) => new NewOrderResponse.AcceptAsNew();
@@ -202,5 +282,28 @@ public static class TestPeerScenarios
         public NewOrderResponse OnNewOrder(NewOrderContext context) => new NewOrderResponse.RejectBusiness(_reason);
         public CancelResponse OnCancel(CancelContext context) => new CancelResponse.Reject(_reason);
         public ModifyResponse OnModify(ModifyContext context) => new ModifyResponse.Reject(_reason);
+    }
+
+    private sealed class SequenceFaultScenario : ITestPeerScenario
+    {
+        private readonly ITestPeerScenario _inner;
+        private readonly IReadOnlyDictionary<int, OutboundFrameAction> _schedule;
+        private int _frameCount;
+
+        public SequenceFaultScenario(ITestPeerScenario inner, IReadOnlyDictionary<int, OutboundFrameAction> schedule)
+        {
+            _inner = inner;
+            _schedule = schedule;
+        }
+
+        public NewOrderResponse OnNewOrder(NewOrderContext context) => _inner.OnNewOrder(context);
+        public CancelResponse OnCancel(CancelContext context) => _inner.OnCancel(context);
+        public ModifyResponse OnModify(ModifyContext context) => _inner.OnModify(context);
+
+        public OutboundFrameAction OnOutboundFrame(OutboundFrameContext context)
+        {
+            var index = System.Threading.Interlocked.Increment(ref _frameCount);
+            return _schedule.TryGetValue(index, out var action) ? action : new OutboundFrameAction.Send();
+        }
     }
 }

--- a/src/B3.EntryPoint.Client.TestPeer/InProcessFixpTestPeer.cs
+++ b/src/B3.EntryPoint.Client.TestPeer/InProcessFixpTestPeer.cs
@@ -718,7 +718,39 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
             return;
         var totalSize = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + bytesWritten;
         SofhFrameWriter.WriteHeader(buffer.AsSpan(0, totalSize), checked((ushort)totalSize));
-        await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
+
+        // Application frames go through the OnOutboundFrame hook so scenarios
+        // can simulate session-layer faults (drop / seq-gap / delay).
+        // Callers increment state.OutSeq before invoking this helper, so the
+        // MsgSeqNum carried on the wire is state.OutSeq - 1.
+        var ctx = new OutboundFrameContext(templateId, state.OutSeq - 1u, totalSize);
+        var action = _options.Scenario.OnOutboundFrame(ctx);
+        await ApplyOutboundActionAsync(action, stream, state, buffer, totalSize, ct).ConfigureAwait(false);
+    }
+
+    private async Task ApplyOutboundActionAsync(OutboundFrameAction action, Stream stream, ConnectionState state, byte[] buffer, int totalSize, CancellationToken ct)
+    {
+        switch (action)
+        {
+            case OutboundFrameAction.Send:
+                await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
+                break;
+            case OutboundFrameAction.Drop:
+                // Frame is dropped; OutSeq has already advanced at the call
+                // site so the next frame will create a one-message gap.
+                break;
+            case OutboundFrameAction.SkipSeq skip:
+                state.OutSeq += skip.Skip;
+                break;
+            case OutboundFrameAction.DelayThen delayThen:
+                if (delayThen.Delay > TimeSpan.Zero)
+                    await Task.Delay(delayThen.Delay, ct).ConfigureAwait(false);
+                await ApplyOutboundActionAsync(delayThen.Then, stream, state, buffer, totalSize, ct).ConfigureAwait(false);
+                break;
+            default:
+                await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
+                break;
+        }
     }
 
     private Task SendAppFrameAsync(Stream stream, ConnectionState state, ushort templateId, int payloadSize, EncodeDelegate encode, CancellationToken ct)

--- a/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
@@ -1,1 +1,78 @@
 #nullable enable
+B3.EntryPoint.Client.TestPeer.ITestPeerScenario.OnOutboundFrame(B3.EntryPoint.Client.TestPeer.OutboundFrameContext context) -> B3.EntryPoint.Client.TestPeer.OutboundFrameAction!
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.Deconstruct(out System.TimeSpan Delay, out B3.EntryPoint.Client.TestPeer.OutboundFrameAction! Then) -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.Delay.get -> System.TimeSpan
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.Delay.init -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.DelayThen(System.TimeSpan Delay, B3.EntryPoint.Client.TestPeer.OutboundFrameAction! Then) -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.Equals(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen? other) -> bool
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.Then.get -> B3.EntryPoint.Client.TestPeer.OutboundFrameAction!
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.Then.init -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop.Drop() -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop.Equals(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop? other) -> bool
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.OutboundFrameAction(B3.EntryPoint.Client.TestPeer.OutboundFrameAction! original) -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send.Equals(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send? other) -> bool
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send.Send() -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.Deconstruct(out uint Skip) -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.Equals(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq? other) -> bool
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.Skip.get -> uint
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.Skip.init -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.SkipSeq(uint Skip) -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameContext
+B3.EntryPoint.Client.TestPeer.OutboundFrameContext.Deconstruct(out uint TemplateId, out ulong MsgSeqNum, out int FrameLength) -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameContext.Equals(B3.EntryPoint.Client.TestPeer.OutboundFrameContext other) -> bool
+B3.EntryPoint.Client.TestPeer.OutboundFrameContext.FrameLength.get -> int
+B3.EntryPoint.Client.TestPeer.OutboundFrameContext.FrameLength.init -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameContext.MsgSeqNum.get -> ulong
+B3.EntryPoint.Client.TestPeer.OutboundFrameContext.MsgSeqNum.init -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameContext.OutboundFrameContext() -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameContext.OutboundFrameContext(uint TemplateId, ulong MsgSeqNum, int FrameLength) -> void
+B3.EntryPoint.Client.TestPeer.OutboundFrameContext.TemplateId.get -> uint
+B3.EntryPoint.Client.TestPeer.OutboundFrameContext.TemplateId.init -> void
+abstract B3.EntryPoint.Client.TestPeer.OutboundFrameAction.<Clone>$() -> B3.EntryPoint.Client.TestPeer.OutboundFrameAction!
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.<Clone>$() -> B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen!
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.Equals(object? obj) -> bool
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.ToString() -> string!
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop.<Clone>$() -> B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop!
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop.Equals(object? obj) -> bool
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop.ToString() -> string!
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Equals(object? obj) -> bool
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send.<Clone>$() -> B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send!
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send.Equals(object? obj) -> bool
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send.ToString() -> string!
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.<Clone>$() -> B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq!
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.Equals(object? obj) -> bool
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.GetHashCode() -> int
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.ToString() -> string!
+override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.ToString() -> string!
+override B3.EntryPoint.Client.TestPeer.OutboundFrameContext.GetHashCode() -> int
+override sealed B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.Equals(B3.EntryPoint.Client.TestPeer.OutboundFrameAction? other) -> bool
+override sealed B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop.Equals(B3.EntryPoint.Client.TestPeer.OutboundFrameAction? other) -> bool
+override sealed B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send.Equals(B3.EntryPoint.Client.TestPeer.OutboundFrameAction? other) -> bool
+override sealed B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.Equals(B3.EntryPoint.Client.TestPeer.OutboundFrameAction? other) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.operator !=(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen? left, B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen? right) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.operator ==(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen? left, B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen? right) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop.operator !=(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop? left, B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop? right) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop.operator ==(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop? left, B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Drop? right) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send.operator !=(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send? left, B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send? right) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send.operator ==(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send? left, B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Send? right) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.operator !=(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq? left, B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq? right) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq.operator ==(B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq? left, B3.EntryPoint.Client.TestPeer.OutboundFrameAction.SkipSeq? right) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameAction.operator !=(B3.EntryPoint.Client.TestPeer.OutboundFrameAction? left, B3.EntryPoint.Client.TestPeer.OutboundFrameAction? right) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameAction.operator ==(B3.EntryPoint.Client.TestPeer.OutboundFrameAction? left, B3.EntryPoint.Client.TestPeer.OutboundFrameAction? right) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameContext.operator !=(B3.EntryPoint.Client.TestPeer.OutboundFrameContext left, B3.EntryPoint.Client.TestPeer.OutboundFrameContext right) -> bool
+static B3.EntryPoint.Client.TestPeer.OutboundFrameContext.operator ==(B3.EntryPoint.Client.TestPeer.OutboundFrameContext left, B3.EntryPoint.Client.TestPeer.OutboundFrameContext right) -> bool
+static B3.EntryPoint.Client.TestPeer.TestPeerScenarios.WithSequenceFaults(B3.EntryPoint.Client.TestPeer.ITestPeerScenario! inner, System.Collections.Generic.IReadOnlyDictionary<int, B3.EntryPoint.Client.TestPeer.OutboundFrameAction!>! schedule) -> B3.EntryPoint.Client.TestPeer.ITestPeerScenario!
+virtual B3.EntryPoint.Client.TestPeer.OutboundFrameAction.EqualityContract.get -> System.Type!
+virtual B3.EntryPoint.Client.TestPeer.OutboundFrameAction.Equals(B3.EntryPoint.Client.TestPeer.OutboundFrameAction? other) -> bool
+virtual B3.EntryPoint.Client.TestPeer.OutboundFrameAction.PrintMembers(System.Text.StringBuilder! builder) -> bool
+~override B3.EntryPoint.Client.TestPeer.OutboundFrameContext.Equals(object obj) -> bool
+~override B3.EntryPoint.Client.TestPeer.OutboundFrameContext.ToString() -> string

--- a/tests/B3.EntryPoint.Client.Tests/TestPeerScenarioTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/TestPeerScenarioTests.cs
@@ -294,4 +294,127 @@ public class TestPeerScenarioTests
         public NewOrderResponse OnNewOrder(NewOrderContext context) =>
             new NewOrderResponse.AcceptAndFill { FillQty = _fillQty, FillPrice = _fillPrice };
     }
+
+    private sealed class CapturingScenario : ITestPeerScenario
+    {
+        private readonly ITestPeerScenario _inner;
+        public List<OutboundFrameContext> Frames { get; } = new();
+
+        public CapturingScenario(ITestPeerScenario inner) { _inner = inner; }
+        public NewOrderResponse OnNewOrder(NewOrderContext context) => _inner.OnNewOrder(context);
+        public CancelResponse OnCancel(CancelContext context) => _inner.OnCancel(context);
+        public ModifyResponse OnModify(ModifyContext context) => _inner.OnModify(context);
+
+        public OutboundFrameAction OnOutboundFrame(OutboundFrameContext context)
+        {
+            lock (Frames) Frames.Add(context);
+            return new OutboundFrameAction.Send();
+        }
+    }
+
+    [Fact]
+    public async Task OnOutboundFrame_InvokedForEachAppMessage_WithMonotonicSeqNums()
+    {
+        var capture = new CapturingScenario(TestPeerScenarios.AcceptAll);
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions { Scenario = capture });
+        peer.Start();
+
+        await using var client = new EntryPointClient(ClientOptions(peer));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        await SubmitOrderAsync(client, 123UL, 1001UL, qty: 1UL, price: 10m, cts.Token);
+        await SubmitOrderAsync(client, 124UL, 1001UL, qty: 1UL, price: 10m, cts.Token);
+
+        await DrainAsync(client, expected: 2, TimeSpan.FromSeconds(2));
+
+        List<OutboundFrameContext> snapshot;
+        lock (capture.Frames) snapshot = capture.Frames.ToList();
+
+        Assert.True(snapshot.Count >= 2, $"expected ≥2 outbound app frames, got {snapshot.Count}");
+        for (int i = 1; i < snapshot.Count; i++)
+            Assert.Equal(snapshot[i - 1].MsgSeqNum + 1, snapshot[i].MsgSeqNum);
+        Assert.All(snapshot, c => Assert.True(c.FrameLength > 0));
+    }
+
+    [Fact]
+    public async Task WithSequenceFaults_DropFirstFrame_SuppressesInboundEvent()
+    {
+        var schedule = new Dictionary<int, OutboundFrameAction>
+        {
+            [1] = new OutboundFrameAction.Drop(),
+        };
+        var scenario = TestPeerScenarios.WithSequenceFaults(TestPeerScenarios.AcceptAll, schedule);
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions { Scenario = scenario });
+        peer.Start();
+
+        await using var client = new EntryPointClient(ClientOptions(peer));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        await SubmitOrderAsync(client, 200UL, 1001UL, qty: 1UL, price: 10m, cts.Token);
+        // No second order — only frame is the dropped ER.
+        var events = await DrainAsync(client, expected: 1, TimeSpan.FromMilliseconds(400));
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public async Task WithSequenceFaults_SkipSeq_AdvancesPeerOutboundCounter()
+    {
+        var capture = new CapturingScenario(TestPeerScenarios.AcceptAll);
+        // Capturing wrapper records context for every frame; we layer a SkipSeq
+        // on the first frame which should bump OutSeq by 5 — the second frame's
+        // MsgSeqNum should therefore jump by 6 (1 from first send + 5 skipped).
+        var inner = new ChainedScenario(capture, new Dictionary<int, OutboundFrameAction>
+        {
+            [1] = new OutboundFrameAction.SkipSeq(5),
+        });
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions { Scenario = inner });
+        peer.Start();
+
+        await using var client = new EntryPointClient(ClientOptions(peer));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        await SubmitOrderAsync(client, 300UL, 1001UL, qty: 1UL, price: 10m, cts.Token);
+        await SubmitOrderAsync(client, 301UL, 1001UL, qty: 1UL, price: 10m, cts.Token);
+
+        // Best effort drain — second event may not be delivered to client because
+        // SkipSeq creates a wire-level seq jump; the assertion below is on the
+        // peer-side capture, not client events.
+        try { await DrainAsync(client, expected: 2, TimeSpan.FromMilliseconds(400)); }
+        catch (OperationCanceledException) { }
+
+        List<OutboundFrameContext> snapshot;
+        lock (capture.Frames) snapshot = capture.Frames.ToList();
+
+        Assert.True(snapshot.Count >= 2);
+        var jump = snapshot[1].MsgSeqNum - snapshot[0].MsgSeqNum;
+        Assert.Equal(6UL, jump);
+    }
+
+    private sealed class ChainedScenario : ITestPeerScenario
+    {
+        private readonly ITestPeerScenario _capture;
+        private readonly IReadOnlyDictionary<int, OutboundFrameAction> _schedule;
+        private int _frameCount;
+
+        public ChainedScenario(ITestPeerScenario capture, IReadOnlyDictionary<int, OutboundFrameAction> schedule)
+        {
+            _capture = capture;
+            _schedule = schedule;
+        }
+
+        public NewOrderResponse OnNewOrder(NewOrderContext context) => _capture.OnNewOrder(context);
+        public CancelResponse OnCancel(CancelContext context) => _capture.OnCancel(context);
+        public ModifyResponse OnModify(ModifyContext context) => _capture.OnModify(context);
+
+        public OutboundFrameAction OnOutboundFrame(OutboundFrameContext context)
+        {
+            _capture.OnOutboundFrame(context);
+            var idx = System.Threading.Interlocked.Increment(ref _frameCount);
+            return _schedule.TryGetValue(idx, out var a) ? a : new OutboundFrameAction.Send();
+        }
+    }
 }


### PR DESCRIPTION
Closes #113.

Adds the first slice of the v0.11.0 plan: outbound frame fault-injection on the in-process test peer.

## Public API additions (TestPeer)
- `ITestPeerScenario.OnOutboundFrame(OutboundFrameContext) -> OutboundFrameAction` (DIM, default returns `Send`)
- `OutboundFrameContext` record (TemplateId, MsgSeqNum, FrameLength)
- `OutboundFrameAction` discriminated union: `Send` | `Drop` | `SkipSeq(uint)` | `DelayThen(TimeSpan, OutboundFrameAction)`
- `TestPeerScenarios.WithSequenceFaults(inner, schedule)` deterministic helper

## Wire-up
`InProcessFixpTestPeer.SendAppFrameAsync` now invokes the hook between encode and write, dispatching via `ApplyOutboundActionAsync`. `OutSeq` is already incremented at every call site before `SendAppFrameAsync` runs, so `Drop` naturally produces a one-message wire gap and `SkipSeq(n)` widens it. Session-layer frames (Negotiate/Establish/Sequence/Retransmission) bypass the hook because they call `SendFrameAsync` directly — fault injection applies only to app frames, as intended.

## Tests
- `OnOutboundFrame_InvokedForEachAppMessage_WithMonotonicSeqNums`
- `WithSequenceFaults_DropFirstFrame_SuppressesInboundEvent`
- `WithSequenceFaults_SkipSeq_AdvancesPeerOutboundCounter`

All 135 unit + 2 sample tests pass; 8 conformance tests still skipped (covered by #114).

## Docs
- `docs/TEST-PEER.md` — new "Sequence-fault simulation" section.
- CHANGELOG `[Unreleased]` entry.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>