### PR TITLE
feat(testpeer,conformance): reject + negative-path coverage (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- TestPeer (#114): peer-side support for negative-path conformance — `TestPeerOptions.EstablishRejectAfter` (+ `EstablishRejectCodeOverride`) makes the peer respond to the N-th and subsequent `Establish` frames with `EstablishReject` instead of `EstablishmentAck`; `TestPeerOptions.RetransmitRejectCode` makes the peer answer `RetransmitRequest` with `RetransmitReject` carrying the configured code; `InProcessFixpTestPeer.InjectNotAppliedAsync(fromSeqNo, count, ct)` writes a session-layer `NotApplied` frame to every established connection (returns the count of writes).
+- Conformance (#114): six new `[ConformanceFact]`/`[TestPeerOnlyConformanceFact]` tests covering `BusinessReject` text round-trip, `ExecutionReport_Reject` for cancel and replace, reconnect rejection (`FixpRejectedException` from `EstablishReject(INVALID_SESSIONVERID)`), `RetransmitReject`, and `NotApplied`.
 - TestPeer (#113): `ITestPeerScenario.OnOutboundFrame(OutboundFrameContext)` default-interface hook plus `OutboundFrameAction` discriminated union (`Send` / `Drop` / `SkipSeq` / `DelayThen`) for injecting drops, sequence gaps, and per-frame delays into the peer's outbound app-frame path. `OutboundFrameContext` carries `TemplateId`, `MsgSeqNum`, and `FrameLength`. New `TestPeerScenarios.WithSequenceFaults(inner, schedule)` helper applies a deterministic `Dictionary<int, OutboundFrameAction>` schedule (1-based outbound app-frame ordinal). `docs/TEST-PEER.md` gets a "Sequence-fault simulation" section.
+
 
 ## [0.10.1] - 2026-05-02
 

--- a/src/B3.EntryPoint.Client.TestPeer/InProcessFixpTestPeer.cs
+++ b/src/B3.EntryPoint.Client.TestPeer/InProcessFixpTestPeer.cs
@@ -24,7 +24,9 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
     private readonly TcpListener _listener;
     private readonly CancellationTokenSource _cts = new();
     private readonly List<Task> _connections = new();
+    private readonly List<ActiveConnection> _activeConnections = new();
     private readonly TestPeerOptions _options;
+    private int _establishAttempts;
     private Task? _acceptLoop;
 
     public InProcessFixpTestPeer() : this(new TestPeerOptions()) { }
@@ -107,6 +109,8 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         public CancellationTokenSource? KeepAliveCts;
         public readonly SemaphoreSlim SendLock = new(1, 1);
     }
+
+    private sealed record ActiveConnection(Stream Stream, ConnectionState State, B3.Entrypoint.Fixp.Sbe.V6.SessionID SessionId);
 
     /// <summary>
     /// Single point of egress for every outbound frame. Serializes writes per
@@ -211,6 +215,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         {
             try { state.KeepAliveCts?.Cancel(); } catch { }
             state.KeepAliveCts?.Dispose();
+            lock (_activeConnections) _activeConnections.RemoveAll(c => ReferenceEquals(c.State, state));
         }
     }
 
@@ -367,6 +372,13 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
             return;
         ref readonly var req = ref reader.Data;
 
+        var attempt = System.Threading.Interlocked.Increment(ref _establishAttempts);
+        if (_options.EstablishRejectAfter is int threshold && attempt >= threshold)
+        {
+            await SendEstablishRejectAsync(stream, state, req.SessionID, req.SessionVerID, req.Timestamp, _options.EstablishRejectCodeOverride, ct).ConfigureAwait(false);
+            return;
+        }
+
         var totalSize = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + EstablishAckData.MESSAGE_SIZE;
         var buffer = new byte[totalSize];
         SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
@@ -382,10 +394,14 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
             LastIncomingSeqNo = new SeqNum(req.NextSeqNo.Value > 0u ? req.NextSeqNo.Value - 1u : 0u),
         };
         var keepAliveMs = req.KeepAliveInterval.Time;
+        var sessionIdLocal = req.SessionID;
         if (!ack.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
             return;
 
         await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
+
+        var entry = new ActiveConnection(stream, state, sessionIdLocal);
+        lock (_activeConnections) _activeConnections.Add(entry);
 
         // Spec §4.6: peer-side keep-alive. Emit Sequence frames at the
         // negotiated interval so the client can observe inbound heartbeats.
@@ -394,6 +410,26 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
             state.KeepAliveCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             _ = Task.Run(() => PeerSequenceLoopAsync(stream, state, TimeSpan.FromMilliseconds(keepAliveMs), state.KeepAliveCts.Token));
         }
+    }
+
+    private async Task SendEstablishRejectAsync(Stream stream, ConnectionState state, B3.Entrypoint.Fixp.Sbe.V6.SessionID sessionId, B3.Entrypoint.Fixp.Sbe.V6.SessionVerID sessionVerId, B3.Entrypoint.Fixp.Sbe.V6.UTCTimestampNanos requestTs, B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode code, CancellationToken ct)
+    {
+        var totalSize = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + EstablishRejectData.MESSAGE_SIZE;
+        var buffer = new byte[totalSize];
+        SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
+        EstablishRejectData.WriteHeader(buffer.AsSpan(SofhFrameReader.HeaderSize));
+
+        var msg = new EstablishRejectData
+        {
+            SessionID = sessionId,
+            SessionVerID = sessionVerId,
+            RequestTimestamp = requestTs,
+            EstablishmentRejectCode = code,
+        };
+        msg.SetLastIncomingSeqNo(0u);
+        if (!msg.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
+            return;
+        await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
     }
 
     private async Task PeerSequenceLoopAsync(Stream stream, ConnectionState state, TimeSpan interval, CancellationToken ct)
@@ -672,6 +708,12 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         var requestTs = reader.Data.Timestamp;
         var fromSeqNo = reader.Data.FromSeqNo;
 
+        if (_options.RetransmitRejectCode is { } rejectCode)
+        {
+            await SendRetransmitRejectAsync(stream, state, sessionId, requestTs, rejectCode, ct).ConfigureAwait(false);
+            return;
+        }
+
         var totalSize = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + RetransmissionData.MESSAGE_SIZE;
         var buffer = new byte[totalSize];
         SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
@@ -688,6 +730,61 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
             return;
 
         await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
+    }
+
+    private async Task SendRetransmitRejectAsync(Stream stream, ConnectionState state, B3.Entrypoint.Fixp.Sbe.V6.SessionID sessionId, B3.Entrypoint.Fixp.Sbe.V6.UTCTimestampNanos requestTs, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode code, CancellationToken ct)
+    {
+        var totalSize = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + RetransmitRejectData.MESSAGE_SIZE;
+        var buffer = new byte[totalSize];
+        SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
+        RetransmitRejectData.WriteHeader(buffer.AsSpan(SofhFrameReader.HeaderSize));
+
+        var msg = new RetransmitRejectData
+        {
+            SessionID = sessionId,
+            RequestTimestamp = requestTs,
+            RetransmitRejectCode = code,
+        };
+        if (!msg.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
+            return;
+        await SendFrameAsync(stream, state, buffer, totalSize, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sends a session-layer <c>NotApplied</c> frame on every currently
+    /// established connection. Used by negative-path conformance/unit tests
+    /// to simulate the server informing the client about messages it could
+    /// not apply (idempotency / format violation). Returns the number of
+    /// connections the frame was written to.
+    /// </summary>
+    public async Task<int> InjectNotAppliedAsync(uint fromSeqNo, uint count, CancellationToken ct = default)
+    {
+        ActiveConnection[] snapshot;
+        lock (_activeConnections) snapshot = _activeConnections.ToArray();
+
+        var totalSize = SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE + NotAppliedData.MESSAGE_SIZE;
+        var sent = 0;
+        foreach (var c in snapshot)
+        {
+            var buffer = new byte[totalSize];
+            SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
+            NotAppliedData.WriteHeader(buffer.AsSpan(SofhFrameReader.HeaderSize));
+            var msg = new NotAppliedData
+            {
+                FromSeqNo = new SeqNum(fromSeqNo),
+                Count = new MessageCounter(count),
+            };
+            if (!msg.TryEncode(buffer.AsSpan(SofhFrameReader.HeaderSize + MessageHeader.MESSAGE_SIZE), out _))
+                continue;
+            try
+            {
+                await SendFrameAsync(c.Stream, c.State, buffer, totalSize, ct).ConfigureAwait(false);
+                sent++;
+            }
+            catch (IOException) { }
+            catch (ObjectDisposedException) { }
+        }
+        return sent;
     }
 
     private static long _orderIdSeq;

--- a/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 B3.EntryPoint.Client.TestPeer.ITestPeerScenario.OnOutboundFrame(B3.EntryPoint.Client.TestPeer.OutboundFrameContext context) -> B3.EntryPoint.Client.TestPeer.OutboundFrameAction!
+B3.EntryPoint.Client.TestPeer.InProcessFixpTestPeer.InjectNotAppliedAsync(uint fromSeqNo, uint count, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
 B3.EntryPoint.Client.TestPeer.OutboundFrameAction
 B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen
 B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.Deconstruct(out System.TimeSpan Delay, out B3.EntryPoint.Client.TestPeer.OutboundFrameAction! Then) -> void
@@ -33,6 +34,12 @@ B3.EntryPoint.Client.TestPeer.OutboundFrameContext.OutboundFrameContext() -> voi
 B3.EntryPoint.Client.TestPeer.OutboundFrameContext.OutboundFrameContext(uint TemplateId, ulong MsgSeqNum, int FrameLength) -> void
 B3.EntryPoint.Client.TestPeer.OutboundFrameContext.TemplateId.get -> uint
 B3.EntryPoint.Client.TestPeer.OutboundFrameContext.TemplateId.init -> void
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.EstablishRejectAfter.get -> int?
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.EstablishRejectAfter.set -> void
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.EstablishRejectCodeOverride.get -> B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.EstablishRejectCodeOverride.set -> void
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.RetransmitRejectCode.get -> B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode?
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.RetransmitRejectCode.set -> void
 abstract B3.EntryPoint.Client.TestPeer.OutboundFrameAction.<Clone>$() -> B3.EntryPoint.Client.TestPeer.OutboundFrameAction!
 override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.<Clone>$() -> B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen!
 override B3.EntryPoint.Client.TestPeer.OutboundFrameAction.DelayThen.Equals(object? obj) -> bool

--- a/src/B3.EntryPoint.Client.TestPeer/TestPeerOptions.cs
+++ b/src/B3.EntryPoint.Client.TestPeer/TestPeerOptions.cs
@@ -43,4 +43,29 @@ public sealed class TestPeerOptions
     /// is accepted, mirroring the historical behaviour.
     /// </summary>
     public IReadOnlyDictionary<uint, byte[]>? Credentials { get; set; }
+
+    /// <summary>
+    /// When set, the peer responds to the N-th and subsequent
+    /// <c>Establish</c> frames (1-based) with an <c>EstablishReject</c>
+    /// carrying <see cref="EstablishRejectCodeOverride"/> instead of an
+    /// <c>EstablishmentAck</c>. Counts across all connections within this
+    /// peer instance. Defaults to <c>null</c> (always ack). Use
+    /// <c>EstablishRejectAfter = 2</c> to test the reconnect-rejected path.
+    /// </summary>
+    public int? EstablishRejectAfter { get; set; }
+
+    /// <summary>
+    /// <see cref="B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode"/> value
+    /// returned when <see cref="EstablishRejectAfter"/> triggers a reject.
+    /// Defaults to <c>INVALID_SESSIONVERID</c>.
+    /// </summary>
+    public B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode EstablishRejectCodeOverride { get; set; }
+        = B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.INVALID_SESSIONVERID;
+
+    /// <summary>
+    /// When set, the peer responds to inbound <c>RetransmitRequest</c>
+    /// frames with a <c>RetransmitReject</c> carrying this code instead of
+    /// the (empty) <c>Retransmission</c> reply. Defaults to <c>null</c>.
+    /// </summary>
+    public B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode? RetransmitRejectCode { get; set; }
 }

--- a/tests/B3.EntryPoint.Conformance/Infrastructure/ConformancePeerFactory.cs
+++ b/tests/B3.EntryPoint.Conformance/Infrastructure/ConformancePeerFactory.cs
@@ -1,0 +1,35 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.TestPeer;
+
+namespace B3.EntryPoint.Conformance.Infrastructure;
+
+/// <summary>
+/// Spins up a per-test in-process FIXP peer with a custom
+/// <see cref="ITestPeerScenario"/> and returns matching client options.
+/// Use only when <see cref="PeerEndpoint.IsTestPeerEnabled"/> is true (i.e.
+/// from a <see cref="TestPeerOnlyConformanceFactAttribute"/> test).
+/// </summary>
+public sealed class ConformancePeerFactory : IAsyncDisposable
+{
+    private readonly InProcessFixpTestPeer _peer;
+
+    public InProcessFixpTestPeer Peer => _peer;
+    public EntryPointClientOptions ClientOptions { get; }
+
+    public ConformancePeerFactory(ITestPeerScenario scenario, uint sessionId = 1u, uint sessionVerId = 1u, uint enteringFirm = 1u, string accessKey = "TESTPEER")
+    {
+        _peer = new InProcessFixpTestPeer(new TestPeerOptions { Scenario = scenario });
+        _peer.Start();
+        ClientOptions = new EntryPointClientOptions
+        {
+            Endpoint = _peer.LocalEndpoint!,
+            SessionId = sessionId,
+            SessionVerId = sessionVerId,
+            EnteringFirm = enteringFirm,
+            Credentials = Credentials.FromUtf8(accessKey),
+        };
+    }
+
+    public ValueTask DisposeAsync() => _peer.DisposeAsync();
+}

--- a/tests/B3.EntryPoint.Conformance/Infrastructure/TestPeerOnlyConformanceFactAttribute.cs
+++ b/tests/B3.EntryPoint.Conformance/Infrastructure/TestPeerOnlyConformanceFactAttribute.cs
@@ -1,0 +1,22 @@
+using Xunit.Sdk;
+
+namespace B3.EntryPoint.Conformance.Infrastructure;
+
+/// <summary>
+/// Marks a conformance test that requires a configurable in-process peer
+/// (e.g. to drive reject paths), so it must be skipped when the suite is
+/// pointed at a real B3 endpoint via <c>B3EP_PEER</c>. Tests that use this
+/// attribute typically construct their own <c>InProcessFixpTestPeer</c> with
+/// a custom <c>ITestPeerScenario</c> via
+/// <see cref="ConformancePeerFactory"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[XunitTestCaseDiscoverer("Xunit.Sdk.FactDiscoverer", "xunit.execution.{Platform}")]
+public sealed class TestPeerOnlyConformanceFactAttribute : FactAttribute
+{
+    public TestPeerOnlyConformanceFactAttribute()
+    {
+        if (!PeerEndpoint.IsTestPeerEnabled())
+            Skip = "Requires ENTRYPOINT_TESTPEER=1 (test-peer-only scenario).";
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/OrderEntry_Cancel/CancelRejectTests.cs
+++ b/tests/B3.EntryPoint.Conformance/OrderEntry_Cancel/CancelRejectTests.cs
@@ -1,0 +1,42 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Client.TestPeer;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.OrderEntry_Cancel;
+
+/// <summary>
+/// Spec — Negative path: peer rejects <c>OrderCancelRequest</c> with
+/// <c>ExecutionReport_Reject</c> (template 204) carrying
+/// <c>CxlRejResponseTo = CANCEL</c>; the client surfaces an
+/// <see cref="OrderRejected"/> event.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class CancelRejectTests
+{
+    [TestPeerOnlyConformanceFact]
+    public async Task RejectAll_Cancel_Surfaces_OrderRejected()
+    {
+        await using var fx = new ConformancePeerFactory(
+            TestPeerScenarios.RejectAll("conformance: cancel rejected"));
+        await using var client = new EntryPointClient(fx.ClientOptions);
+        await client.ConnectAsync();
+
+        await client.CancelAsync(new CancelOrderRequest
+        {
+            ClOrdID = (ClOrdID)801UL,
+            OrigClOrdID = (ClOrdID)800UL,
+            SecurityId = 2001UL,
+            Side = Side.Buy,
+        });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await foreach (var evt in client.Events(cts.Token))
+        {
+            var rejected = Assert.IsType<OrderRejected>(evt);
+            Assert.Equal((ushort)99, rejected.RejectCode);
+            return;
+        }
+        throw new TimeoutException("No OrderRejected received");
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/OrderEntry_NewOrder/NewOrderRejectTests.cs
+++ b/tests/B3.EntryPoint.Conformance/OrderEntry_NewOrder/NewOrderRejectTests.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Client.TestPeer;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.OrderEntry_NewOrder;
+
+/// <summary>
+/// Spec — Negative path: peer rejects <c>NewOrder</c> with
+/// <c>BusinessMessageReject</c> (template 206), client surfaces a
+/// <see cref="BusinessReject"/> event with the original reason text.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class NewOrderRejectTests
+{
+    [TestPeerOnlyConformanceFact]
+    public async Task RejectAll_NewOrder_Surfaces_BusinessReject_With_Text()
+    {
+        const string reason = "conformance: business-reject text";
+        await using var fx = new ConformancePeerFactory(TestPeerScenarios.RejectAll(reason));
+        await using var client = new EntryPointClient(fx.ClientOptions);
+        await client.ConnectAsync();
+
+        await client.SubmitAsync(new NewOrderRequest
+        {
+            ClOrdID = (ClOrdID)123UL,
+            SecurityId = 1001,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            Price = 1.23m,
+            OrderQty = 5,
+        });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await foreach (var evt in client.Events(cts.Token))
+        {
+            var bmr = Assert.IsType<BusinessReject>(evt);
+            Assert.Equal(reason, bmr.Text);
+            return;
+        }
+        throw new TimeoutException("No BusinessReject received");
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/OrderEntry_Replace/ReplaceRejectTests.cs
+++ b/tests/B3.EntryPoint.Conformance/OrderEntry_Replace/ReplaceRejectTests.cs
@@ -1,0 +1,45 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Client.TestPeer;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.OrderEntry_Replace;
+
+/// <summary>
+/// Spec — Negative path: peer rejects <c>OrderCancelReplaceRequest</c>
+/// with <c>ExecutionReport_Reject</c> carrying
+/// <c>CxlRejResponseTo = REPLACE</c>; the client surfaces an
+/// <see cref="OrderRejected"/> event.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class ReplaceRejectTests
+{
+    [TestPeerOnlyConformanceFact]
+    public async Task RejectAll_Replace_Surfaces_OrderRejected()
+    {
+        await using var fx = new ConformancePeerFactory(
+            TestPeerScenarios.RejectAll("conformance: replace rejected"));
+        await using var client = new EntryPointClient(fx.ClientOptions);
+        await client.ConnectAsync();
+
+        await client.ReplaceAsync(new ReplaceOrderRequest
+        {
+            ClOrdID = (ClOrdID)1101UL,
+            OrigClOrdID = (ClOrdID)1100UL,
+            SecurityId = 4001UL,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            Price = 12.34m,
+            OrderQty = 10UL,
+        });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        await foreach (var evt in client.Events(cts.Token))
+        {
+            var rejected = Assert.IsType<OrderRejected>(evt);
+            Assert.Equal((ushort)99, rejected.RejectCode);
+            return;
+        }
+        throw new TimeoutException("No OrderRejected received");
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/Spec_4_5_Negotiate/ReconnectRejectTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_5_Negotiate/ReconnectRejectTests.cs
@@ -1,0 +1,33 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Fixp;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.EntryPoint.Client.TestPeer;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.Spec_4_5_Negotiate;
+
+/// <summary>
+/// Spec §4.5 — Negative path. Peer rejects the second <c>Establish</c>
+/// (the reconnect) with <c>EstablishReject(INVALID_SESSIONVERID)</c>;
+/// the client surfaces a <see cref="FixpRejectedException"/>.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class ReconnectRejectTests
+{
+    [TestPeerOnlyConformanceFact]
+    public async Task Reconnect_With_Invalid_SessionVerId_Surfaces_FixpRejected()
+    {
+        await using var fx = new ConformancePeerFactory(
+            TestPeerScenarios.AcceptAll);
+        // Reject only the second (reconnect) Establish — the first must succeed.
+        fx.Peer.Options.EstablishRejectAfter = 2;
+        fx.Peer.Options.EstablishRejectCodeOverride = EstablishRejectCode.INVALID_SESSIONVERID;
+
+        await using var client = new EntryPointClient(fx.ClientOptions);
+        await client.ConnectAsync();
+        Assert.Equal(FixpClientState.Established, client.State);
+
+        await Assert.ThrowsAsync<FixpRejectedException>(
+            async () => await client.ReconnectAsync(fx.ClientOptions.SessionVerId + 1));
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/NotAppliedTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/NotAppliedTests.cs
@@ -1,0 +1,37 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.TestPeer;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.Spec_4_7_Retransmit;
+
+/// <summary>
+/// Spec — Negative path. Peer injects an unsolicited <c>NotApplied</c>
+/// frame; the client surfaces it via
+/// <see cref="IRetransmitRequestHandler.NotAppliedReceived"/>.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class NotAppliedTests
+{
+    [TestPeerOnlyConformanceFact]
+    public async Task NotApplied_From_Peer_Surfaces_Event_With_Range()
+    {
+        await using var fx = new ConformancePeerFactory(TestPeerScenarios.AcceptAll);
+        await using var client = new EntryPointClient(fx.ClientOptions);
+        await client.ConnectAsync();
+        Assert.NotNull(client.Retransmit);
+
+        var na = new TaskCompletionSource<NotAppliedEventArgs>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        client.Retransmit!.NotAppliedReceived += (_, args) => na.TrySetResult(args);
+
+        var sent = await fx.Peer.InjectNotAppliedAsync(fromSeqNo: 7u, count: 3u);
+        Assert.True(sent >= 1, "Expected the NotApplied frame to be written to at least one connection");
+
+        var completed = await Task.WhenAny(na.Task, Task.Delay(TimeSpan.FromSeconds(3)));
+        Assert.Same(na.Task, completed);
+        var evt = await na.Task;
+        Assert.Equal(7UL, evt.FromSeqNo);
+        Assert.Equal(3u, evt.Count);
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/RetransmitRejectTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/RetransmitRejectTests.cs
@@ -1,0 +1,39 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.TestPeer;
+using B3.EntryPoint.Conformance.Infrastructure;
+using SbeRetransmitRejectCode = B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode;
+
+namespace B3.EntryPoint.Conformance.Spec_4_7_Retransmit;
+
+/// <summary>
+/// Spec §4.7 — Negative path. Peer responds to <c>RetransmitRequest</c>
+/// with <c>RetransmitReject</c>; the client surfaces a
+/// <see cref="IRetransmitRequestHandler.RetransmitRejected"/> event with
+/// the rejection code.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class RetransmitRejectTests
+{
+    [TestPeerOnlyConformanceFact]
+    public async Task Retransmit_Reject_Is_Surfaced_With_Code()
+    {
+        await using var fx = new ConformancePeerFactory(TestPeerScenarios.AcceptAll);
+        fx.Peer.Options.RetransmitRejectCode = SbeRetransmitRejectCode.OUT_OF_RANGE;
+
+        await using var client = new EntryPointClient(fx.ClientOptions);
+        await client.ConnectAsync();
+        Assert.NotNull(client.Retransmit);
+
+        var rejected = new TaskCompletionSource<RetransmitRejectedEventArgs>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        client.Retransmit!.RetransmitRejected += (_, args) => rejected.TrySetResult(args);
+
+        await client.Retransmit.RequestRetransmitAsync(fromSeqNo: 1UL, count: 5U);
+
+        var completed = await Task.WhenAny(rejected.Task, Task.Delay(TimeSpan.FromSeconds(3)));
+        Assert.Same(rejected.Task, completed);
+        var evt = await rejected.Task;
+        Assert.Equal(RetransmitRejectCode.OutOfRange, evt.Code);
+    }
+}


### PR DESCRIPTION
Closes #114.

Closes the second slice of v0.11.0 — peer-side support for the three remaining negative session-layer paths and six new conformance tests covering the full reject matrix.

## TestPeer additions
- `TestPeerOptions.EstablishRejectAfter` (+ `EstablishRejectCodeOverride`) — peer responds to the N-th and subsequent `Establish` frames with `EstablishReject` instead of `EstablishmentAck`.
- `TestPeerOptions.RetransmitRejectCode` — peer answers `RetransmitRequest` with `RetransmitReject` carrying the configured code instead of an empty `Retransmission`.
- `InProcessFixpTestPeer.InjectNotAppliedAsync(fromSeqNo, count, ct)` — writes a session-layer `NotApplied` frame on every established connection.

## Conformance suite additions
New `ConformancePeerFactory` (per-test peer with custom scenario) + `TestPeerOnlyConformanceFactAttribute` (skips when not in test-peer mode):
- BMR text round-trip via `RejectAll`
- ER reject for cancel
- ER reject for replace
- Reconnect rejected → `FixpRejectedException`
- RetransmitReject(`OUT_OF_RANGE`) → `RetransmitRejected`
- Peer-injected `NotApplied(7,3)` → `NotAppliedReceived`

8 happy + 6 negative = 14 conformance tests, all pass under `ENTRYPOINT_TESTPEER=1`, all skip cleanly without the env var. 135 unit + 2 sample tests unchanged.

## Acceptance criteria (from #114)
- [x] One new `[ConformanceFact]` per item.
- [x] All pass under `ENTRYPOINT_TESTPEER=1`.
- [x] No flakes (timing budget 3s/test using TCS-based sync — no polling).

## PublicAPI additions (TestPeer)
- `TestPeerOptions.EstablishRejectAfter`
- `TestPeerOptions.EstablishRejectCodeOverride`
- `TestPeerOptions.RetransmitRejectCode`
- `InProcessFixpTestPeer.InjectNotAppliedAsync`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>