### PR TITLE
fix(#120): non-mutating accessors for outbound seq counter (v0.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-05-02
+
+### Fixed
+- **client (#120)**: `EntryPointClient.BuildSnapshot()` and the `KeepAliveScheduler` callback both called `FixpClientSession.NextOutboundSeqNum()` (a post-increment) for read-only purposes, burning one outbound `MsgSeqNum` per snapshot/heartbeat. The first compaction or any heartbeat would create a sequence gap that the peer could reject (`NotApplied`/`Terminate`). Added two non-mutating accessors — `LastAssignedOutboundSeqNum()` and `PeekNextOutboundSeqNum()` — and switched both call sites. Snapshots now report the true last-assigned seq, and the FIXP `Sequence` heartbeat now announces the actual next `MsgSeqNum` the sender will use. Pre-0.11.1 persisted snapshots may have inflated `LastOutboundSeqNum`; on resume the peer may reject with a duplicate-seq error if the gap was never recovered (replay actual `OutboundDelta` records or perform a session reset).
+
 ## [0.11.0] - 2026-05-02
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- NuGet metadata shared by all packable projects. -->
-    <Version>0.11.0</Version>
+    <Version>0.11.1</Version>
     <Authors>pedrosakuma</Authors>
     <Company>pedrosakuma</Company>
     <Copyright>Copyright (c) pedrosakuma</Copyright>

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -168,7 +168,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         _keepAlive = new KeepAliveScheduler(
             _options.KeepAliveInterval,
             sendSequence: (seq, token) => _session.SendSequenceAsync(seq, token),
-            nextSeqNo: () => _session.NextOutboundSeqNum());
+            nextSeqNo: () => _session.PeekNextOutboundSeqNum());
         _session.OnInboundSequence = nextSeq =>
         {
             _lastInboundUtc = DateTime.UtcNow;
@@ -360,7 +360,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     {
         SessionId = _options.SessionId,
         SessionVerId = _options.SessionVerId,
-        LastOutboundSeqNum = _session is null ? 0UL : _session.NextOutboundSeqNum() - 1UL,
+        LastOutboundSeqNum = _session is null ? 0UL : _session.LastAssignedOutboundSeqNum(),
         LastInboundSeqNum = _lastInboundSeqNum,
         CapturedAt = DateTimeOffset.UtcNow,
         OutstandingOrders = new Dictionary<string, ulong>(_outstandingOrders),

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -250,6 +250,31 @@ internal sealed class FixpClientSession : IAsyncDisposable
     public ulong NextOutboundSeqNum() =>
         (ulong)System.Threading.Interlocked.Increment(ref _outboundSeqNum);
 
+    /// <summary>
+    /// Reads the last outbound MsgSeqNum that was assigned via <see cref="NextOutboundSeqNum"/>
+    /// without mutating the counter. Returns 0 when no outbound frame has been assigned yet.
+    /// </summary>
+    /// <remarks>
+    /// "Assigned" means the seq slot was reserved for an outbound send attempt. The frame
+    /// may not have been successfully flushed to the wire if the underlying write failed.
+    /// </remarks>
+    public ulong LastAssignedOutboundSeqNum() =>
+        (ulong)System.Threading.Interlocked.Read(ref _outboundSeqNum);
+
+    /// <summary>
+    /// Returns the value the next call to <see cref="NextOutboundSeqNum"/> would produce
+    /// (i.e. the announce-only "next NextSeqNo" used by FIXP <c>Sequence</c> frames),
+    /// without mutating the counter.
+    /// </summary>
+    /// <remarks>
+    /// Note: callers that read this value and then write it to the wire on a separate
+    /// path (e.g. <c>KeepAliveScheduler</c>) can race with concurrent application sends
+    /// that allocate a new seq between the peek and the wire write. Tracked separately
+    /// in the outbound-serialization follow-up.
+    /// </remarks>
+    public ulong PeekNextOutboundSeqNum() =>
+        (ulong)System.Threading.Interlocked.Read(ref _outboundSeqNum) + 1UL;
+
     /// <summary>Sends a single FIXP <c>Sequence</c> frame announcing <paramref name="nextSeqNo"/>.</summary>
     public async Task SendSequenceAsync(ulong nextSeqNo, CancellationToken ct)
     {

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/FixpClientSessionSeqCounterTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/FixpClientSessionSeqCounterTests.cs
@@ -1,0 +1,87 @@
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+
+namespace B3.EntryPoint.Client.Tests.Fixp;
+
+/// <summary>
+/// Regression coverage for #120 — non-mutating seq-counter accessors.
+/// Verifies that <see cref="FixpClientSession.LastAssignedOutboundSeqNum"/>
+/// and <see cref="FixpClientSession.PeekNextOutboundSeqNum"/> do not advance
+/// the outbound counter, and that <see cref="FixpClientSession.NextOutboundSeqNum"/>
+/// resumes from the correct value after they are called.
+/// </summary>
+public class FixpClientSessionSeqCounterTests
+{
+    private static FixpClientSession NewSession()
+    {
+        var opts = new EntryPointClientOptions
+        {
+            Endpoint = new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 1),
+            SessionId = 1,
+            SessionVerId = 1,
+            EnteringFirm = 1,
+            Credentials = Credentials.FromUtf8("k"),
+        };
+        return new FixpClientSession(new MemoryStream(), opts);
+    }
+
+    [Fact]
+    public void Peek_AndLastAssigned_DoNotMutateCounter()
+    {
+        var session = NewSession();
+
+        // Counter starts at 0 — nothing assigned yet.
+        Assert.Equal(0UL, session.LastAssignedOutboundSeqNum());
+        Assert.Equal(1UL, session.PeekNextOutboundSeqNum());
+
+        // Calling either accessor repeatedly must not mutate the counter.
+        for (int i = 0; i < 1000; i++)
+        {
+            Assert.Equal(0UL, session.LastAssignedOutboundSeqNum());
+            Assert.Equal(1UL, session.PeekNextOutboundSeqNum());
+        }
+
+        // First real allocation returns 1; counter advances exactly once.
+        Assert.Equal(1UL, session.NextOutboundSeqNum());
+        Assert.Equal(1UL, session.LastAssignedOutboundSeqNum());
+        Assert.Equal(2UL, session.PeekNextOutboundSeqNum());
+    }
+
+    [Fact]
+    public void Allocations_Are_Contiguous_When_Interleaved_With_Peek_And_LastAssigned()
+    {
+        var session = NewSession();
+        var observed = new List<ulong>();
+
+        // Simulate the buggy pattern from #120: BuildSnapshot + keep-alive both
+        // peek/read between every app send. Before the fix this would burn
+        // outbound seqs and produce gaps.
+        for (int i = 0; i < 100; i++)
+        {
+            _ = session.PeekNextOutboundSeqNum();
+            _ = session.LastAssignedOutboundSeqNum();
+            observed.Add(session.NextOutboundSeqNum());
+            _ = session.PeekNextOutboundSeqNum();
+            _ = session.LastAssignedOutboundSeqNum();
+        }
+
+        // Must be 1,2,3,...,100 — no gaps.
+        Assert.Equal(Enumerable.Range(1, 100).Select(i => (ulong)i), observed);
+    }
+
+    [Fact]
+    public void ResumeOutboundSeqNum_Then_Peek_Reports_The_Resumed_Next()
+    {
+        var session = NewSession();
+
+        session.ResumeOutboundSeqNum(nextOutboundSeqNum: 42UL);
+
+        // After resuming "next outbound seq = 42", LastAssigned is 41 and Peek is 42.
+        Assert.Equal(41UL, session.LastAssignedOutboundSeqNum());
+        Assert.Equal(42UL, session.PeekNextOutboundSeqNum());
+
+        Assert.Equal(42UL, session.NextOutboundSeqNum());
+        Assert.Equal(42UL, session.LastAssignedOutboundSeqNum());
+        Assert.Equal(43UL, session.PeekNextOutboundSeqNum());
+    }
+}


### PR DESCRIPTION
Closes #120.

## Bug
`EntryPointClient.BuildSnapshot()` and the `KeepAliveScheduler.nextSeqNo` callback both called `FixpClientSession.NextOutboundSeqNum()` (a post-increment `Interlocked.Increment`) for **read-only** purposes:
- BuildSnapshot did `NextOutboundSeqNum() - 1` to get the last-assigned seq, side effect: counter advanced, next real app frame skipped a seq.
- KeepAliveScheduler called it every tick to fill the FIXP Sequence frame's `NextSeqNo` field, burning an outbound seq per heartbeat and announcing an off-by-one value vs. the actual next MsgSeqNum.

Peer would eventually reject the gap with `NotApplied` / `Terminate`.

## Fix
- New non-mutating accessors on `FixpClientSession`:
  - `LastAssignedOutboundSeqNum()` → `Interlocked.Read`, returns the last seq consumed (0 if none).
  - `PeekNextOutboundSeqNum()` → returns what the next `NextOutboundSeqNum` call would produce.
- `BuildSnapshot` now uses `LastAssignedOutboundSeqNum()`.
- Keep-alive callback now uses `PeekNextOutboundSeqNum()`.
- 3 new regression unit tests in `FixpClientSessionSeqCounterTests`.

`FixpClientSession` is internal — no public API change. Patch release.

## Known follow-ups (not in this PR)
- Outbound serialization between keep-alive peek and concurrent app sends — the peek-then-write window can still race. Will track in a follow-up issue (the race pre-existed; the fix here at least uses correct values when uncontested).
- Pre-0.11.1 snapshots may carry inflated `LastOutboundSeqNum`; documented in CHANGELOG.

## Verification
- `dotnet test SbeB3EntryPointClient.slnx` with `ENTRYPOINT_TESTPEER=1`: 138 unit (was 135) + 14 conformance + 2 sample, all green.

## Release
This will ship as **v0.11.1** patch. Version + CHANGELOG already bumped in this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>