### PR TITLE
chore(ci): bump GitHub Actions off Node 20 runtime

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,13 +15,13 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
       - name: Run benchmarks
         run: dotnet run -c Release --project benchmarks/B3.EntryPoint.Benchmarks/B3.EntryPoint.Benchmarks.csproj -- --filter "${{ github.event.inputs.filter }}" --exporters json github
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: BenchmarkDotNet.Artifacts
           path: BenchmarkDotNet.Artifacts/**

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,11 +15,11 @@ jobs:
     env:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
@@ -42,7 +42,7 @@ jobs:
             dotnet nuget push "$pkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
           done
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: nupkgs
           path: ./nupkgs/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CI (#129): bumped `actions/checkout` to v6, `actions/setup-dotnet` to v5, and `actions/upload-artifact` to v7 in `bench.yml` and `publish.yml` to drop the deprecated Node 20 runtime (Node 20 is removed from GitHub Actions runners on 2026-09-16). Other workflows were already on these versions.
+
 ## [0.11.1] - 2026-05-02
 
 ### Fixed


### PR DESCRIPTION
Closes #129 once v0.12.0 ships (issue stays open until then).

## Problem
The latest publish workflow run produced a Node-20 deprecation annotation:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-dotnet@v4, actions/upload-artifact@v4. ... Node.js 20 will be removed from the runner on September 16th, 2026.

## Change
Bumped the three offending actions in the two workflows that were still on the v4 major (`bench.yml` and `publish.yml`) to the same versions already used elsewhere in the repo (`ci.yml`, `codeql.yml`, `copilot-setup-steps.yml`):

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-dotnet` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |

All other workflows were already on these versions, so this is a small, surgical alignment patch.

## Verification
- `dotnet build SbeB3EntryPointClient.slnx --nologo -v q` — succeeded, 0 warnings, 0 errors.
- CI on this PR will exercise the bumped workflows.

## Release note
Added a `### Changed` entry under `[Unreleased]` in `CHANGELOG.md`. No version bump — this ships as part of v0.12.0.