### PR TITLE
feat(client): bound Events() channel with configurable capacity (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - CI (#129): bumped `actions/checkout` to v6, `actions/setup-dotnet` to v5, and `actions/upload-artifact` to v7 in `bench.yml` and `publish.yml` to drop the deprecated Node 20 runtime (Node 20 is removed from GitHub Actions runners on 2026-09-16). Other workflows were already on these versions.
+- **client (#126)**: the inbound event channel backing `IEntryPointClient.Events()` (and `SegmentedEntryPointClient.Events()`) is now actually bounded, matching its long-standing XML doc. Capacity is configurable via the new `EntryPointClientOptions.EventChannelCapacity` (default 4096), and the channel uses `BoundedChannelFullMode.Wait` — when the buffer fills, the inbound decoder awaits a free slot rather than dropping events or growing memory unboundedly. A slow consumer therefore applies backpressure all the way to the wire reader. Previous behavior used `Channel.CreateUnbounded`, which contradicted the docs and could grow without limit on a stalled consumer.
 
 ## [0.11.1] - 2026-05-02
 

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -26,12 +26,7 @@ namespace B3.EntryPoint.Client;
 public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplaceOrder, ICancelOrder, ISubmitCross, IQuoteFlow
 {
     private readonly EntryPointClientOptions _options;
-    private readonly Channel<EntryPointEvent> _events =
-        Channel.CreateUnbounded<EntryPointEvent>(new UnboundedChannelOptions
-        {
-            SingleReader = false,
-            SingleWriter = true,
-        });
+    private readonly Channel<EntryPointEvent> _events;
     private TcpClient? _tcp;
     private FixpClientSession? _session;
     private KeepAliveScheduler? _keepAlive;
@@ -62,6 +57,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         ArgumentNullException.ThrowIfNull(options);
         ValidateOptions(options);
         _options = options;
+        _events = Channel.CreateBounded<EntryPointEvent>(new BoundedChannelOptions(options.EventChannelCapacity)
+        {
+            SingleReader = false,
+            SingleWriter = true,
+            FullMode = BoundedChannelFullMode.Wait,
+        });
     }
 
     private static void ValidateOptions(EntryPointClientOptions options)
@@ -662,8 +663,13 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     /// (<see cref="OrderAccepted"/>, <see cref="OrderRejected"/>,
     /// <see cref="OrderTrade"/>, <see cref="OrderCancelled"/>,
     /// <see cref="OrderModified"/>, <see cref="BusinessReject"/>, etc.).
-    /// Backed by a bounded channel; consumers that fall behind block the
-    /// inbound decoder, so drain promptly.
+    /// Backed by a bounded channel of capacity
+    /// <see cref="EntryPointClientOptions.EventChannelCapacity"/> (default 4096) with
+    /// <see cref="BoundedChannelFullMode.Wait"/>: when the channel fills, the inbound
+    /// decoder awaits a free slot before publishing the next event. A consumer that
+    /// does not drain promptly therefore stalls the decoder, which propagates
+    /// backpressure all the way to the wire reader (and ultimately the TCP receive
+    /// window). No events are dropped.
     /// </summary>
     public async IAsyncEnumerable<EntryPointEvent> Events([EnumeratorCancellation] CancellationToken ct = default)
     {

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -114,6 +114,26 @@ public sealed class EntryPointClientOptions
     /// <summary>TLS configuration for the FIXP transport. Disabled by default.</summary>
     public TlsOptions Tls { get; set; } = new();
 
+    private int _eventChannelCapacity = 4096;
+
+    /// <summary>
+    /// Capacity of the bounded inbound event channel backing
+    /// <see cref="IEntryPointClient.Events"/>. When the channel is full the
+    /// inbound decoder awaits until a consumer drains an item
+    /// (<see cref="System.Threading.Channels.BoundedChannelFullMode.Wait"/>),
+    /// surfacing backpressure all the way up to the wire reader. Defaults to 4096.
+    /// </summary>
+    public int EventChannelCapacity
+    {
+        get => _eventChannelCapacity;
+        set
+        {
+            if (value <= 0)
+                throw new ArgumentOutOfRangeException(nameof(value), value, $"{nameof(EventChannelCapacity)} must be greater than zero.");
+            _eventChannelCapacity = value;
+        }
+    }
+
     private static string ThisAssemblyVersion() =>
         typeof(EntryPointClientOptions).Assembly.GetName().Version?.ToString() ?? "0.0.0";
 }

--- a/src/B3.EntryPoint.Client/IEntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/IEntryPointClient.cs
@@ -50,6 +50,12 @@ public interface IEntryPointClient :
     /// <summary>Snapshot of in-memory client health counters.</summary>
     ClientHealth GetHealth();
 
-    /// <summary>Streams inbound EntryPoint events as they are decoded.</summary>
+    /// <summary>
+    /// Streams inbound EntryPoint events as they are decoded. Backed by a bounded
+    /// channel (see <see cref="EntryPointClientOptions.EventChannelCapacity"/>,
+    /// default 4096, <see cref="System.Threading.Channels.BoundedChannelFullMode.Wait"/>)
+    /// so a slow consumer applies backpressure to the inbound decoder rather than
+    /// dropping events or growing memory unboundedly.
+    /// </summary>
     IAsyncEnumerable<EntryPointEvent> Events(CancellationToken ct = default);
 }

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+B3.EntryPoint.Client.EntryPointClientOptions.EventChannelCapacity.get -> int
+B3.EntryPoint.Client.EntryPointClientOptions.EventChannelCapacity.set -> void

--- a/src/B3.EntryPoint.Client/SegmentedEntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/SegmentedEntryPointClient.cs
@@ -29,12 +29,7 @@ public sealed class SegmentedEntryPointClient : IAsyncDisposable, ISubmitOrder, 
     private readonly SegmentRouter<CancelOrderRequest> _routeCancel;
     private readonly SegmentRouter<MassActionRequest> _routeMassAction;
 
-    private readonly Channel<EntryPointEvent> _aggregatedEvents =
-        Channel.CreateUnbounded<EntryPointEvent>(new UnboundedChannelOptions
-        {
-            SingleReader = false,
-            SingleWriter = false,
-        });
+    private readonly Channel<EntryPointEvent> _aggregatedEvents;
     private readonly List<Task> _pumps = new();
     private readonly CancellationTokenSource _pumpCts = new();
     private bool _connected;
@@ -59,6 +54,14 @@ public sealed class SegmentedEntryPointClient : IAsyncDisposable, ISubmitOrder, 
         _routeMassAction = routeMassAction ?? (_ => DefaultSegment);
         _routeSimpleNewOrder = routeSimpleNewOrder ?? (req => routeNewOrder(MapSimple(req)));
         _routeSimpleReplace = routeSimpleReplace ?? (req => routeReplace(MapSimple(req)));
+
+        var aggregateCapacity = perSegmentOptions.Values.Max(o => o.EventChannelCapacity);
+        _aggregatedEvents = Channel.CreateBounded<EntryPointEvent>(new BoundedChannelOptions(aggregateCapacity)
+        {
+            SingleReader = false,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.Wait,
+        });
     }
 
     /// <summary>The lowest configured MarketSegmentID; used as a fallback route.</summary>
@@ -95,7 +98,13 @@ public sealed class SegmentedEntryPointClient : IAsyncDisposable, ISubmitOrder, 
         }
     }
 
-    /// <summary>Aggregated event stream merging every per-segment <c>Events()</c>.</summary>
+    /// <summary>
+    /// Aggregated event stream merging every per-segment <c>Events()</c>. Backed by a
+    /// bounded channel sized to the largest per-segment
+    /// <see cref="EntryPointClientOptions.EventChannelCapacity"/>, with
+    /// <see cref="BoundedChannelFullMode.Wait"/>: a slow consumer stalls the per-segment
+    /// pump tasks, which in turn stall each underlying client's inbound decoder.
+    /// </summary>
     public async IAsyncEnumerable<EntryPointEvent> Events([EnumeratorCancellation] CancellationToken ct = default)
     {
         await foreach (var evt in _aggregatedEvents.Reader.ReadAllAsync(ct).ConfigureAwait(false))

--- a/tests/B3.EntryPoint.Client.Tests/EntryPointClientEventChannelTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/EntryPointClientEventChannelTests.cs
@@ -1,0 +1,80 @@
+using System.Net;
+using System.Reflection;
+using System.Threading.Channels;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client.Tests;
+
+public class EntryPointClientEventChannelTests
+{
+    private static EntryPointClientOptions Valid(int capacity) => new()
+    {
+        Endpoint = new IPEndPoint(IPAddress.Loopback, 9000),
+        SessionId = 1u,
+        SessionVerId = 1u,
+        EnteringFirm = 7u,
+        Credentials = Credentials.FromUtf8("k"),
+        EventChannelCapacity = capacity,
+    };
+
+    private static Channel<EntryPointEvent> GetChannel(EntryPointClient client)
+    {
+        var field = typeof(EntryPointClient).GetField("_events", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (Channel<EntryPointEvent>)field.GetValue(client)!;
+    }
+
+    private static OrderRejected MakeEvent(ulong seq) => new()
+    {
+        SeqNum = seq,
+        SendingTime = DateTimeOffset.UnixEpoch,
+        ClOrdID = new ClOrdID(seq),
+        OrderId = seq,
+        RejectCode = 0,
+    };
+
+    [Fact]
+    public void Options_EventChannelCapacity_DefaultsTo4096()
+    {
+        Assert.Equal(4096, new EntryPointClientOptions().EventChannelCapacity);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void Options_EventChannelCapacity_RejectsNonPositive(int value)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new EntryPointClientOptions { EventChannelCapacity = value });
+    }
+
+    [Fact]
+    public async Task EventChannel_IsBounded_ProducerBlocksUntilConsumerDrains()
+    {
+        var client = new EntryPointClient(Valid(capacity: 2));
+        var channel = GetChannel(client);
+        var writer = channel.Writer;
+        var reader = channel.Reader;
+
+        // Saturate the channel up to capacity. Synchronous TryWrite should succeed
+        // exactly `capacity` times for a bounded channel with FullMode.Wait.
+        Assert.True(writer.TryWrite(MakeEvent(1)));
+        Assert.True(writer.TryWrite(MakeEvent(2)));
+        Assert.False(writer.TryWrite(MakeEvent(3)),
+            "TryWrite must fail once the bounded channel is full.");
+
+        // The next WriteAsync must NOT complete synchronously — the producer is
+        // expected to await a free slot (BoundedChannelFullMode.Wait).
+        var blocked = writer.WriteAsync(MakeEvent(3)).AsTask();
+        await Task.Delay(50);
+        Assert.False(blocked.IsCompleted,
+            "WriteAsync should block while the bounded channel is full; an unbounded channel would have completed synchronously.");
+
+        // Drain one item — the pending WriteAsync should now complete promptly.
+        Assert.True(reader.TryRead(out _));
+        await blocked.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(blocked.IsCompletedSuccessfully);
+
+        await client.DisposeAsync();
+    }
+}


### PR DESCRIPTION
Fixes #126.

The XML doc on `IEntryPointClient.Events()` has long claimed a bounded channel, but both `EntryPointClient` and `SegmentedEntryPointClient` backed it with `Channel.CreateUnbounded`. A slow consumer could therefore grow memory without limit, contradicting the docs.

## Change
- New `EntryPointClientOptions.EventChannelCapacity` (`int`, default **4096**, validated `> 0`).
- Both `EntryPointClient._events` and `SegmentedEntryPointClient._aggregatedEvents` now use `Channel.CreateBounded` with `BoundedChannelFullMode.Wait`. Channel construction moved into the constructor so it can read the option.
- The segmented variant sizes the aggregated channel to the **largest** per-segment capacity.
- Updated XML docs on `IEntryPointClient.Events`, `EntryPointClient.Events`, and `SegmentedEntryPointClient.Events` to describe the new backpressure semantics (consumer slow → producer awaits → backpressure surfaces upstream to the wire reader).
- `PublicAPI.Unshipped.txt` updated (not promoted to Shipped — that's for v0.12.0).
- `CHANGELOG.md` `[Unreleased]` → `### Changed` entry.

## Behavior change
This is technically a behavior change: a stalled consumer now blocks the inbound decoder instead of buffering unboundedly. That's intentional and matches what the docs always promised. No deprecation needed — the previous behavior contradicted the docs.

## Tests
New `EntryPointClientEventChannelTests` (under `tests/B3.EntryPoint.Client.Tests/`):
1. `Options_EventChannelCapacity_DefaultsTo4096` — default value.
2. `Options_EventChannelCapacity_RejectsNonPositive` — setter validation (0, -1, `int.MinValue`).
3. `EventChannel_IsBounded_ProducerBlocksUntilConsumerDrains` — constructs a client with `EventChannelCapacity = 2`, saturates the channel via `TryWrite`, asserts the third `TryWrite` fails, asserts the next `WriteAsync` does **not** complete synchronously (proving boundedness — an unbounded channel would have completed instantly), drains one item, and asserts the pending write then completes.

Local `dotnet build` clean. `ENTRYPOINT_TESTPEER=1 dotnet test` green: 143 client tests (+5), 14 conformance, 2 sample.

Do **not** bump version, do **not** promote PublicAPI.Unshipped → Shipped, do **not** close #126 — those happen at the v0.12.0 release.