### PR TITLE
release: v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-02
+
 ### Changed
 - CI (#129): bumped `actions/checkout` to v6, `actions/setup-dotnet` to v5, and `actions/upload-artifact` to v7 in `bench.yml` and `publish.yml` to drop the deprecated Node 20 runtime (Node 20 is removed from GitHub Actions runners on 2026-09-16). Other workflows were already on these versions.
 - **client (#126)**: the inbound event channel backing `IEntryPointClient.Events()` (and `SegmentedEntryPointClient.Events()`) is now actually bounded, matching its long-standing XML doc. Capacity is configurable via the new `EntryPointClientOptions.EventChannelCapacity` (default 4096), and the channel uses `BoundedChannelFullMode.Wait` — when the buffer fills, the inbound decoder awaits a free slot rather than dropping events or growing memory unboundedly. A slow consumer therefore applies backpressure all the way to the wire reader. Previous behavior used `Channel.CreateUnbounded`, which contradicted the docs and could grow without limit on a stalled consumer.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- NuGet metadata shared by all packable projects. -->
-    <Version>0.11.1</Version>
+    <Version>0.12.0</Version>
     <Authors>pedrosakuma</Authors>
     <Company>pedrosakuma</Company>
     <Copyright>Copyright (c) pedrosakuma</Copyright>

--- a/src/B3.EntryPoint.Client/PublicAPI.Shipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Shipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+
 B3.EntryPoint.Client.Auth.Credentials
 B3.EntryPoint.Client.Auth.Credentials.AsSpan() -> System.ReadOnlySpan<byte>
 B3.EntryPoint.Client.Auth.Credentials.Credentials(System.ReadOnlySpan<byte> bytes) -> void
@@ -71,6 +72,8 @@ B3.EntryPoint.Client.EntryPointClientOptions.EnteringFirm.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.EnteringTrader.get -> string!
 B3.EntryPoint.Client.EntryPointClientOptions.EnteringTrader.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.EntryPointClientOptions() -> void
+B3.EntryPoint.Client.EntryPointClientOptions.EventChannelCapacity.get -> int
+B3.EntryPoint.Client.EntryPointClientOptions.EventChannelCapacity.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.HandshakeTimeout.get -> System.TimeSpan
 B3.EntryPoint.Client.EntryPointClientOptions.HandshakeTimeout.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.IdleTimeout.get -> System.TimeSpan
@@ -80,6 +83,8 @@ B3.EntryPoint.Client.EntryPointClientOptions.KeepAliveIntervalMs.get -> uint
 B3.EntryPoint.Client.EntryPointClientOptions.KeepAliveIntervalMs.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.Logger.get -> Microsoft.Extensions.Logging.ILogger!
 B3.EntryPoint.Client.EntryPointClientOptions.Logger.set -> void
+B3.EntryPoint.Client.EntryPointClientOptions.PersistenceQueueCapacity.get -> int
+B3.EntryPoint.Client.EntryPointClientOptions.PersistenceQueueCapacity.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.Profile.get -> B3.EntryPoint.Client.SessionProfile
 B3.EntryPoint.Client.EntryPointClientOptions.Profile.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.SenderLocation.get -> string!
@@ -88,10 +93,14 @@ B3.EntryPoint.Client.EntryPointClientOptions.SessionId.get -> uint
 B3.EntryPoint.Client.EntryPointClientOptions.SessionId.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.SessionStateStore.get -> B3.EntryPoint.Client.State.ISessionStateStore?
 B3.EntryPoint.Client.EntryPointClientOptions.SessionStateStore.set -> void
+B3.EntryPoint.Client.EntryPointClientOptions.SessionTeardownTimeout.get -> System.TimeSpan
+B3.EntryPoint.Client.EntryPointClientOptions.SessionTeardownTimeout.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.SessionVerId.get -> uint
 B3.EntryPoint.Client.EntryPointClientOptions.SessionVerId.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.StateCompactEveryDeltas.get -> int
 B3.EntryPoint.Client.EntryPointClientOptions.StateCompactEveryDeltas.set -> void
+B3.EntryPoint.Client.EntryPointClientOptions.Tls.get -> B3.EntryPoint.Client.TlsOptions!
+B3.EntryPoint.Client.EntryPointClientOptions.Tls.set -> void
 B3.EntryPoint.Client.Fixp.FixpClientState
 B3.EntryPoint.Client.Fixp.FixpClientState.Disconnected = 0 -> B3.EntryPoint.Client.Fixp.FixpClientState
 B3.EntryPoint.Client.Fixp.FixpClientState.Established = 5 -> B3.EntryPoint.Client.Fixp.FixpClientState
@@ -963,6 +972,18 @@ B3.EntryPoint.Client.TerminationCode.TerminateNotAllowed = 20 -> B3.EntryPoint.C
 B3.EntryPoint.Client.TerminationCode.Unnegotiated = 2 -> B3.EntryPoint.Client.TerminationCode
 B3.EntryPoint.Client.TerminationCode.UnrecognizedMessage = 15 -> B3.EntryPoint.Client.TerminationCode
 B3.EntryPoint.Client.TerminationCode.Unspecified = 0 -> B3.EntryPoint.Client.TerminationCode
+B3.EntryPoint.Client.TlsOptions
+B3.EntryPoint.Client.TlsOptions.ClientCertificates.get -> System.Security.Cryptography.X509Certificates.X509CertificateCollection?
+B3.EntryPoint.Client.TlsOptions.ClientCertificates.set -> void
+B3.EntryPoint.Client.TlsOptions.Enabled.get -> bool
+B3.EntryPoint.Client.TlsOptions.Enabled.set -> void
+B3.EntryPoint.Client.TlsOptions.EnabledSslProtocols.get -> System.Security.Authentication.SslProtocols
+B3.EntryPoint.Client.TlsOptions.EnabledSslProtocols.set -> void
+B3.EntryPoint.Client.TlsOptions.RemoteCertificateValidationCallback.get -> System.Net.Security.RemoteCertificateValidationCallback?
+B3.EntryPoint.Client.TlsOptions.RemoteCertificateValidationCallback.set -> void
+B3.EntryPoint.Client.TlsOptions.TargetHost.get -> string?
+B3.EntryPoint.Client.TlsOptions.TargetHost.set -> void
+B3.EntryPoint.Client.TlsOptions.TlsOptions() -> void
 abstract B3.EntryPoint.Client.Models.EntryPointEvent.<Clone>$() -> B3.EntryPoint.Client.Models.EntryPointEvent!
 abstract B3.EntryPoint.Client.State.SessionDelta.<Clone>$() -> B3.EntryPoint.Client.State.SessionDelta!
 const B3.EntryPoint.Client.DependencyInjection.EntryPointClientServiceCollectionExtensions.DropCopyOptionsName = "B3.EntryPoint.DropCopy" -> string!
@@ -1191,17 +1212,3 @@ virtual B3.EntryPoint.Client.State.SessionDelta.PrintMembers(System.Text.StringB
 ~override B3.EntryPoint.Client.Risk.OutboundRequest.ToString() -> string
 ~override B3.EntryPoint.Client.Telemetry.ClientHealth.Equals(object obj) -> bool
 ~override B3.EntryPoint.Client.Telemetry.ClientHealth.ToString() -> string
-B3.EntryPoint.Client.EntryPointClientOptions.Tls.get -> B3.EntryPoint.Client.TlsOptions!
-B3.EntryPoint.Client.EntryPointClientOptions.Tls.set -> void
-B3.EntryPoint.Client.TlsOptions
-B3.EntryPoint.Client.TlsOptions.ClientCertificates.get -> System.Security.Cryptography.X509Certificates.X509CertificateCollection?
-B3.EntryPoint.Client.TlsOptions.ClientCertificates.set -> void
-B3.EntryPoint.Client.TlsOptions.Enabled.get -> bool
-B3.EntryPoint.Client.TlsOptions.Enabled.set -> void
-B3.EntryPoint.Client.TlsOptions.EnabledSslProtocols.get -> System.Security.Authentication.SslProtocols
-B3.EntryPoint.Client.TlsOptions.EnabledSslProtocols.set -> void
-B3.EntryPoint.Client.TlsOptions.RemoteCertificateValidationCallback.get -> System.Net.Security.RemoteCertificateValidationCallback?
-B3.EntryPoint.Client.TlsOptions.RemoteCertificateValidationCallback.set -> void
-B3.EntryPoint.Client.TlsOptions.TargetHost.get -> string?
-B3.EntryPoint.Client.TlsOptions.TargetHost.set -> void
-B3.EntryPoint.Client.TlsOptions.TlsOptions() -> void

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -1,7 +1,1 @@
 #nullable enable
-B3.EntryPoint.Client.EntryPointClientOptions.EventChannelCapacity.get -> int
-B3.EntryPoint.Client.EntryPointClientOptions.EventChannelCapacity.set -> void
-B3.EntryPoint.Client.EntryPointClientOptions.PersistenceQueueCapacity.get -> int
-B3.EntryPoint.Client.EntryPointClientOptions.PersistenceQueueCapacity.set -> void
-B3.EntryPoint.Client.EntryPointClientOptions.SessionTeardownTimeout.get -> System.TimeSpan
-B3.EntryPoint.Client.EntryPointClientOptions.SessionTeardownTimeout.set -> void


### PR DESCRIPTION
## v0.12.0

Bundles four post-v0.11.0 discovery items that landed on `main`:

- **#129** CI: bumped `actions/checkout@v6`, `actions/setup-dotnet@v5`, `actions/upload-artifact@v7` (drops Node 20 deprecation).
- **#126** Client: `Events()` channel is now actually bounded (configurable via `EventChannelCapacity`, default 4096, `BoundedChannelFullMode.Wait`) — matching the long-standing XML doc.
- **#121** Client: persistence work is no longer fire-and-forget `Task.Run` — a single dedicated worker drains a bounded `Channel<PersistOp>` (capacity `PersistenceQueueCapacity`, default 256). Drained on dispose/reconnect.
- **#124** Client: session teardown centralized in `StopActiveSessionAsync` shared by `ReconnectAsync` and `DisposeAsync` — eliminates the previous race where prior-session background work could leak into the new session. Hard timeout via `SessionTeardownTimeout` (default 5s).

## Release mechanics
- `Directory.Build.props` 0.11.1 → 0.12.0.
- Promoted 6 client public API entries from Unshipped → Shipped.
- Stamped CHANGELOG `[Unreleased]` → `[0.12.0] - 2026-05-02`.
- Build clean, 147 unit + 14 conformance + 2 sample tests pass (was 138).

After merge: tag `v0.12.0` → publish workflow auto-runs → GitHub release + close issues.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>