### PR TITLE
release: v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-02
+
 ### Added
 - **client (#123)**: new `EntryPointClientOptions.AutoFlushOutboundFrames` (default `true`) controls whether `FixpClientSession.SendApplicationFrameAsync` flushes the underlying transport after every outbound application frame. The default preserves prior latency-sensitive behavior; set to `false` for throughput-sensitive batching over buffered transports (e.g. `SslStream`) and pair with the new `EntryPointClient.FlushAsync(CancellationToken)` / `IEntryPointClient.FlushAsync(CancellationToken)` at batch boundaries.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- NuGet metadata shared by all packable projects. -->
-    <Version>0.12.0</Version>
+    <Version>0.13.0</Version>
     <Authors>pedrosakuma</Authors>
     <Company>pedrosakuma</Company>
     <Copyright>Copyright (c) pedrosakuma</Copyright>

--- a/src/B3.EntryPoint.Client/PublicAPI.Shipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Shipped.txt
@@ -28,6 +28,7 @@ B3.EntryPoint.Client.EntryPointClient.ConnectAsync(System.Threading.Cancellation
 B3.EntryPoint.Client.EntryPointClient.DisposeAsync() -> System.Threading.Tasks.ValueTask
 B3.EntryPoint.Client.EntryPointClient.EntryPointClient(B3.EntryPoint.Client.EntryPointClientOptions! options) -> void
 B3.EntryPoint.Client.EntryPointClient.Events(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<B3.EntryPoint.Client.Models.EntryPointEvent!>!
+B3.EntryPoint.Client.EntryPointClient.FlushAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 B3.EntryPoint.Client.EntryPointClient.GetHealth() -> B3.EntryPoint.Client.Telemetry.ClientHealth
 B3.EntryPoint.Client.EntryPointClient.KeepAlive.get -> B3.EntryPoint.Client.Fixp.IKeepAliveScheduler?
 B3.EntryPoint.Client.EntryPointClient.MassActionAsync(B3.EntryPoint.Client.Models.MassActionRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<B3.EntryPoint.Client.Models.MassActionReport!>!
@@ -45,6 +46,8 @@ B3.EntryPoint.Client.EntryPointClient.SubmitSimpleAsync(B3.EntryPoint.Client.Mod
 B3.EntryPoint.Client.EntryPointClient.TerminateAsync(B3.EntryPoint.Client.TerminationCode code, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 B3.EntryPoint.Client.EntryPointClient.Terminated -> System.EventHandler<B3.EntryPoint.Client.TerminatedEventArgs!>?
 B3.EntryPoint.Client.EntryPointClientOptions
+B3.EntryPoint.Client.EntryPointClientOptions.AutoFlushOutboundFrames.get -> bool
+B3.EntryPoint.Client.EntryPointClientOptions.AutoFlushOutboundFrames.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.CancelOnDisconnect.get -> B3.EntryPoint.Client.CancelOnDisconnectType
 B3.EntryPoint.Client.EntryPointClientOptions.CancelOnDisconnect.set -> void
 B3.EntryPoint.Client.EntryPointClientOptions.ClientAppName.get -> string!
@@ -201,6 +204,7 @@ B3.EntryPoint.Client.ICancelOrder.MassActionAsync(B3.EntryPoint.Client.Models.Ma
 B3.EntryPoint.Client.IEntryPointClient
 B3.EntryPoint.Client.IEntryPointClient.ConnectAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 B3.EntryPoint.Client.IEntryPointClient.Events(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<B3.EntryPoint.Client.Models.EntryPointEvent!>!
+B3.EntryPoint.Client.IEntryPointClient.FlushAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 B3.EntryPoint.Client.IEntryPointClient.GetHealth() -> B3.EntryPoint.Client.Telemetry.ClientHealth
 B3.EntryPoint.Client.IEntryPointClient.KeepAlive.get -> B3.EntryPoint.Client.Fixp.IKeepAliveScheduler?
 B3.EntryPoint.Client.IEntryPointClient.ReconnectAsync(uint nextSessionVerId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -1,5 +1,1 @@
 #nullable enable
-B3.EntryPoint.Client.EntryPointClient.FlushAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-B3.EntryPoint.Client.EntryPointClientOptions.AutoFlushOutboundFrames.get -> bool
-B3.EntryPoint.Client.EntryPointClientOptions.AutoFlushOutboundFrames.set -> void
-B3.EntryPoint.Client.IEntryPointClient.FlushAsync(System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!


### PR DESCRIPTION
## v0.13.0

### Shipped
- **#123** Client: opt-in `AutoFlushOutboundFrames` (default `true`, preserves prior behavior) + new `FlushAsync(CancellationToken)` on `EntryPointClient`/`IEntryPointClient` for batching over buffered transports.
- **#125** Conformance: new `ReconnectRetransmitTests` end-to-end test covering send → peer-side drop → terminate → reconnect → resume with persisted state. Validates the v0.11.1 `LastAssignedOutboundSeqNum` snapshot fix across a terminate boundary.

### Closed as not planned
- **#122** / **#127** FIXP `FinishedSending` / `FinishedReceiving` handshake — schema v6.3 removed those frames; B3's drain is `Terminate(FINISHED)`, already implemented and exposed via `TerminateAsync`.

### Follow-up filed during this work
- **#138** — `EntryPointClient` advances `_lastInboundSeqNum` as a running max, swallowing inbound app-frame gaps without emitting `RetransmitRequest`. Production gap surfaced by the #125 test (assertion left as commented pending block referencing #138). Will be addressed in a later release.

## Release mechanics
- `Directory.Build.props` 0.12.0 → 0.13.0.
- Promoted 4 client public API entries from Unshipped → Shipped.
- Stamped CHANGELOG `[Unreleased]` → `[0.13.0] - 2026-05-02`.
- Build clean, 149 unit + 15 conformance + 2 sample tests pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>