### PR TITLE
fix(client): detect inbound seq gaps and emit RetransmitRequest (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **client (#138)**: new `EntryPointClient.InboundGapAtReconnect` event (with `InboundGapAtReconnectEventArgs` payload carrying `FromSeqNo`, `Count`, `PriorSessionVerId`). Raised exactly once per `ReconnectAsync` call when the prior session terminated with an outstanding inbound app-frame gap that cannot be served in-band — the peer bumps `SessionVerID` on reconnect and resets its outbound counter to 1, so the missing range from the prior session is unrecoverable via §4.7. Consumers should reconcile out-of-band (e.g. via a business-layer order-status query). New structured-log events `4010` (`InboundGapDetected`), `4011` (`InboundGapRequestFailed`), `4012` (`InboundGapAtReconnect`).
+
+### Fixed
+- **client (#138)**: `EntryPointClient` no longer silently swallows inbound app-frame gaps. The single `_lastInboundSeqNum` running-max counter is replaced by a `_lastContiguousInboundSeqNum` (last contiguous tail from seq 1) plus a `_highestInboundSeqNum` (running max). When an inbound app frame arrives with `SeqNum > contiguous + 1`, the client now auto-issues a §4.7 `RetransmitRequest(fromSeqNo = contiguous + 1, count = missing)` via the existing `RetransmitRequestHandler`. Concurrent gap requests are capped at one in-flight (cleared on `Retransmission` reply or `RetransmitReject`); subsequent in-order frames continue to flow to consumers immediately. Frames that arrive past a gap are buffered for contiguity tracking and the contiguous tail advances as missing seqs arrive (typically via Retransmission). The persisted `SessionSnapshot.LastInboundSeqNum` is now the contiguous tail rather than the running max — pre-0.14.0 snapshots may carry an inflated `LastInboundSeqNum`; on resume the gap is "lost" silently (same warning pattern as the v0.11.1 outbound seq fix). The persistence-worker `OrderClosedDelta`/`InboundDelta` pair now persists the contiguous tail at the time of enqueue, matching `BuildSnapshot` semantics.
+
 ## [0.13.0] - 2026-05-02
 
 ### Added

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -40,7 +40,22 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
 
     private readonly ConcurrentDictionary<string, ulong> _outstandingOrders = new(StringComparer.Ordinal);
     private long _deltasSinceCompact;
-    private ulong _lastInboundSeqNum;
+
+    // ---- Inbound gap detection (#138) ---------------------------------------
+    // _lastContiguousInboundSeqNum is the last inbound app-frame seq we know
+    // arrived contiguously from seq 1 (or from the persisted snapshot's
+    // contiguous tail). Persisted into SessionSnapshot.LastInboundSeqNum.
+    // _highestInboundSeqNum is the running max of any inbound seq we've seen,
+    // including frames that landed past a gap. The two diverge while a gap is
+    // outstanding. _pendingInboundSeqs holds the post-gap seqs received so we
+    // can advance _lastContiguousInboundSeqNum incrementally as the missing
+    // frames arrive (typically via Retransmission). _gapRequestInFlight caps
+    // concurrent outstanding RetransmitRequests at one.
+    private readonly object _inboundGapGate = new();
+    private ulong _lastContiguousInboundSeqNum;
+    private ulong _highestInboundSeqNum;
+    private readonly SortedSet<ulong> _pendingInboundSeqs = new();
+    private bool _gapRequestInFlight;
 
     /// <summary>
     /// Persistence operation enqueued from the inbound loop and drained by a
@@ -100,6 +115,16 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     /// required to resume.
     /// </summary>
     public event EventHandler<TerminatedEventArgs>? Terminated;
+
+    /// <summary>
+    /// Raised exactly once per <see cref="ReconnectAsync"/> call when the prior
+    /// session terminated with an unrecovered inbound app-frame gap. The peer
+    /// bumps <c>SessionVerID</c> on reconnect and resets its outbound counter
+    /// to 1, so the missing range cannot be served by a §4.7 <c>RetransmitRequest</c>
+    /// against the new session. Consumers should reconcile out-of-band (e.g.
+    /// via a business-layer order-status query). (#138)
+    /// </summary>
+    public event EventHandler<InboundGapAtReconnectEventArgs>? InboundGapAtReconnect;
 
     public async Task ConnectAsync(CancellationToken ct = default)
     {
@@ -196,11 +221,22 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         _session.OnInboundRetransmission = (nextSeq, count, reqNanos) =>
         {
             _lastInboundUtc = DateTime.UtcNow;
+            // The peer's reply to our outstanding RetransmitRequest. Whether
+            // it carries frames (count>0) or is an empty completion (count=0,
+            // observed against TestPeer / some gateway error paths), we clear
+            // the in-flight flag so a future gap can issue a new request.
+            // The retransmitted frames themselves flow through the inbound
+            // loop and OnInboundEventForPersistence advances the contiguous
+            // tail accordingly. (#138)
+            lock (_inboundGapGate) { _gapRequestInFlight = false; }
             _retransmit!.RaiseRetransmissionReceived(nextSeq, count, NanosToOffset(reqNanos));
         };
         _session.OnInboundRetransmitReject = (code, reqNanos) =>
         {
             _lastInboundUtc = DateTime.UtcNow;
+            // Reject clears the in-flight flag — a later gap may need to
+            // re-request after a transient peer-side condition lifts. (#138)
+            lock (_inboundGapGate) { _gapRequestInFlight = false; }
             _retransmit!.RaiseRetransmitRejected((B3.EntryPoint.Client.Fixp.RetransmitRejectCode)(byte)code, NanosToOffset(reqNanos));
         };
         _session.OnInboundNotApplied = (from, count) =>
@@ -331,7 +367,13 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             return;
         }
         _session!.ResumeOutboundSeqNum(snapshot.LastOutboundSeqNum + 1UL);
-        _lastInboundSeqNum = snapshot.LastInboundSeqNum;
+        lock (_inboundGapGate)
+        {
+            _lastContiguousInboundSeqNum = snapshot.LastInboundSeqNum;
+            _highestInboundSeqNum = snapshot.LastInboundSeqNum;
+            _pendingInboundSeqs.Clear();
+            _gapRequestInFlight = false;
+        }
         _outstandingOrders.Clear();
         foreach (var (clordid, secId) in snapshot.OutstandingOrders)
             _outstandingOrders[clordid] = secId;
@@ -371,19 +413,101 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         }
     }
 
-    private SessionSnapshot BuildSnapshot() => new()
+    private SessionSnapshot BuildSnapshot()
     {
-        SessionId = _options.SessionId,
-        SessionVerId = _options.SessionVerId,
-        LastOutboundSeqNum = _session is null ? 0UL : _session.LastAssignedOutboundSeqNum(),
-        LastInboundSeqNum = _lastInboundSeqNum,
-        CapturedAt = DateTimeOffset.UtcNow,
-        OutstandingOrders = new Dictionary<string, ulong>(_outstandingOrders),
-    };
+        ulong contiguous;
+        lock (_inboundGapGate) { contiguous = _lastContiguousInboundSeqNum; }
+        return new()
+        {
+            SessionId = _options.SessionId,
+            SessionVerId = _options.SessionVerId,
+            LastOutboundSeqNum = _session is null ? 0UL : _session.LastAssignedOutboundSeqNum(),
+            // #138: persist the last *contiguous* inbound seq, never the
+            // running max. A snapshot captured while a gap is outstanding
+            // would otherwise silently lose the missing range on resume.
+            LastInboundSeqNum = contiguous,
+            CapturedAt = DateTimeOffset.UtcNow,
+            OutstandingOrders = new Dictionary<string, ulong>(_outstandingOrders),
+        };
+    }
 
     private void OnInboundEventForPersistence(EntryPointEvent evt)
     {
-        if (evt.SeqNum > _lastInboundSeqNum) _lastInboundSeqNum = evt.SeqNum;
+        ulong contiguousAfter;
+        bool requestGap = false;
+        ulong gapFrom = 0UL;
+        uint gapCount = 0u;
+        ulong gapTriggerSeq = 0UL;
+        ulong gapExpectedSeq = 0UL;
+
+        lock (_inboundGapGate)
+        {
+            var seq = evt.SeqNum;
+            if (seq > _highestInboundSeqNum) _highestInboundSeqNum = seq;
+
+            if (seq == _lastContiguousInboundSeqNum + 1UL)
+            {
+                _lastContiguousInboundSeqNum = seq;
+                // Drain any post-gap seqs that are now contiguous.
+                while (_pendingInboundSeqs.Count > 0)
+                {
+                    var min = _pendingInboundSeqs.Min;
+                    if (min != _lastContiguousInboundSeqNum + 1UL) break;
+                    _lastContiguousInboundSeqNum = min;
+                    _pendingInboundSeqs.Remove(min);
+                }
+                if (_lastContiguousInboundSeqNum >= _highestInboundSeqNum)
+                    _gapRequestInFlight = false;
+            }
+            else if (seq > _lastContiguousInboundSeqNum + 1UL)
+            {
+                // Gap. Buffer the post-gap seq for later contiguity tracking;
+                // the frame itself is still surfaced to consumers immediately
+                // by the inbound loop (any duplicates that arrive via the
+                // Retransmission reply are detected as already-contiguous and
+                // ignored for advancement, but still flow to consumers). #138
+                _pendingInboundSeqs.Add(seq);
+                if (!_gapRequestInFlight)
+                {
+                    gapFrom = _lastContiguousInboundSeqNum + 1UL;
+                    var missing = seq - gapFrom;
+                    gapCount = (uint)Math.Min(missing, RetransmitRequestHandler.MaxCountPerRequest);
+                    gapExpectedSeq = gapFrom;
+                    gapTriggerSeq = seq;
+                    _gapRequestInFlight = true;
+                    requestGap = true;
+                }
+            }
+            // else: duplicate (seq <= _lastContiguousInboundSeqNum). Already
+            // contiguous; persistence below is still safe — it operates on
+            // ClOrdID set membership.
+
+            contiguousAfter = _lastContiguousInboundSeqNum;
+        }
+
+        if (requestGap)
+        {
+            _options.Logger.InboundGapDetected(gapExpectedSeq, gapTriggerSeq, gapFrom, gapCount);
+            var handler = _retransmit;
+            if (handler is not null)
+            {
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await handler.RequestRetransmitAsync(gapFrom, gapCount).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Reset in-flight on send failure so a later frame can
+                        // re-trigger the request.
+                        lock (_inboundGapGate) { _gapRequestInFlight = false; }
+                        _options.Logger.InboundGapRequestFailed(ex, gapFrom, gapCount);
+                    }
+                });
+            }
+        }
+
         var store = _options.SessionStateStore;
         if (store is null) return;
 
@@ -398,7 +522,9 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         if (closedClOrdId is null) return;
         _outstandingOrders.TryRemove(closedClOrdId, out _);
 
-        EnqueuePersistOp(new PersistOp(closedClOrdId, evt.SeqNum));
+        // #138: persist the contiguous tail, not the raw evt.SeqNum, so the
+        // replayed snapshot's LastInboundSeqNum matches BuildSnapshot semantics.
+        EnqueuePersistOp(new PersistOp(closedClOrdId, contiguousAfter));
     }
 
     /// <summary>
@@ -446,6 +572,24 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         => EnqueuePersistOp(new PersistOp(clOrdID, inboundSeqNum));
     internal Task StopActiveSessionForTestingAsync(CancellationToken ct = default)
         => StopActiveSessionAsync(ct);
+
+    internal void HandleInboundEventForTesting(EntryPointEvent evt) => OnInboundEventForPersistence(evt);
+    internal void BindRetransmitForTesting(RetransmitRequestHandler handler) => _retransmit = handler;
+    internal (ulong contiguous, ulong highest, int pending, bool gapInFlight) GetInboundGapStateForTesting()
+    {
+        lock (_inboundGapGate)
+            return (_lastContiguousInboundSeqNum, _highestInboundSeqNum, _pendingInboundSeqs.Count, _gapRequestInFlight);
+    }
+    internal void RaiseInboundGapAtReconnectForTesting(ulong fromSeqNo, uint count, ulong priorSessionVerId)
+        => InboundGapAtReconnect?.Invoke(this, new InboundGapAtReconnectEventArgs(fromSeqNo, count, priorSessionVerId));
+    internal void SetInboundGapStateForTesting(ulong contiguous, ulong highest)
+    {
+        lock (_inboundGapGate)
+        {
+            _lastContiguousInboundSeqNum = contiguous;
+            _highestInboundSeqNum = highest;
+        }
+    }
 
     private void StartPersistenceWorkerCore()
     {
@@ -734,6 +878,26 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             throw new ArgumentOutOfRangeException(nameof(nextSessionVerId),
                 "Next SessionVerID must be strictly greater than the current one.");
 
+        // #138: capture an outstanding inbound gap from the prior session
+        // before any state is reset. The peer bumps SessionVerID on reconnect
+        // and resets its outbound to 1, so the missing range is unrecoverable
+        // in-band — surface it via InboundGapAtReconnect after the new
+        // session is up so consumers can reconcile out-of-band.
+        ulong gapFrom = 0UL;
+        uint gapCount = 0u;
+        var priorSessionVerId = (ulong)_options.SessionVerId;
+        lock (_inboundGapGate)
+        {
+            if (_highestInboundSeqNum > _lastContiguousInboundSeqNum)
+            {
+                gapFrom = _lastContiguousInboundSeqNum + 1UL;
+                var window = _highestInboundSeqNum - _lastContiguousInboundSeqNum;
+                // window includes both missing and post-gap-buffered seqs;
+                // subtract the latter to get the true missing count.
+                gapCount = (uint)(window - (ulong)_pendingInboundSeqs.Count);
+            }
+        }
+
         // Best-effort graceful Terminate before tearing the active session down.
         try
         {
@@ -747,8 +911,26 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         // one (#124).
         await StopActiveSessionAsync(ct).ConfigureAwait(false);
 
+        // Reset inbound seq tracking — the new session starts at peer seq 1.
+        // HydrateFromSnapshotAsync (called from the next ConnectAsync) will
+        // overwrite this from the persisted snapshot for warm-restart paths.
+        lock (_inboundGapGate)
+        {
+            _lastContiguousInboundSeqNum = 0UL;
+            _highestInboundSeqNum = 0UL;
+            _pendingInboundSeqs.Clear();
+            _gapRequestInFlight = false;
+        }
+
         _options.SessionVerId = nextSessionVerId;
         await ConnectAsync(ct).ConfigureAwait(false);
+
+        if (gapCount > 0u)
+        {
+            _options.Logger.InboundGapAtReconnect(priorSessionVerId, gapFrom, gapCount);
+            InboundGapAtReconnect?.Invoke(this,
+                new InboundGapAtReconnectEventArgs(gapFrom, gapCount, priorSessionVerId));
+        }
     }
 
     /// <summary>

--- a/src/B3.EntryPoint.Client/InboundGapAtReconnectEventArgs.cs
+++ b/src/B3.EntryPoint.Client/InboundGapAtReconnectEventArgs.cs
@@ -1,0 +1,30 @@
+namespace B3.EntryPoint.Client;
+
+/// <summary>
+/// Payload of <see cref="EntryPointClient.InboundGapAtReconnect"/>. Surfaces an
+/// inbound application-frame gap that was outstanding when the prior session
+/// terminated and is therefore unrecoverable in-band — the peer bumps
+/// <c>SessionVerID</c> on reconnect and resets its outbound counter to 1, so
+/// the missing range from the prior session cannot be served by a §4.7
+/// <c>RetransmitRequest</c> against the new session. Consumers should reconcile
+/// out-of-band (e.g. via a business-layer order-status query). Emitted exactly
+/// once per <see cref="EntryPointClient.ReconnectAsync"/> call. (#138)
+/// </summary>
+public sealed class InboundGapAtReconnectEventArgs : EventArgs
+{
+    public InboundGapAtReconnectEventArgs(ulong fromSeqNo, uint count, ulong priorSessionVerId)
+    {
+        FromSeqNo = fromSeqNo;
+        Count = count;
+        PriorSessionVerId = priorSessionVerId;
+    }
+
+    /// <summary>First missing inbound sequence number from the prior session.</summary>
+    public ulong FromSeqNo { get; }
+
+    /// <summary>Number of consecutive missing inbound sequence numbers starting at <see cref="FromSeqNo"/>.</summary>
+    public uint Count { get; }
+
+    /// <summary><c>SessionVerID</c> of the prior session in which the gap occurred.</summary>
+    public ulong PriorSessionVerId { get; }
+}

--- a/src/B3.EntryPoint.Client/Logging/LogMessages.cs
+++ b/src/B3.EntryPoint.Client/Logging/LogMessages.cs
@@ -127,6 +127,18 @@ internal static partial class LogMessages
         Message = "Session teardown: background task '{Task}' did not complete within {Timeout}; abandoning")]
     public static partial void SessionTeardownTimeout(this ILogger logger, string task, TimeSpan timeout);
 
+    [LoggerMessage(EventId = 4010, Level = LogLevel.Warning,
+        Message = "Inbound app-frame gap detected: expected {Expected}, received {Received}; auto-issuing RetransmitRequest fromSeqNo={FromSeqNo} count={Count}")]
+    public static partial void InboundGapDetected(this ILogger logger, ulong expected, ulong received, ulong fromSeqNo, uint count);
+
+    [LoggerMessage(EventId = 4011, Level = LogLevel.Warning,
+        Message = "Failed to auto-issue RetransmitRequest for inbound gap fromSeqNo={FromSeqNo} count={Count}")]
+    public static partial void InboundGapRequestFailed(this ILogger logger, Exception ex, ulong fromSeqNo, uint count);
+
+    [LoggerMessage(EventId = 4012, Level = LogLevel.Warning,
+        Message = "Reconnect carries unrecovered inbound gap from prior session ver={PriorSessionVerId}: fromSeqNo={FromSeqNo} count={Count} — out-of-band reconciliation required")]
+    public static partial void InboundGapAtReconnect(this ILogger logger, ulong priorSessionVerId, ulong fromSeqNo, uint count);
+
     // ---------------- Error (5000–5999) ----------------
 
     [LoggerMessage(EventId = 5000, Level = LogLevel.Error,

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+B3.EntryPoint.Client.EntryPointClient.InboundGapAtReconnect -> System.EventHandler<B3.EntryPoint.Client.InboundGapAtReconnectEventArgs!>?
+B3.EntryPoint.Client.InboundGapAtReconnectEventArgs
+B3.EntryPoint.Client.InboundGapAtReconnectEventArgs.InboundGapAtReconnectEventArgs(ulong fromSeqNo, uint count, ulong priorSessionVerId) -> void
+B3.EntryPoint.Client.InboundGapAtReconnectEventArgs.FromSeqNo.get -> ulong
+B3.EntryPoint.Client.InboundGapAtReconnectEventArgs.Count.get -> uint
+B3.EntryPoint.Client.InboundGapAtReconnectEventArgs.PriorSessionVerId.get -> ulong

--- a/tests/B3.EntryPoint.Client.Tests/InboundGapDetectionUnitTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/InboundGapDetectionUnitTests.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Reflection;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client.Tests;
+
+/// <summary>
+/// Unit tests for the inbound gap detection introduced in #138. Drives
+/// <c>OnInboundEventForPersistence</c> directly via the
+/// <c>HandleInboundEventForTesting</c> internal hook with a stub
+/// <see cref="RetransmitRequestHandler"/> bound via
+/// <c>BindRetransmitForTesting</c>, so the tests do not require a live FIXP
+/// session.
+/// </summary>
+public class InboundGapDetectionUnitTests
+{
+    private static EntryPointClientOptions BaseOptions() => new()
+    {
+        Endpoint = new IPEndPoint(IPAddress.Loopback, 1),
+        SessionId = 42u,
+        SessionVerId = 1u,
+        EnteringFirm = 7u,
+        Credentials = Credentials.FromUtf8("k"),
+    };
+
+    private static RetransmitRequestHandler StubHandler(List<(ulong from, uint count)> calls)
+    {
+        Task SendAsync(ulong from, uint count, CancellationToken ct)
+        {
+            lock (calls) calls.Add((from, count));
+            return Task.CompletedTask;
+        }
+        var ctor = typeof(RetransmitRequestHandler).GetConstructors(
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            .Single(c => c.GetParameters().Length == 1);
+        return (RetransmitRequestHandler)ctor.Invoke(new object?[]
+        {
+            (Func<ulong, uint, CancellationToken, Task>)SendAsync,
+        });
+    }
+
+    private static EntryPointEvent FakeAck(ulong seq) => new OrderAccepted
+    {
+        SeqNum = seq,
+        SendingTime = DateTimeOffset.UnixEpoch,
+        ClOrdID = new ClOrdID(seq),
+        OrderId = seq,
+        OrderStatus = OrderStatus.New,
+        SecurityId = 1UL,
+        Side = Side.Buy,
+    };
+
+    [Fact]
+    public async Task InSessionGap_EmitsRetransmitRequest()
+    {
+        var calls = new List<(ulong from, uint count)>();
+        var handler = StubHandler(calls);
+
+        var client = new EntryPointClient(BaseOptions());
+        client.BindRetransmitForTesting(handler);
+
+        var requested = new TaskCompletionSource<RetransmitRequestedEventArgs>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        handler.RetransmitRequested += (_, e) => requested.TrySetResult(e);
+
+        // Feed seqs [1, 2, 5] — gap is [3, 4].
+        client.HandleInboundEventForTesting(FakeAck(1));
+        client.HandleInboundEventForTesting(FakeAck(2));
+        client.HandleInboundEventForTesting(FakeAck(5));
+
+        var args = await requested.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(3UL, args.FromSeqNo);
+        Assert.Equal(2u, args.Count);
+
+        // Wait for the async send dispatched from OnInboundEventForPersistence
+        // (Task.Run) to actually invoke the stub.
+        for (var i = 0; i < 50 && calls.Count == 0; i++)
+            await Task.Delay(10);
+        Assert.Single(calls);
+        Assert.Equal((3UL, 2u), calls[0]);
+
+        var state = client.GetInboundGapStateForTesting();
+        Assert.Equal(2UL, state.contiguous);
+        Assert.Equal(5UL, state.highest);
+        Assert.Equal(1, state.pending);
+        Assert.True(state.gapInFlight);
+    }
+
+    [Fact]
+    public async Task GapFilledByRetransmission_AdvancesContiguousAndClearsInFlight()
+    {
+        var calls = new List<(ulong from, uint count)>();
+        var handler = StubHandler(calls);
+        var client = new EntryPointClient(BaseOptions());
+        client.BindRetransmitForTesting(handler);
+
+        client.HandleInboundEventForTesting(FakeAck(1));
+        client.HandleInboundEventForTesting(FakeAck(2));
+        client.HandleInboundEventForTesting(FakeAck(5));
+
+        // Wait until the gap-detect dispatch has fired so _gapRequestInFlight
+        // is observably set.
+        for (var i = 0; i < 50 && calls.Count == 0; i++)
+            await Task.Delay(10);
+
+        // Retransmitted frames arrive in order — contiguous tail catches up
+        // to the running max (5).
+        client.HandleInboundEventForTesting(FakeAck(3));
+        client.HandleInboundEventForTesting(FakeAck(4));
+
+        var state = client.GetInboundGapStateForTesting();
+        Assert.Equal(5UL, state.contiguous);
+        Assert.Equal(5UL, state.highest);
+        Assert.Equal(0, state.pending);
+        Assert.False(state.gapInFlight);
+
+        // No additional RetransmitRequest while only one gap was outstanding.
+        Assert.Single(calls);
+    }
+
+    [Fact]
+    public async Task ConcurrentGaps_AreCappedAtOneInFlight()
+    {
+        var calls = new List<(ulong from, uint count)>();
+        var handler = StubHandler(calls);
+        var client = new EntryPointClient(BaseOptions());
+        client.BindRetransmitForTesting(handler);
+
+        // Two non-contiguous gaps in quick succession: [3] missing, then [6,7]
+        // missing. Only one RetransmitRequest should be in flight at a time.
+        client.HandleInboundEventForTesting(FakeAck(1));
+        client.HandleInboundEventForTesting(FakeAck(2));
+        client.HandleInboundEventForTesting(FakeAck(4));
+        client.HandleInboundEventForTesting(FakeAck(5));
+        client.HandleInboundEventForTesting(FakeAck(8));
+
+        for (var i = 0; i < 50 && calls.Count == 0; i++)
+            await Task.Delay(10);
+
+        Assert.Single(calls);
+        Assert.Equal((3UL, 1u), calls[0]);
+    }
+
+    [Fact]
+    public void DuplicateSeqs_AreIgnoredForAdvancement()
+    {
+        var calls = new List<(ulong from, uint count)>();
+        var handler = StubHandler(calls);
+        var client = new EntryPointClient(BaseOptions());
+        client.BindRetransmitForTesting(handler);
+
+        client.HandleInboundEventForTesting(FakeAck(1));
+        client.HandleInboundEventForTesting(FakeAck(2));
+        client.HandleInboundEventForTesting(FakeAck(2)); // duplicate
+        client.HandleInboundEventForTesting(FakeAck(1)); // duplicate
+
+        var state = client.GetInboundGapStateForTesting();
+        Assert.Equal(2UL, state.contiguous);
+        Assert.Equal(2UL, state.highest);
+        Assert.False(state.gapInFlight);
+        Assert.Empty(calls);
+    }
+
+    [Fact]
+    public void InboundGapAtReconnectEvent_FiresWithExpectedArgs()
+    {
+        var client = new EntryPointClient(BaseOptions());
+        InboundGapAtReconnectEventArgs? captured = null;
+        client.InboundGapAtReconnect += (_, e) => captured = e;
+
+        client.RaiseInboundGapAtReconnectForTesting(fromSeqNo: 3UL, count: 1u, priorSessionVerId: 5UL);
+
+        Assert.NotNull(captured);
+        Assert.Equal(3UL, captured!.FromSeqNo);
+        Assert.Equal(1u, captured.Count);
+        Assert.Equal(5UL, captured.PriorSessionVerId);
+    }
+
+    [Fact]
+    public void GapState_CapturedForReconnect_ReportsCorrectMissingCount()
+    {
+        // Simulates the snapshot the ReconnectAsync prelude takes: contiguous=2,
+        // highest=5, pending=[4,5] -> missing = (5-2) - 2 = 1 (seq 3 only).
+        var client = new EntryPointClient(BaseOptions());
+        var handler = StubHandler(new List<(ulong, uint)>());
+        client.BindRetransmitForTesting(handler);
+
+        client.HandleInboundEventForTesting(FakeAck(1));
+        client.HandleInboundEventForTesting(FakeAck(2));
+        client.HandleInboundEventForTesting(FakeAck(4));
+        client.HandleInboundEventForTesting(FakeAck(5));
+
+        var state = client.GetInboundGapStateForTesting();
+        Assert.Equal(2UL, state.contiguous);
+        Assert.Equal(5UL, state.highest);
+        Assert.Equal(2, state.pending);
+        // Missing in the [3..5] window = (5-2) - pending(2) = 1 (only seq 3).
+        var missing = (uint)((state.highest - state.contiguous) - (ulong)state.pending);
+        Assert.Equal(1u, missing);
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/InboundGapDetectionTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/InboundGapDetectionTests.cs
@@ -1,0 +1,150 @@
+using System.Collections.Concurrent;
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Client.TestPeer;
+using B3.EntryPoint.Conformance.Infrastructure;
+using NewOrderSingleData = B3.Entrypoint.Fixp.Sbe.V6.NewOrderSingleData;
+
+namespace B3.EntryPoint.Conformance.Spec_4_7_Retransmit;
+
+/// <summary>
+/// Spec §4.7 — In-session inbound gap detection (issue #138). Asserts that the
+/// client auto-emits a <c>RetransmitRequest</c> when a peer-side outbound app
+/// frame is dropped, and that the <c>InboundGapAtReconnect</c> event does
+/// <i>not</i> fire after a clean Terminate (the event is reserved for the
+/// reconnect path).
+/// </summary>
+[Trait("Category", "Conformance")]
+public class InboundGapDetectionTests
+{
+    [TestPeerOnlyConformanceFact]
+    public async Task InboundGapTriggersRetransmitRequest()
+    {
+        // Drop the 2nd outbound app frame so the client receives ER seqs
+        // [1, 3]. The arrival of seq 3 should trigger the gap-detection logic
+        // to emit RetransmitRequest(fromSeqNo=2, count=1).
+        var schedule = new Dictionary<int, OutboundFrameAction>
+        {
+            [2] = new OutboundFrameAction.Drop(),
+        };
+        var scenario = TestPeerScenarios.WithSequenceFaults(TestPeerScenarios.AcceptAll, schedule);
+        await using var fx = new ConformancePeerFactory(scenario);
+
+        var peerInboundNosSeqs = new ConcurrentQueue<uint>();
+        fx.Peer.MessageReceived += (_, args) =>
+        {
+            if (args.TemplateId != NewOrderSingleData.MESSAGE_ID) return;
+            if (!NewOrderSingleData.TryParse(args.Payload.Span, out var reader)) return;
+            peerInboundNosSeqs.Enqueue(reader.Data.BusinessHeader.MsgSeqNum.Value);
+        };
+
+        await using var client = new EntryPointClient(fx.ClientOptions);
+        await client.ConnectAsync();
+
+        var retransmitRequested = new TaskCompletionSource<RetransmitRequestedEventArgs>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        client.Retransmit!.RetransmitRequested += (_, args) => retransmitRequested.TrySetResult(args);
+
+        var inboundGapAtReconnectFired = false;
+        client.InboundGapAtReconnect += (_, _) => inboundGapAtReconnectFired = true;
+
+        for (ulong i = 1; i <= 3; i++)
+        {
+            await client.SubmitAsync(new NewOrderRequest
+            {
+                ClOrdID = (ClOrdID)i,
+                SecurityId = 4321UL,
+                Side = Side.Buy,
+                OrderType = OrderType.Limit,
+                Price = 10.0m,
+                OrderQty = 100UL,
+            });
+        }
+
+        // Drain the 2 ERs we expect to actually arrive (seq 2 was dropped).
+        await DrainEventsAsync(client, expected: 2, TimeSpan.FromSeconds(5));
+
+        // The client should have detected the gap (received seq=3 while
+        // contiguous tail was 1) and issued RetransmitRequest(2, 1).
+        var rr = await retransmitRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(2UL, rr.FromSeqNo);
+        Assert.Equal(1u, rr.Count);
+
+        // Clean Terminate. InboundGapAtReconnect must NOT fire — that event
+        // is reserved for the reconnect path. (Terminate alone does not
+        // surface unrecovered gaps; the consumer simply loses the session.)
+        await client.TerminateAsync(TerminationCode.Finished);
+
+        // Settle window: give any spurious event a chance to surface.
+        await Task.Delay(TimeSpan.FromMilliseconds(200));
+        Assert.False(inboundGapAtReconnectFired, "InboundGapAtReconnect must not fire on clean Terminate.");
+    }
+
+    [TestPeerOnlyConformanceFact]
+    public async Task InboundGapAtReconnect_FiresWhenUnrecoveredGapAtReconnect()
+    {
+        // Drop the 2nd outbound app frame (ER seq 2). The peer's TestPeer
+        // implementation answers RetransmitRequest with an empty
+        // Retransmission frame (count=0), so the gap stays unrecovered.
+        // After ReconnectAsync bumps SessionVerID, the client must surface
+        // the leftover gap via InboundGapAtReconnect.
+        var schedule = new Dictionary<int, OutboundFrameAction>
+        {
+            [2] = new OutboundFrameAction.Drop(),
+        };
+        var scenario = TestPeerScenarios.WithSequenceFaults(TestPeerScenarios.AcceptAll, schedule);
+        await using var fx = new ConformancePeerFactory(scenario);
+
+        var options = fx.ClientOptions;
+        await using var client = new EntryPointClient(options);
+        await client.ConnectAsync();
+
+        var gapAtReconnect = new TaskCompletionSource<InboundGapAtReconnectEventArgs>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        client.InboundGapAtReconnect += (_, args) => gapAtReconnect.TrySetResult(args);
+
+        var priorVer = options.SessionVerId;
+
+        for (ulong i = 1; i <= 3; i++)
+        {
+            await client.SubmitAsync(new NewOrderRequest
+            {
+                ClOrdID = (ClOrdID)i,
+                SecurityId = 4321UL,
+                Side = Side.Buy,
+                OrderType = OrderType.Limit,
+                Price = 10.0m,
+                OrderQty = 100UL,
+            });
+        }
+
+        // Drain the 2 ERs we expect (seq 2 dropped).
+        await DrainEventsAsync(client, expected: 2, TimeSpan.FromSeconds(5));
+
+        // ReconnectAsync — the prior session's gap (seq 2) is unrecovered;
+        // event must fire exactly once after the new session establishes.
+        await client.ReconnectAsync(options.SessionVerId + 1);
+
+        var args = await gapAtReconnect.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(2UL, args.FromSeqNo);
+        Assert.Equal(1u, args.Count);
+        Assert.Equal((ulong)priorVer, args.PriorSessionVerId);
+    }
+
+    private static async Task<List<ulong>> DrainEventsAsync(EntryPointClient client, int expected, TimeSpan timeout)
+    {
+        var seqs = new List<ulong>();
+        using var cts = new CancellationTokenSource(timeout);
+        try
+        {
+            await foreach (var evt in client.Events().WithCancellation(cts.Token))
+            {
+                seqs.Add(evt.SeqNum);
+                if (seqs.Count >= expected) break;
+            }
+        }
+        catch (OperationCanceledException) { /* timeout — caller may inspect */ }
+        return seqs;
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/ReconnectRetransmitTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/ReconnectRetransmitTests.cs
@@ -78,6 +78,14 @@ public class ReconnectRetransmitTests
         await using var client = new EntryPointClient(options);
         await client.ConnectAsync();
 
+        // #138 — the client now auto-detects inbound gaps and emits a §4.7
+        // RetransmitRequest. Register the listener BEFORE submitting orders
+        // so we don't race the asynchronous request issued from the inbound
+        // loop the moment the post-gap frame (ER seq 4) arrives.
+        var retransmitRequested = new TaskCompletionSource<RetransmitRequestedEventArgs>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        client.Retransmit!.RetransmitRequested += (_, args) => retransmitRequested.TrySetResult(args);
+
         // 2. Submit 5 NewOrderSingle requests sequentially.
         for (ulong i = 1; i <= 5; i++)
         {
@@ -163,18 +171,12 @@ public class ReconnectRetransmitTests
         }
         Assert.Equal(6u, await seenSix.Task);
 
-        // 8. Pending #138 follow-up — production gap: the client does not
-        //    detect the inbound gap (peer→client ER seq 3 was dropped) and
-        //    does not auto-emit a §4.7 RetransmitRequest, in the live session
-        //    or after reconnect. When that gap is closed, re-enable the
-        //    assertion below.
-        //
-        // var retransmitRequested = new TaskCompletionSource<RetransmitRequestedEventArgs>(
-        //     TaskCreationOptions.RunContinuationsAsynchronously);
-        // client.Retransmit!.RetransmitRequested += (_, args) => retransmitRequested.TrySetResult(args);
-        // var rr = await retransmitRequested.Task.WaitAsync(TimeSpan.FromSeconds(3));
-        // Assert.Equal(3UL, rr.FromSeqNo);
-        // Assert.Equal(1u, rr.Count);
+        // 8. #138 — assert the auto-emitted RetransmitRequest from step 2's
+        //    gap detection (ER seq 3 was dropped). Listener was wired up
+        //    front so we don't race the inbound loop's async send.
+        var rr = await retransmitRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(3UL, rr.FromSeqNo);
+        Assert.Equal(1u, rr.Count);
     }
 
     private static async Task<List<ulong>> DrainEventsAsync(EntryPointClient client, int expected, TimeSpan timeout)


### PR DESCRIPTION
Closes #138

## Summary
- Replace running-max `_lastInboundSeqNum` with contiguous-tail + running-max model in `EntryPointClient`.
- Auto-issue §4.7 `RetransmitRequest(fromSeqNo = contiguous + 1, count = missing)` on inbound gap detection (capped at 1 in-flight).
- Persisted `SessionSnapshot.LastInboundSeqNum` is now the contiguous tail (pre-0.14.0 snapshots may carry inflated values; same warning as v0.11.1).
- New `EntryPointClient.InboundGapAtReconnect` event + `InboundGapAtReconnectEventArgs` for unrecovered gaps surviving `ReconnectAsync` (peer bumps SessionVerID, so out-of-band reconciliation is required).

## Tests
- Uncommented the pending block in `ReconnectRetransmitTests`.
- New `InboundGapDetectionTests` (conformance, 2 tests).
- New `InboundGapDetectionUnitTests` (6 tests).
- Counts: 155 unit / 17 conformance / 2 sample — all green under `ENTRYPOINT_TESTPEER=1`.

## Public API additions (Unshipped)
- `EntryPointClient.InboundGapAtReconnect` event
- `InboundGapAtReconnectEventArgs` + ctor + `FromSeqNo` + `Count` + `PriorSessionVerId`
