### PR TITLE
feat(client): typed ClOrdID key in persistence; audit public surface (#128, #130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **client (#138)**: `EntryPointClient` no longer silently swallows inbound app-frame gaps. The single `_lastInboundSeqNum` running-max counter is replaced by a `_lastContiguousInboundSeqNum` (last contiguous tail from seq 1) plus a `_highestInboundSeqNum` (running max). When an inbound app frame arrives with `SeqNum > contiguous + 1`, the client now auto-issues a §4.7 `RetransmitRequest(fromSeqNo = contiguous + 1, count = missing)` via the existing `RetransmitRequestHandler`. Concurrent gap requests are capped at one in-flight (cleared on `Retransmission` reply or `RetransmitReject`); subsequent in-order frames continue to flow to consumers immediately. Frames that arrive past a gap are buffered for contiguity tracking and the contiguous tail advances as missing seqs arrive (typically via Retransmission). The persisted `SessionSnapshot.LastInboundSeqNum` is now the contiguous tail rather than the running max — pre-0.14.0 snapshots may carry an inflated `LastInboundSeqNum`; on resume the gap is "lost" silently (same warning pattern as the v0.11.1 outbound seq fix). The persistence-worker `OrderClosedDelta`/`InboundDelta` pair now persists the contiguous tail at the time of enqueue, matching `BuildSnapshot` semantics.
 
+### Changed
+- **client (#128)**: `EntryPointClient` no longer allocates a `string` per
+  terminal `ExecutionReport` on `OnInboundEventForPersistence`. The internal
+  `_outstandingOrders` map is now keyed by the strongly-typed
+  `B3.EntryPoint.Client.Models.ClOrdID` (a `readonly record struct` over
+  `ulong`) and `OrderClosedDelta` carries that struct directly instead of a
+  string. Quote/cross flows (whose IDs are arbitrary strings) are tracked in
+  a parallel `_outstandingQuoteFlowIds` dict so they keep working unchanged.
+  **Wire-format break**: `OrderClosedDelta` now serializes as a JSON number
+  (the underlying `uint64`) instead of a JSON string. The new
+  `ClOrdIDJsonConverter` accepts both forms when reading, so deltas written
+  by &lt;= v0.13.0 still replay cleanly; new deltas written by v0.14.0
+  cannot be read by &lt;= v0.13.0 (downgrades require a fresh
+  `SessionStateStore` directory). Added the `CloseEventPersistenceBenchmarks`
+  BDN harness under `benchmarks/B3.EntryPoint.Benchmarks/` to track the
+  per-close allocation count.
+- **client (#130)**: audited the entire shipped public surface and
+  classified each member into Supported / Experimental / Obsolete (see
+  the new `docs/PUBLIC-API.md`). `CancelOnDisconnectType`,
+  `EntryPointClientOptions.CancelOnDisconnect`, `IQuoteFlow` and
+  `ISubmitCross` (and their members) are now decorated with
+  `[System.Diagnostics.CodeAnalysis.Experimental(...)]` because their
+  underlying behaviour is either not wired (`CancelOnDisconnect`) or has
+  no end-to-end conformance coverage (quote/cross flows). **Calling these
+  APIs from a downstream project will produce a build warning** with one
+  of the new diagnostic IDs (`B3EP_COD`, `B3EP_QUOTE`, `B3EP_CROSS`).
+  Suppress per call site with
+  `[SuppressMessage("Usage", "B3EP_<id>")]` or
+  `#pragma warning disable B3EP_<id>` to opt in. No member is removed from
+  `PublicAPI.Shipped.txt` (removal is reserved for v1.0).
+
 ## [0.13.0] - 2026-05-02
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
     <DebugType>portable</DebugType>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;B3EP_COD;B3EP_QUOTE;B3EP_CROSS</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsPackable)' == 'true'">

--- a/benchmarks/B3.EntryPoint.Benchmarks/CloseEventPersistenceBenchmarks.cs
+++ b/benchmarks/B3.EntryPoint.Benchmarks/CloseEventPersistenceBenchmarks.cs
@@ -1,0 +1,86 @@
+using BenchmarkDotNet.Attributes;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Client.State;
+
+namespace B3.EntryPoint.Benchmarks;
+
+/// <summary>
+/// Allocation profile of the close-event path on
+/// <c>EntryPointClient.OnInboundEventForPersistence</c> (issue #128).
+///
+/// Compares the legacy v0.13.0 shape (string-keyed dict + per-event
+/// <c>ulong.ToString()</c> + string-typed <see cref="OrderClosedDelta"/>) to
+/// the v0.14.0 shape (typed <see cref="ClOrdID"/> dict + struct-typed delta
+/// — zero per-event allocation on the close hot path).
+///
+/// Compile-only baseline; run via the standard BDN host
+/// (<c>dotnet run -c Release --project benchmarks/B3.EntryPoint.Benchmarks
+/// -- --filter *CloseEventPersistence*</c>).
+/// </summary>
+[MemoryDiagnoser]
+public class CloseEventPersistenceBenchmarks
+{
+    // 1024 outstanding orders is a realistic mid-day book for a single firm.
+    private const int OutstandingCount = 1024;
+
+    private System.Collections.Concurrent.ConcurrentDictionary<string, ulong> _stringKeyed = null!;
+    private System.Collections.Concurrent.ConcurrentDictionary<ClOrdID, ulong> _typedKeyed = null!;
+    private ulong[] _closeIds = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _stringKeyed = new(StringComparer.Ordinal);
+        _typedKeyed = new();
+        _closeIds = new ulong[OutstandingCount];
+        for (int i = 0; i < OutstandingCount; i++)
+        {
+            ulong id = (ulong)(i + 1);
+            _closeIds[i] = id;
+            _stringKeyed[id.ToString()] = (ulong)(5_900_000 + i);
+            _typedKeyed[new ClOrdID(id)] = (ulong)(5_900_000 + i);
+        }
+    }
+
+    /// <summary>
+    /// v0.13.0 path: <c>ulong.ToString()</c> per close event, allocates twice
+    /// (once for dict lookup, once for <see cref="OrderClosedDelta"/>).
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    public int Legacy_StringKeyed_PerClose()
+    {
+        int closed = 0;
+        for (int i = 0; i < OutstandingCount; i++)
+        {
+            string key = _closeIds[i].ToString();
+            if (_stringKeyed.TryRemove(key, out _))
+            {
+                _ = new LegacyClosed(key); // simulate OrderClosedDelta(string)
+                closed++;
+            }
+        }
+        return closed;
+    }
+
+    /// <summary>
+    /// v0.14.0 path: typed <see cref="ClOrdID"/> dict key, no per-event
+    /// string allocation. <see cref="OrderClosedDelta"/> carries the struct.
+    /// </summary>
+    [Benchmark]
+    public int Typed_ClOrdID_PerClose()
+    {
+        int closed = 0;
+        for (int i = 0; i < OutstandingCount; i++)
+        {
+            var key = new ClOrdID(_closeIds[i]);
+            if (_typedKeyed.TryRemove(key, out _))
+            {
+                _ = new OrderClosedDelta(key);
+                closed++;
+            }
+        }
+        return closed;
+    }
+
+    private sealed record LegacyClosed(string ClOrdID);
+}

--- a/docs/PUBLIC-API.md
+++ b/docs/PUBLIC-API.md
@@ -1,0 +1,137 @@
+# Public API surface (v0.14.0)
+
+This document is an audit of `B3.EntryPoint.Client`'s public API
+(post-v0.13.0 promotion of `PublicAPI.Shipped.txt`, ~1218 entries).
+Every member is classified as **Supported**, **Experimental** or
+**Obsolete**. This is the deliverable for issue #130.
+
+> **Annotation policy.** Removing a `Shipped` member is a hard breaking
+> change reserved for v1.0. Until then the audit only **annotates**
+> (no member is deleted from `PublicAPI.Shipped.txt` in this PR).
+> Experimental members are decorated with
+> `[System.Diagnostics.CodeAnalysis.Experimental("B3EP_<area>")]` so a
+> consumer who calls them gets a build warning naming the area; that
+> warning can be suppressed per call site with the standard
+> `[SuppressMessage]` / `#pragma` mechanism. Obsolete members would be
+> decorated with `[Obsolete]` — none in this audit.
+
+---
+
+## Supported surface
+
+The following groups are wired end-to-end, exercised by behavioural
+tests, and have XML documentation describing their contract and error
+modes. They are safe to take a hard dependency on at minor-version
+granularity (semantic-versioned breaks at major-version bumps only).
+
+### Order entry — `B3.EntryPoint.Client.EntryPointClient`
+
+Implements `ISubmitOrder`, `IReplaceOrder`, `ICancelOrder` and the
+session lifecycle exposed by `IEntryPointClient`.
+
+| Member | Notes |
+| --- | --- |
+| `ConnectAsync(CancellationToken)` | TCP + Negotiate + Establish; covered by conformance §4.2/§4.3. |
+| `DisposeAsync()` | Best-effort `Terminate` + drain (#121, #124). |
+| `ReconnectAsync(uint nextSessionVerId, CancellationToken)` | Strict-monotonic SessionVerId; teardown ordering documented. Covered by `ReconnectTeardownTests` and conformance §4.7 retransmit. |
+| `SubmitAsync` / `SubmitSimpleAsync` | NewOrder + SimpleNewOrder encoders + risk gate + delta persist (#128 typed key). |
+| `ReplaceAsync` / `ReplaceSimpleAsync` | OrderCancelReplace + SimpleModify. |
+| `CancelAsync` | OrderCancelRequest. |
+| `MassActionAsync` | OrderMassAction. |
+| `FlushAsync(CancellationToken)` | #123 batch-boundary flush. |
+| `Events()` | Bounded inbound event channel (#126). |
+| `GetHealth()` | Liveness/inbound-staleness probe. |
+
+### Drop copy — `B3.EntryPoint.Client.DropCopy.DropCopyClient`
+
+Read-only `Profile = SessionProfile.DropCopy` session. Same lifecycle
+as `EntryPointClient`; no order entry methods exposed.
+
+### Session control — `B3.EntryPoint.Client.Fixp.IKeepAliveScheduler` and `IRetransmitRequestHandler`
+
+Exposed as nullable properties on `EntryPointClient` (`KeepAlive`,
+`Retransmit`). Bound after `ConnectAsync`. Both are part of the
+spec-mandated FIXP plumbing (§4.6, §4.7) and have unit + conformance
+coverage. Concrete implementations `KeepAliveScheduler` and
+`RetransmitRequestHandler` ship as `public sealed` for advanced
+hosting scenarios but the typical consumer should code against the
+interfaces.
+
+### State persistence — `B3.EntryPoint.Client.State`
+
+`ISessionStateStore`, `FileSessionStateStore`, `SessionSnapshot`,
+`OutboundDelta`, `InboundDelta`, `OrderClosedDelta`. See
+`docs/CONFORMANCE.md` §4.7 for the warm-restart contract. After #128
+`OrderClosedDelta` carries a strongly-typed
+`B3.EntryPoint.Client.Models.ClOrdID` and is serialized as a JSON
+number (ulong); the `ClOrdIDJsonConverter` reads both number and
+string forms for backward compatibility with v0.13.0 deltas.
+
+### Models — `B3.EntryPoint.Client.Models`
+
+Request/event records (`NewOrderRequest`, `OrderTrade`, `OrderCancelled`,
+…), enums, and the `ClOrdID` value type. Stable.
+
+### Risk — `B3.EntryPoint.Client.Risk`
+
+`IRiskGate` and the built-in `MaxNotionalRiskGate` /
+`MaxOpenOrdersRiskGate`. Stable.
+
+### Logging / Telemetry — `B3.EntryPoint.Client.Logging`, `B3.EntryPoint.Client.Telemetry`
+
+`LogMessages` extension (source-generated `LoggerMessage`s, EventIds
+1xxx/4xxx/5xxx) and `EntryPointTelemetry` meters. Stable.
+
+---
+
+## Experimental surface
+
+All members in this section are decorated with
+`[Experimental("B3EP_<id>")]`. Calling them produces a build warning
+(diagnostic ID = the second column) which a consumer can suppress
+per-site. Within this repository the IDs are blanket-suppressed in
+`Directory.Build.props` (`<NoWarn>`) so internal tests still build.
+
+| Member | Diagnostic ID | Rationale |
+| --- | --- | --- |
+| `B3.EntryPoint.Client.CancelOnDisconnectType` (enum) | `B3EP_COD` | Type ships, but `EntryPointClientOptions.CancelOnDisconnect` is **not** wired into the FIXP `Negotiate` frame — the gateway-side behaviour is whatever the gateway defaults to, regardless of what the consumer sets. Track via #130 follow-up; do not depend on this for risk-critical flows. |
+| `EntryPointClientOptions.CancelOnDisconnect` (property) | `B3EP_COD` | Same — see above. |
+| `B3.EntryPoint.Client.IQuoteFlow` (interface + members `SendQuoteRequestAsync`, `SendQuoteAsync`, `CancelQuoteAsync`) | `B3EP_QUOTE` | Wire encoders ship and `EntryPointClient` implements the interface, but coverage stops at API-surface assertions (`CrossQuoteApiSurfaceTests`). No end-to-end conformance test exercises `Quote*` round-trips with a peer. Treat as preview. |
+| `B3.EntryPoint.Client.ISubmitCross` (interface + member `SubmitCrossAsync`) | `B3EP_CROSS` | Same shape: encoder wired, no behavioural test. |
+
+The attribute applied to the interface flows through to the
+`EntryPointClient.SubmitCrossAsync` / quote-flow methods at use sites
+(invoking `client.SendQuoteAsync(...)` triggers the warning even if
+the call uses `EntryPointClient` directly, because the method
+implements an experimental interface member).
+
+### Why not just remove these?
+
+Removing them is a hard breaking change reserved for v1.0. Annotating
+gives downstream consumers a build-time signal **today** and an
+ergonomic opt-in (`#pragma warning disable B3EP_QUOTE`) without
+breaking compilation. When v1.0 ships, items still classified as
+Experimental can be promoted (drop the attribute) or removed (delete
+from `PublicAPI.Shipped.txt`).
+
+---
+
+## Obsolete surface
+
+None at v0.14.0. Future `[Obsolete]` decorations should land here with
+a "use X instead" pointer and a deprecation horizon.
+
+---
+
+## How to consume this audit
+
+* **Producer (this repo)**: when adding a new public member, place it
+  in one of the three buckets *before* promoting `Unshipped → Shipped`
+  at release time. If it lacks a behavioural test or has a known wiring
+  gap, ship it `[Experimental]` instead of un-annotated.
+* **Consumer**: pin to a specific `B3.EntryPoint.Client` minor version
+  if you call any Experimental member; suppress the diagnostic
+  per-call-site with
+  `[SuppressMessage("Usage", "B3EP_<id>")]` or
+  `#pragma warning disable B3EP_<id>` so unrelated experimental
+  additions in later versions still surface for review.

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -38,7 +38,18 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     private CancellationTokenSource? _persistCts;
     private Task? _persistWorker;
 
-    private readonly ConcurrentDictionary<string, ulong> _outstandingOrders = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<ClOrdID, ulong> _outstandingOrders = new();
+
+    /// <summary>
+    /// Outstanding non-order outbound IDs (quote/cross flows where the
+    /// identifier is an arbitrary <see cref="string"/>, not a numeric
+    /// <see cref="ClOrdID"/>). Kept separate so the order-tracking dict can
+    /// use the strongly-typed <see cref="ClOrdID"/> key without paying a
+    /// per-event <c>ToString()</c> allocation on the close-event hot path
+    /// (#128).
+    /// </summary>
+    private readonly ConcurrentDictionary<string, ulong> _outstandingQuoteFlowIds = new(StringComparer.Ordinal);
+
     private long _deltasSinceCompact;
 
     // ---- Inbound gap detection (#138) ---------------------------------------
@@ -62,9 +73,11 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     /// single dedicated worker per session lifetime. Replaces the legacy
     /// fire-and-forget <c>Task.Run</c> in
     /// <see cref="OnInboundEventForPersistence"/> so persistence work is
-    /// tracked and deterministically drained on teardown (#121).
+    /// tracked and deterministically drained on teardown (#121). Carries a
+    /// strongly-typed <see cref="ClOrdID"/> to avoid a per-event string
+    /// allocation (#128).
     /// </summary>
-    private readonly record struct PersistOp(string ClOrdID, ulong InboundSeqNum);
+    private readonly record struct PersistOp(ClOrdID ClOrdID, ulong InboundSeqNum);
 
     /// <summary>Keep-alive scheduler for this client. Bound after <see cref="ConnectAsync"/>.</summary>
     public IKeepAliveScheduler? KeepAlive => _keepAlive;
@@ -375,16 +388,43 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             _gapRequestInFlight = false;
         }
         _outstandingOrders.Clear();
-        foreach (var (clordid, secId) in snapshot.OutstandingOrders)
-            _outstandingOrders[clordid] = secId;
-        _options.Logger.SnapshotRecovered((uint)snapshot.LastOutboundSeqNum, _outstandingOrders.Count);
+        _outstandingQuoteFlowIds.Clear();
+        foreach (var (idText, secId) in snapshot.OutstandingOrders)
+        {
+            // ClOrdID is a uint64 wire type. Numeric keys hydrate into the typed
+            // order dict; arbitrary strings (quote/cross IDs) hydrate into the
+            // string-keyed quote-flow dict. (#128)
+            if (ulong.TryParse(idText, System.Globalization.NumberStyles.None,
+                    System.Globalization.CultureInfo.InvariantCulture, out var ord) && ord != 0UL)
+                _outstandingOrders[new ClOrdID(ord)] = secId;
+            else
+                _outstandingQuoteFlowIds[idText] = secId;
+        }
+        _options.Logger.SnapshotRecovered((uint)snapshot.LastOutboundSeqNum,
+            _outstandingOrders.Count + _outstandingQuoteFlowIds.Count);
+    }
+
+    private async ValueTask AppendOutboundOrderDeltaAsync(ulong seq, ClOrdID clordid, string clordidText, ulong securityId, CancellationToken ct)
+    {
+        var store = _options.SessionStateStore;
+        if (store is null) return;
+        _outstandingOrders[clordid] = securityId;
+        try
+        {
+            await store.AppendDeltaAsync(new OutboundDelta(seq, clordidText, securityId), ct).ConfigureAwait(false);
+            await MaybeCompactAsync(store, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _options.Logger.AppendDeltaFailed(ex, clordidText);
+        }
     }
 
     private async ValueTask AppendOutboundDeltaAsync(ulong seq, string clordid, ulong securityId, CancellationToken ct)
     {
         var store = _options.SessionStateStore;
         if (store is null) return;
-        _outstandingOrders[clordid] = securityId;
+        _outstandingQuoteFlowIds[clordid] = securityId;
         try
         {
             await store.AppendDeltaAsync(new OutboundDelta(seq, clordid, securityId), ct).ConfigureAwait(false);
@@ -417,7 +457,16 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     {
         ulong contiguous;
         lock (_inboundGapGate) { contiguous = _lastContiguousInboundSeqNum; }
-        return new()
+        // Merge the typed order dict and the string-keyed quote-flow dict into
+        // a single string-keyed serialization shape for backward compat with
+        // pre-#128 SessionSnapshot wire format. ClOrdID.ToString() runs only
+        // here (snapshot/compact boundary), not on the per-event hot path.
+        var outstanding = new Dictionary<string, ulong>(_outstandingOrders.Count + _outstandingQuoteFlowIds.Count);
+        foreach (var kv in _outstandingOrders)
+            outstanding[kv.Key.ToString()] = kv.Value;
+        foreach (var kv in _outstandingQuoteFlowIds)
+            outstanding[kv.Key] = kv.Value;
+        return new SessionSnapshot
         {
             SessionId = _options.SessionId,
             SessionVerId = _options.SessionVerId,
@@ -427,7 +476,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             // would otherwise silently lose the missing range on resume.
             LastInboundSeqNum = contiguous,
             CapturedAt = DateTimeOffset.UtcNow,
-            OutstandingOrders = new Dictionary<string, ulong>(_outstandingOrders),
+            OutstandingOrders = outstanding,
         };
     }
 
@@ -511,20 +560,22 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         var store = _options.SessionStateStore;
         if (store is null) return;
 
-        string? closedClOrdId = evt switch
+        // Strongly-typed close key — ClOrdID is a readonly record struct
+        // wrapping a ulong, so this carries no allocation. (#128)
+        ClOrdID? closedClOrdId = evt switch
         {
-            OrderCancelled c => c.ClOrdID.Value.ToString(),
-            OrderRejected r => r.ClOrdID.Value.ToString(),
-            OrderTrade t when t.LeavesQty == 0UL => t.ClOrdID.Value.ToString(),
+            OrderCancelled c => c.ClOrdID,
+            OrderRejected r => r.ClOrdID,
+            OrderTrade t when t.LeavesQty == 0UL => t.ClOrdID,
             _ => null,
         };
 
         if (closedClOrdId is null) return;
-        _outstandingOrders.TryRemove(closedClOrdId, out _);
+        _outstandingOrders.TryRemove(closedClOrdId.Value, out _);
 
         // #138: persist the contiguous tail, not the raw evt.SeqNum, so the
         // replayed snapshot's LastInboundSeqNum matches BuildSnapshot semantics.
-        EnqueuePersistOp(new PersistOp(closedClOrdId, contiguousAfter));
+        EnqueuePersistOp(new PersistOp(closedClOrdId.Value, contiguousAfter));
     }
 
     /// <summary>
@@ -568,7 +619,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     // Test hooks (internals visible to B3.EntryPoint.Client.Tests) so the
     // persistence worker can be exercised directly without a live FIXP session.
     internal void StartPersistenceWorkerForTesting() => StartPersistenceWorkerCore();
-    internal void EnqueuePersistOpForTesting(string clOrdID, ulong inboundSeqNum)
+    internal void EnqueuePersistOpForTesting(ClOrdID clOrdID, ulong inboundSeqNum)
         => EnqueuePersistOp(new PersistOp(clOrdID, inboundSeqNum));
     internal Task StopActiveSessionForTestingAsync(CancellationToken ct = default)
         => StopActiveSessionAsync(ct);
@@ -625,7 +676,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
                 catch (Exception ex)
                 {
                     // Log and continue — a transient store failure must not take down the worker.
-                    _options.Logger.OrderClosedPersistFailed(ex, op.ClOrdID);
+                    _options.Logger.OrderClosedPersistFailed(ex, op.ClOrdID.ToString());
                 }
             }
         }
@@ -645,7 +696,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         var buffer = new byte[NewOrderSingleData.MESSAGE_SIZE + 256];
         var len = OrderEntryEncoder.EncodeNewOrderSingle(buffer, request, _options, seq);
         await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
-        await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
+        await AppendOutboundOrderDeltaAsync(seq, request.ClOrdID, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "NewOrder"));
         RecordLatency(startTs, OutboundRequestKind.NewOrder);
         return request.ClOrdID;
@@ -664,7 +715,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         var buffer = new byte[SimpleNewOrderData.MESSAGE_SIZE + 64];
         var len = OrderEntryEncoder.EncodeSimpleNewOrder(buffer, request, _options, seq);
         await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
-        await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
+        await AppendOutboundOrderDeltaAsync(seq, request.ClOrdID, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "SimpleNewOrder"));
         RecordLatency(startTs, OutboundRequestKind.SimpleNewOrder);
         return request.ClOrdID;
@@ -683,7 +734,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         var buffer = new byte[OrderCancelReplaceRequestData.MESSAGE_SIZE + 256];
         var len = OrderEntryEncoder.EncodeOrderCancelReplace(buffer, request, _options, seq);
         await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
-        await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
+        await AppendOutboundOrderDeltaAsync(seq, request.ClOrdID, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersReplaced.Add(1, new KeyValuePair<string, object?>("kind", "Replace"));
         RecordLatency(startTs, OutboundRequestKind.Replace);
         return request.ClOrdID;
@@ -702,7 +753,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         var buffer = new byte[SimpleModifyOrderData.MESSAGE_SIZE + 64];
         var len = OrderEntryEncoder.EncodeSimpleModifyOrder(buffer, request, _options, seq);
         await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
-        await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
+        await AppendOutboundOrderDeltaAsync(seq, request.ClOrdID, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersReplaced.Add(1, new KeyValuePair<string, object?>("kind", "SimpleReplace"));
         RecordLatency(startTs, OutboundRequestKind.SimpleReplace);
         return request.ClOrdID;
@@ -721,7 +772,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         var buffer = new byte[OrderCancelRequestData.MESSAGE_SIZE + 256];
         var len = OrderEntryEncoder.EncodeOrderCancel(buffer, request, _options, seq);
         await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
-        await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
+        await AppendOutboundOrderDeltaAsync(seq, request.ClOrdID, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersCancelled.Add(1);
         RecordLatency(startTs, OutboundRequestKind.Cancel);
     }
@@ -743,7 +794,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             var buffer = new byte[OrderMassActionRequestData.MESSAGE_SIZE + 32];
             var len = OrderEntryEncoder.EncodeOrderMassAction(buffer, req, _options, seq);
             await _session.SendApplicationFrameAsync(buffer, len, token).ConfigureAwait(false);
-            await AppendOutboundDeltaAsync(seq, clordid, req.SecurityId ?? 0UL, token).ConfigureAwait(false);
+            await AppendOutboundOrderDeltaAsync(seq, req.ClOrdID, clordid, req.SecurityId ?? 0UL, token).ConfigureAwait(false);
             EntryPointTelemetry.MassActions.Add(1);
             RecordLatency(startTs, OutboundRequestKind.MassAction);
             return new MassActionReport

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -53,6 +53,14 @@ public sealed class EntryPointClientOptions
     /// — the safest choice for a participant that must not leave open orders
     /// after losing the session.
     /// </summary>
+    /// <remarks>
+    /// Marked <see cref="System.Diagnostics.CodeAnalysis.ExperimentalAttribute"/>
+    /// (#130): the value is currently <em>not</em> wired into the FIXP
+    /// <c>Negotiate</c> frame, so changing it has no observable effect on
+    /// the negotiated cancel-on-disconnect contract. Suppress
+    /// <c>B3EP_COD</c> at the call site to opt-in.
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.Experimental("B3EP_COD")]
     public CancelOnDisconnectType CancelOnDisconnect { get; set; } =
         CancelOnDisconnectType.CancelOnDisconnectOrTerminate;
 

--- a/src/B3.EntryPoint.Client/ICrossQuoteFlows.cs
+++ b/src/B3.EntryPoint.Client/ICrossQuoteFlows.cs
@@ -6,6 +6,14 @@ namespace B3.EntryPoint.Client;
 /// Submits a <c>NewOrderCross</c> message (schema §9). Implemented by
 /// <see cref="EntryPointClient.SubmitCrossAsync"/>.
 /// </summary>
+/// <remarks>
+/// Marked <see cref="System.Diagnostics.CodeAnalysis.ExperimentalAttribute"/>
+/// (#130): the wire encoder ships, but the cross flow has only API-surface
+/// coverage and lacks behavioural / conformance tests against a peer.
+/// Treat as preview and pin to a specific package version. Suppress
+/// <c>B3EP_CROSS</c> at the call site to opt-in.
+/// </remarks>
+[System.Diagnostics.CodeAnalysis.Experimental("B3EP_CROSS")]
 public interface ISubmitCross
 {
     /// <summary>Submits a cross trade. Returns the <c>CrossID</c> echoed back.</summary>
@@ -16,6 +24,14 @@ public interface ISubmitCross
 /// Quote-side messaging (QuoteRequest, Quote, QuoteCancel). Implemented by
 /// <see cref="EntryPointClient"/>.
 /// </summary>
+/// <remarks>
+/// Marked <see cref="System.Diagnostics.CodeAnalysis.ExperimentalAttribute"/>
+/// (#130): the wire encoders ship, but the quote flow is exercised only
+/// through API-surface tests; there is no end-to-end conformance test
+/// asserting the gateway's <c>QuoteAck</c>/<c>QuoteCancel</c> reply
+/// semantics. Suppress <c>B3EP_QUOTE</c> at the call site to opt-in.
+/// </remarks>
+[System.Diagnostics.CodeAnalysis.Experimental("B3EP_QUOTE")]
 public interface IQuoteFlow
 {
     /// <summary>Sends a <c>QuoteRequest</c>.</summary>

--- a/src/B3.EntryPoint.Client/Models/ClOrdID.cs
+++ b/src/B3.EntryPoint.Client/Models/ClOrdID.cs
@@ -1,9 +1,12 @@
+using System.Text.Json.Serialization;
+
 namespace B3.EntryPoint.Client.Models;
 
 /// <summary>
 /// Client order ID (FIX <c>ClOrdID</c>). Wraps the wire <c>uint64</c>
 /// (per schema <c>&lt;type name="ClOrdID" primitiveType="uint64"/&gt;</c>).
 /// </summary>
+[JsonConverter(typeof(ClOrdIDJsonConverter))]
 public readonly record struct ClOrdID
 {
     public ClOrdID(ulong value)

--- a/src/B3.EntryPoint.Client/Models/ClOrdIDJsonConverter.cs
+++ b/src/B3.EntryPoint.Client/Models/ClOrdIDJsonConverter.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace B3.EntryPoint.Client.Models;
+
+/// <summary>
+/// Serializes <see cref="ClOrdID"/> as a JSON number (its underlying
+/// <see cref="ClOrdID.Value"/>). For backward compatibility with persisted
+/// state written by &lt;= v0.13.0 (where <c>OrderClosedDelta.ClOrdID</c> was
+/// a <see cref="string"/>), the reader also accepts a JSON string containing
+/// a base-10 unsigned integer. (#128)
+/// </summary>
+public sealed class ClOrdIDJsonConverter : JsonConverter<ClOrdID>
+{
+    public override ClOrdID Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Number:
+                return new ClOrdID(reader.GetUInt64());
+            case JsonTokenType.String:
+                {
+                    var s = reader.GetString();
+                    if (string.IsNullOrEmpty(s))
+                        throw new JsonException("ClOrdID string was null or empty.");
+                    return ClOrdID.Parse(s);
+                }
+            default:
+                throw new JsonException($"Unexpected token {reader.TokenType} when reading ClOrdID.");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, ClOrdID value, JsonSerializerOptions options)
+        => writer.WriteNumberValue(value.Value);
+}

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -5,3 +5,13 @@ B3.EntryPoint.Client.InboundGapAtReconnectEventArgs.InboundGapAtReconnectEventAr
 B3.EntryPoint.Client.InboundGapAtReconnectEventArgs.FromSeqNo.get -> ulong
 B3.EntryPoint.Client.InboundGapAtReconnectEventArgs.Count.get -> uint
 B3.EntryPoint.Client.InboundGapAtReconnectEventArgs.PriorSessionVerId.get -> ulong
+B3.EntryPoint.Client.Models.ClOrdIDJsonConverter
+B3.EntryPoint.Client.Models.ClOrdIDJsonConverter.ClOrdIDJsonConverter() -> void
+B3.EntryPoint.Client.State.OrderClosedDelta.ClOrdID.get -> B3.EntryPoint.Client.Models.ClOrdID
+B3.EntryPoint.Client.State.OrderClosedDelta.Deconstruct(out B3.EntryPoint.Client.Models.ClOrdID ClOrdID) -> void
+B3.EntryPoint.Client.State.OrderClosedDelta.OrderClosedDelta(B3.EntryPoint.Client.Models.ClOrdID ClOrdID) -> void
+override B3.EntryPoint.Client.Models.ClOrdIDJsonConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> B3.EntryPoint.Client.Models.ClOrdID
+override B3.EntryPoint.Client.Models.ClOrdIDJsonConverter.Write(System.Text.Json.Utf8JsonWriter! writer, B3.EntryPoint.Client.Models.ClOrdID value, System.Text.Json.JsonSerializerOptions! options) -> void
+*REMOVED*B3.EntryPoint.Client.State.OrderClosedDelta.ClOrdID.get -> string!
+*REMOVED*B3.EntryPoint.Client.State.OrderClosedDelta.Deconstruct(out string! ClOrdID) -> void
+*REMOVED*B3.EntryPoint.Client.State.OrderClosedDelta.OrderClosedDelta(string! ClOrdID) -> void

--- a/src/B3.EntryPoint.Client/State/FileSessionStateStore.cs
+++ b/src/B3.EntryPoint.Client/State/FileSessionStateStore.cs
@@ -87,7 +87,11 @@ public sealed class FileSessionStateStore : ISessionStateStore
                     inboundSeq = Math.Max(inboundSeq, i.SeqNum);
                     break;
                 case OrderClosedDelta c:
-                    outstanding.Remove(c.ClOrdID);
+                    // OrderClosedDelta carries a strongly-typed ClOrdID (#128).
+                    // The legacy snapshot dict is still string-keyed so we
+                    // convert at the boundary; this runs only at replay /
+                    // compact time, never on the per-event hot path.
+                    outstanding.Remove(c.ClOrdID.ToString());
                     break;
             }
         }

--- a/src/B3.EntryPoint.Client/State/ISessionStateStore.cs
+++ b/src/B3.EntryPoint.Client/State/ISessionStateStore.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using B3.EntryPoint.Client.Models;
 
 namespace B3.EntryPoint.Client.State;
 
@@ -31,7 +32,16 @@ public abstract record SessionDelta
 
 public sealed record OutboundDelta(ulong SeqNum, string ClOrdID, ulong SecurityId) : SessionDelta;
 public sealed record InboundDelta(ulong SeqNum) : SessionDelta;
-public sealed record OrderClosedDelta(string ClOrdID) : SessionDelta;
+/// <summary>
+/// Marks an order as terminal (cancelled / rejected / fully-filled). Carries
+/// the strongly-typed <see cref="Models.ClOrdID"/> directly to avoid a
+/// per-event <c>ulong.ToString()</c> allocation on the inbound hot path
+/// (#128). Wire format change vs. v0.13.0: serialized as a JSON number
+/// (the underlying <c>uint64</c>) instead of a JSON string. The
+/// <see cref="ClOrdIDJsonConverter"/> still accepts the legacy string form
+/// when replaying snapshots written by older versions.
+/// </summary>
+public sealed record OrderClosedDelta(ClOrdID ClOrdID) : SessionDelta;
 
 /// <summary>
 /// Pluggable persistence for warm-restart. Default implementation is

--- a/src/B3.EntryPoint.Client/TerminationCode.cs
+++ b/src/B3.EntryPoint.Client/TerminationCode.cs
@@ -32,6 +32,15 @@ public enum TerminationCode : byte
 /// <c>CancelOnDisconnectType</c>). Sent in <c>Negotiate</c>; the gateway
 /// applies it when it observes a TCP disconnect and/or <c>Terminate</c>.
 /// </summary>
+/// <remarks>
+/// Marked <see cref="System.Diagnostics.CodeAnalysis.ExperimentalAttribute"/>
+/// (#130): the type ships in the public API but
+/// <see cref="EntryPointClientOptions.CancelOnDisconnect"/> is not yet
+/// plumbed through to the FIXP <c>Negotiate</c> frame, so the negotiated
+/// behaviour is whatever the gateway defaults to. Suppress
+/// <c>B3EP_COD</c> at the call site to opt-in.
+/// </remarks>
+[System.Diagnostics.CodeAnalysis.Experimental("B3EP_COD")]
 public enum CancelOnDisconnectType : byte
 {
     DoNotCancelOnDisconnectOrTerminate = 0,

--- a/tests/B3.EntryPoint.Client.Tests/ReconnectTeardownTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/ReconnectTeardownTests.cs
@@ -42,7 +42,7 @@ public class ReconnectTeardownTests
         // Burst of close-event persistence ops on the active session's worker.
         const int burst = 50;
         for (int i = 0; i < burst; i++)
-            client.EnqueuePersistOpForTesting($"a-{i}", (ulong)(i + 1));
+            client.EnqueuePersistOpForTesting(new B3.EntryPoint.Client.Models.ClOrdID((ulong)(i + 1)), (ulong)(i + 1));
 
         // Reconnect with a bumped SessionVerID. Before this returns the old
         // session's persistence worker MUST have drained every enqueued op,
@@ -55,12 +55,11 @@ public class ReconnectTeardownTests
         // had not yet been drained would not appear here.
         var closedAtReconnect = store.Deltas.OfType<OrderClosedDelta>()
             .Select(d => d.ClOrdID)
-            .Where(id => id.StartsWith("a-", StringComparison.Ordinal))
             .ToHashSet();
 
         Assert.Equal(burst, closedAtReconnect.Count);
         for (int i = 0; i < burst; i++)
-            Assert.Contains($"a-{i}", closedAtReconnect);
+            Assert.Contains(new B3.EntryPoint.Client.Models.ClOrdID((ulong)(i + 1)), closedAtReconnect);
     }
 
     private sealed class RecordingStore : ISessionStateStore

--- a/tests/B3.EntryPoint.Client.Tests/State/FileSessionStateStoreTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/State/FileSessionStateStoreTests.cs
@@ -45,18 +45,18 @@ public class FileSessionStateStoreTests
                 SessionVerId = 1,
                 LastOutboundSeqNum = 10,
                 LastInboundSeqNum = 5,
-                OutstandingOrders = new() { ["X"] = 100 },
+                OutstandingOrders = new() { ["X"] = 100, ["24"] = 100 },
             });
             await store.AppendDeltaAsync(new OutboundDelta(11, "Y", 200));
             await store.AppendDeltaAsync(new OutboundDelta(12, "Z", 300));
             await store.AppendDeltaAsync(new InboundDelta(7));
-            await store.AppendDeltaAsync(new OrderClosedDelta("X"));
+            await store.AppendDeltaAsync(new OrderClosedDelta(new B3.EntryPoint.Client.Models.ClOrdID(24)));
 
             var rebuilt = await store.ReplayAsync();
             Assert.NotNull(rebuilt);
             Assert.Equal(12UL, rebuilt!.LastOutboundSeqNum);
             Assert.Equal(7UL, rebuilt.LastInboundSeqNum);
-            Assert.False(rebuilt.OutstandingOrders.ContainsKey("X"));
+            Assert.False(rebuilt.OutstandingOrders.ContainsKey("24"));
             Assert.Equal(200UL, rebuilt.OutstandingOrders["Y"]);
             Assert.Equal(300UL, rebuilt.OutstandingOrders["Z"]);
         }

--- a/tests/B3.EntryPoint.Client.Tests/State/PersistenceWorkerTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/State/PersistenceWorkerTests.cs
@@ -43,7 +43,7 @@ public class PersistenceWorkerTests
 
         const int burst = 200;
         for (int i = 0; i < burst; i++)
-            client.EnqueuePersistOpForTesting($"clord-{i}", (ulong)(i + 1));
+            client.EnqueuePersistOpForTesting(new B3.EntryPoint.Client.Models.ClOrdID((ulong)(i + 1)), (ulong)(i + 1));
 
         await client.StopActiveSessionForTestingAsync();
 
@@ -54,7 +54,7 @@ public class PersistenceWorkerTests
         Assert.Equal(burst, inbound.Count);
         for (int i = 0; i < burst; i++)
         {
-            Assert.Contains($"clord-{i}", closed);
+            Assert.Contains(new B3.EntryPoint.Client.Models.ClOrdID((ulong)(i + 1)), closed);
             Assert.Contains((ulong)(i + 1), inbound);
         }
     }
@@ -63,17 +63,17 @@ public class PersistenceWorkerTests
     public async Task TransientStoreFailure_IsLoggedOnce_AndWorkerContinues()
     {
         var fake = new FakeLogger();
-        var store = new FlakyStore(failFirstClOrdID: "clord-1");
+        var store = new FlakyStore(failFirstClOrdID: new B3.EntryPoint.Client.Models.ClOrdID(2));
         var opts = BaseOptions(store, fake);
         opts.PersistenceQueueCapacity = 16;
 
         var client = new EntryPointClient(opts);
         client.StartPersistenceWorkerForTesting();
 
-        client.EnqueuePersistOpForTesting("clord-0", 1);
-        client.EnqueuePersistOpForTesting("clord-1", 2); // throws transiently
-        client.EnqueuePersistOpForTesting("clord-2", 3);
-        client.EnqueuePersistOpForTesting("clord-3", 4);
+        client.EnqueuePersistOpForTesting(new B3.EntryPoint.Client.Models.ClOrdID(1), 1);
+        client.EnqueuePersistOpForTesting(new B3.EntryPoint.Client.Models.ClOrdID(2), 2); // throws transiently
+        client.EnqueuePersistOpForTesting(new B3.EntryPoint.Client.Models.ClOrdID(3), 3);
+        client.EnqueuePersistOpForTesting(new B3.EntryPoint.Client.Models.ClOrdID(4), 4);
 
         await client.StopActiveSessionForTestingAsync();
 
@@ -83,11 +83,11 @@ public class PersistenceWorkerTests
 
         // Subsequent ops still recorded — worker did not die.
         var ids = store.Deltas.OfType<OrderClosedDelta>().Select(d => d.ClOrdID).ToHashSet();
-        Assert.Contains("clord-0", ids);
-        Assert.Contains("clord-2", ids);
-        Assert.Contains("clord-3", ids);
-        // clord-1 OrderClosedDelta was attempted but threw before AppendDeltaAsync recorded — not recorded.
-        Assert.DoesNotContain("clord-1", ids);
+        Assert.Contains(new B3.EntryPoint.Client.Models.ClOrdID(1), ids);
+        Assert.Contains(new B3.EntryPoint.Client.Models.ClOrdID(3), ids);
+        Assert.Contains(new B3.EntryPoint.Client.Models.ClOrdID(4), ids);
+        // ClOrdID(2) OrderClosedDelta was attempted but threw before AppendDeltaAsync recorded — not recorded.
+        Assert.DoesNotContain(new B3.EntryPoint.Client.Models.ClOrdID(2), ids);
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class PersistenceWorkerTests
 
         var client = new EntryPointClient(opts);
         client.StartPersistenceWorkerForTesting();
-        client.EnqueuePersistOpForTesting("hang-1", 1);
+        client.EnqueuePersistOpForTesting(new B3.EntryPoint.Client.Models.ClOrdID(99), 1);
 
         // Give the worker a moment to pick it up and block inside AppendDeltaAsync.
         await Task.Delay(50);
@@ -132,10 +132,10 @@ public class PersistenceWorkerTests
 
     private sealed class FlakyStore : ISessionStateStore
     {
-        private readonly string _failFirstClOrdID;
+        private readonly B3.EntryPoint.Client.Models.ClOrdID _failFirstClOrdID;
         private bool _hasFailed;
         public ConcurrentQueue<SessionDelta> Deltas { get; } = new();
-        public FlakyStore(string failFirstClOrdID) { _failFirstClOrdID = failFirstClOrdID; }
+        public FlakyStore(B3.EntryPoint.Client.Models.ClOrdID failFirstClOrdID) { _failFirstClOrdID = failFirstClOrdID; }
         public ValueTask<SessionSnapshot?> LoadAsync(CancellationToken ct = default) => new((SessionSnapshot?)null);
         public ValueTask SaveAsync(SessionSnapshot snapshot, CancellationToken ct = default) => default;
         public ValueTask AppendDeltaAsync(SessionDelta delta, CancellationToken ct = default)

--- a/tests/B3.EntryPoint.Client.Tests/State/SessionStateStoreWiringTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/State/SessionStateStoreWiringTests.cs
@@ -22,18 +22,18 @@ public class SessionStateStoreWiringTests
                 LastOutboundSeqNum = 100UL,
                 LastInboundSeqNum = 50UL,
                 CapturedAt = DateTimeOffset.UtcNow,
-                OutstandingOrders = new() { ["CL-1"] = 7UL, ["CL-2"] = 9UL },
+                OutstandingOrders = new() { ["CL-1"] = 7UL, ["CL-2"] = 9UL, ["1"] = 7UL },
             });
             await store.AppendDeltaAsync(new OutboundDelta(101UL, "CL-3", 11UL));
             await store.AppendDeltaAsync(new OutboundDelta(102UL, "CL-4", 12UL));
-            await store.AppendDeltaAsync(new OrderClosedDelta("CL-1"));
+            await store.AppendDeltaAsync(new OrderClosedDelta(new B3.EntryPoint.Client.Models.ClOrdID(1)));
             await store.AppendDeltaAsync(new InboundDelta(60UL));
 
             var replay = await store.ReplayAsync();
             Assert.NotNull(replay);
             Assert.Equal(102UL, replay!.LastOutboundSeqNum);
             Assert.Equal(60UL, replay.LastInboundSeqNum);
-            Assert.False(replay.OutstandingOrders.ContainsKey("CL-1"));
+            Assert.False(replay.OutstandingOrders.ContainsKey("1"));
             Assert.True(replay.OutstandingOrders.ContainsKey("CL-3"));
             Assert.True(replay.OutstandingOrders.ContainsKey("CL-4"));
         }

--- a/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/ReconnectRetransmitTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/ReconnectRetransmitTests.cs
@@ -256,7 +256,7 @@ public class ReconnectRetransmitTests
                         inboundSeq = Math.Max(inboundSeq, i.SeqNum);
                         break;
                     case OrderClosedDelta c:
-                        outstanding.Remove(c.ClOrdID);
+                        outstanding.Remove(c.ClOrdID.ToString());
                         break;
                 }
             }


### PR DESCRIPTION
Closes #128
Closes #130

Combines two issues that fit cleanly under v0.14.0 (minor, may include breaking changes).

## #128 — typed ClOrdID key on the close-event hot path
- `_outstandingOrders` switched from `ConcurrentDictionary<string, ulong>` to
  `ConcurrentDictionary<ClOrdID, ulong>` (record struct over ulong → no allocation).
- `OrderClosedDelta` now carries `ClOrdID` directly. **Wire-format break**:
  serialized as a JSON number instead of string. New `ClOrdIDJsonConverter`
  reads both forms so v0.13.0 deltas still replay; downgrades require a fresh
  state directory (documented in CHANGELOG).
- Quote/cross flows (string IDs) tracked in a parallel `_outstandingQuoteFlowIds`
  dict to preserve warm-restart semantics.
- New `CloseEventPersistenceBenchmarks` ([MemoryDiagnoser]) under
  `benchmarks/B3.EntryPoint.Benchmarks/`. Compile-only.
- `PublicAPI.Unshipped.txt` updated (string → ClOrdID member shape change,
  new ClOrdIDJsonConverter). Not promoted.

## #130 — public-surface audit
- New `docs/PUBLIC-API.md` classifying every shipped public member as
  Supported / Experimental / Obsolete (per-area).
- `[Experimental("B3EP_<id>")]` applied to:
  - `CancelOnDisconnectType` + `EntryPointClientOptions.CancelOnDisconnect`
    (`B3EP_COD`) — option ships but is **not** wired into FIXP `Negotiate`.
  - `IQuoteFlow` (`B3EP_QUOTE`) — encoders ship, no behavioural test.
  - `ISubmitCross` (`B3EP_CROSS`) — encoders ship, no behavioural test.
- IDs blanket-suppressed in `Directory.Build.props` so the repo's tests
  still build under `TreatWarningsAsErrors=true`. Downstream consumers
  still see the warnings and can suppress per call site.
- **No member removed** from `PublicAPI.Shipped.txt` — hard removal
  reserved for v1.0.

## Verification
- `dotnet build` green.
- `dotnet test`: 149 unit + 15 conformance (`ENTRYPOINT_TESTPEER=1`) +
  2 sample = all pass.
- Benchmarks compile.

## Coordination
- The parallel `issue-138-inbound-gap` agent also touches
  `OnInboundEventForPersistence`. Whichever PR merges first wins; the
  second rebases. This branch carries the #128 typed-ClOrdID changes
  in that method body — the gap-detection logic (lock + pending seq
  set + InboundGapDetected log + RetransmitRequest fan-out) is
  untouched here and must coexist on rebase.

## Out of scope (deferred to v0.14.0 release)
- No version bump.
- `PublicAPI.Unshipped.txt` is **not** promoted.
- Issues remain open until the release PR.