### PR TITLE
fix(client): keep shared event channel open across reconnect (#144)

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -216,8 +216,10 @@ internal sealed class FixpClientSession : IAsyncDisposable
                                 var code = payload[12];
                                 OnInboundTerminate?.Invoke(code);
                             }
-                            // peer is shutting us down — exit loop
-                            _eventWriter?.TryComplete();
+                            // peer is shutting us down — exit loop. Do NOT
+                            // complete the shared event channel writer: it
+                            // outlives this session and is owned by the outer
+                            // EntryPointClient (see #144).
                             return;
                     }
                 }
@@ -228,11 +230,15 @@ internal sealed class FixpClientSession : IAsyncDisposable
         catch (IOException) { /* peer closed */ }
         catch (Exception ex)
         {
+            // Surface telemetry but do NOT poison the shared event channel:
+            // the writer is owned by the outer EntryPointClient and must
+            // remain usable across session swaps (e.g. ReconnectAsync). #144
             _options.Logger.InboundLoopFaulted(ex);
-            _eventWriter?.TryComplete(ex);
             return;
         }
-        _eventWriter?.TryComplete();
+        // Loop exiting normally (cancellation, peer closed). The shared event
+        // channel writer is intentionally NOT completed here — only
+        // EntryPointClient.DisposeAsync may complete it. #144
     }
 
     /// <summary>

--- a/tests/B3.EntryPoint.Client.Tests/ReconnectEventChannelTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/ReconnectEventChannelTests.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Client.TestPeer;
+
+namespace B3.EntryPoint.Client.Tests;
+
+/// <summary>
+/// Regression test for #144 — <c>ReconnectAsync</c> must NOT close the
+/// shared <c>EntryPointClient.Events</c> channel. The previous session's
+/// inbound Terminate / loop-exit used to call <c>TryComplete()</c> on the
+/// shared writer, leaving the new session unable to deliver any inbound
+/// frames (every <c>WriteAsync</c> threw <c>ChannelClosedException</c> and
+/// killed the new inbound loop).
+/// </summary>
+public class ReconnectEventChannelTests
+{
+    private static EntryPointClientOptions Options(InProcessFixpTestPeer peer) => new()
+    {
+        Endpoint = peer.LocalEndpoint,
+        SessionId = 42u,
+        SessionVerId = 1u,
+        EnteringFirm = 7u,
+        Credentials = Credentials.FromUtf8("test-key"),
+        KeepAliveIntervalMs = 60_000u,
+        SessionTeardownTimeout = TimeSpan.FromSeconds(5),
+    };
+
+    [Fact]
+    public async Task EventsChannel_RemainsOpen_AcrossReconnect()
+    {
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions
+        {
+            Scenario = TestPeerScenarios.AcceptAll,
+        });
+        peer.Start();
+
+        await using var client = new EntryPointClient(Options(peer));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        await client.ConnectAsync(cts.Token);
+
+        var collected = new List<EntryPointEvent>();
+        using var collectorCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+        var collector = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var evt in client.Events(collectorCts.Token).ConfigureAwait(false))
+                {
+                    lock (collected) collected.Add(evt);
+                }
+            }
+            catch (OperationCanceledException) { }
+        });
+
+        await client.SubmitAsync(new NewOrderRequest
+        {
+            ClOrdID = (ClOrdID)1UL,
+            SecurityId = 1001,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            Price = 10m,
+            OrderQty = 5,
+        }, cts.Token);
+
+        await WaitForCountAsync(collected, 1, TimeSpan.FromSeconds(5));
+
+        // Reconnect bumps SessionVerID and tears down the prior session. The
+        // bug: the prior session's inbound Terminate handler completes the
+        // shared event channel, so no further events can ever reach the
+        // consumer.
+        await client.ReconnectAsync(2u, cts.Token);
+
+        await client.SubmitAsync(new NewOrderRequest
+        {
+            ClOrdID = (ClOrdID)2UL,
+            SecurityId = 1001,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            Price = 10m,
+            OrderQty = 5,
+        }, cts.Token);
+
+        await WaitForCountAsync(collected, 2, TimeSpan.FromSeconds(5));
+
+        collectorCts.Cancel();
+        try { await collector.ConfigureAwait(true); } catch { }
+
+        lock (collected)
+        {
+            Assert.True(collected.Count >= 2,
+                $"expected ≥2 events delivered across reconnect, got {collected.Count}");
+        }
+    }
+
+    private static async Task WaitForCountAsync(List<EntryPointEvent> bag, int target, TimeSpan timeout)
+    {
+        var sw = Stopwatch.StartNew();
+        while (true)
+        {
+            int count;
+            lock (bag) count = bag.Count;
+            if (count >= target) return;
+            if (sw.Elapsed > timeout)
+                throw new TimeoutException($"timed out waiting for {target} events; got {count}");
+            await Task.Delay(25).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## Root cause

`EntryPointClient._events` is a single `Channel<EntryPointEvent>` allocated once in the constructor and shared across every FIXP session the client opens. The session's inbound loop (`FixpClientSession.RunInboundLoopAsync`) was calling `_eventWriter?.TryComplete(...)` in three places — when an inbound `Terminate` frame arrives, on any unhandled exception, and on normal loop exit — even though the writer is owned by the outer client.

On `ReconnectAsync` the prior session's loop processes the gateway's Terminate response, completes the shared writer, and the new session — which captures the same writer reference in `StartInboundLoop` — can no longer publish events:
- the first `WriteAsync` throws `ChannelClosedException`,
- the catch-all logs `InboundLoopFaulted` and returns,
- the consumer's `Events()` async-enumerable terminates silently.

Net effect: any consumer using `ReconnectAsync` (e.g. for `SessionVerID` bumps) silently stops receiving inbound events on the new session.

## Fix (Option A from the issue)

Move the channel lifecycle entirely to the outer client:

- Removed all three `_eventWriter?.TryComplete(...)` calls inside `RunInboundLoopAsync`.
- The session loop still writes to the writer; on any exit (peer Terminate, cancellation, exception) it simply returns and lets `FixpClientSession.DisposeAsync` await the loop.
- `_options.Logger.InboundLoopFaulted(ex)` telemetry is preserved.
- `EntryPointClient.DisposeAsync` remains the only place that completes `_events.Writer` — already verified that `ReconnectAsync` only tears down the session/transport (via `StopActiveSessionAsync`), never the client itself.

Race-with-stale-loop is already handled: `StopActiveSessionAsync` awaits `_session.DisposeAsync()` (which cancels and awaits `_inboundLoop`) before `ConnectAsync` rebinds session hooks.

## Regression test

`tests/B3.EntryPoint.Client.Tests/ReconnectEventChannelTests.cs`:

1. Spins up `InProcessFixpTestPeer` with `AcceptAll`.
2. Connects, submits an order, awaits one event from `Events()`.
3. Calls `ReconnectAsync(2u)`.
4. Submits another order, awaits a second event.
5. Asserts both events were delivered.

**Verified to fail on main** (`TimeoutException : timed out waiting for 2 events; got 1`) and **pass after the fix**.

## Pre-PR checklist

- ✅ `dotnet build -c Release` clean (warnings-as-errors)
- ✅ `dotnet test --filter ReconnectEventChannelTests` passes
- ✅ `dotnet format --verify-no-changes` clean for touched files
- No new public symbols, so `PublicAPI.Unshipped.txt` not touched.
- No schema/SBE changes.

Fixes #144
Refs B3MatchingPlatform#253