### PR TITLE
fix(client): correct OCRR encoder offsets and stop clobbering OrigClOrdID (#145)

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
@@ -255,23 +255,23 @@ internal static class OrderEntryEncoder
         msg.OrdType = (SbeOrdType)(byte)request.OrderType;
         msg.SetTimeInForce((SbeTimeInForce)(byte)request.TimeInForce);
         msg.OrderQty = new Quantity(request.OrderQty);
+        // Price@68 is PriceOptional (composite): no public setter, write mantissa directly.
         if (request.Price.HasValue)
             BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 68, 8), PriceMantissa(request.Price.Value));
         else
             BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 68, 8), long.MinValue);
+        // OrderID@76 left unset (NullValue=0). OrigClOrdID@84 set via generated setter.
         msg.SetOrigClOrdID(request.OrigClOrdID.Value);
+        // StopPx@92 is PriceOptional (composite): no public setter, write mantissa directly.
         if (request.StopPrice.HasValue)
-            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 84, 8), PriceMantissa(request.StopPrice.Value));
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 92, 8), PriceMantissa(request.StopPrice.Value));
         else
-            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 84, 8), long.MinValue);
-        if (request.MinQty.HasValue)
-            BinaryPrimitives.WriteUInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 92, 8), request.MinQty.Value);
-        if (request.MaxFloor.HasValue)
-            BinaryPrimitives.WriteUInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 100, 8), request.MaxFloor.Value);
-        MemoryMarshalAsBytes(ref msg, 113, 1)[0] = (byte)request.AccountType;
+            BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 92, 8), long.MinValue);
+        msg.SetMinQty(request.MinQty);
+        msg.SetMaxFloor(request.MaxFloor);
+        msg.SetAccountType((SbeAccountType)(byte)request.AccountType);
         if (request.ExpireDate.HasValue)
-            BinaryPrimitives.WriteUInt16LittleEndian(MemoryMarshalAsBytes(ref msg, 114, 2),
-                (ushort)((request.ExpireDate.Value - DateTimeOffset.UnixEpoch).Days));
+            msg.SetExpireDate((ushort)((request.ExpireDate.Value - DateTimeOffset.UnixEpoch).Days));
 
         if (!OrderCancelReplaceRequestData.TryEncode(msg, buffer.Slice(SofhSize + SbeHeaderSize),
                 ReadOnlySpan<byte>.Empty, memoBytes, out _))

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
@@ -4,6 +4,8 @@ using B3.EntryPoint.Client;
 using B3.EntryPoint.Client.Auth;
 using B3.EntryPoint.Client.Fixp;
 using B3.EntryPoint.Client.Models;
+using SbeOcrr = B3.Entrypoint.Fixp.Sbe.V6.OrderCancelReplaceRequestData;
+using SbeAccountType = B3.Entrypoint.Fixp.Sbe.V6.AccountType;
 
 namespace B3.EntryPoint.Client.Tests.Fixp;
 
@@ -105,6 +107,56 @@ public class OrderEntryEncoderTests
         var (_, tid) = ReadFrameHeader(buffer);
         Assert.True(len > 0);
         Assert.Equal((ushort)104, tid);
+    }
+
+    // Regression test for issue #145: OCRR encoder used hand-coded offsets
+    // shifted by -8 (pre-V6 layout, before orderID@76 was added), which both
+    // clobbered OrigClOrdID with the StopPx null sentinel (long.MinValue) and
+    // wrote MinQty/MaxFloor/AccountType/ExpireDate at the wrong offsets.
+    [Fact]
+    public void EncodeOrderCancelReplace_RoundTrips_OptionalFields_ToSbeDecoder()
+    {
+        const ulong OrigClOrd = 0x1122334455667788UL;
+        var expireDate = new DateTimeOffset(2030, 12, 31, 0, 0, 0, TimeSpan.Zero);
+        var expireDays = (ushort)((expireDate - DateTimeOffset.UnixEpoch).Days);
+
+        var req = new ReplaceOrderRequest
+        {
+            ClOrdID = new ClOrdID(2UL),
+            OrigClOrdID = new ClOrdID(OrigClOrd),
+            SecurityId = 7,
+            Side = Side.Sell,
+            OrderType = OrderType.StopLimit,
+            OrderQty = 50,
+            Price = 12.34m,
+            StopPrice = 11.50m,
+            MinQty = 10UL,
+            MaxFloor = 25UL,
+            AccountType = AccountType.RegularAccount,
+            ExpireDate = expireDate,
+        };
+
+        var buffer = new byte[512];
+        var len = OrderEntryEncoder.EncodeOrderCancelReplace(buffer, req, Opts(), msgSeqNum: 4);
+        Assert.True(len > 0);
+
+        // Frame layout: SOFH (4) + MessageHeader (8) + payload.
+        var payload = buffer.AsSpan(4 + 8, len - 4 - 8);
+        Assert.True(SbeOcrr.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Equal(OrigClOrd, data.OrigClOrdID);
+        Assert.NotEqual(unchecked((ulong)long.MinValue), data.OrigClOrdID);
+        Assert.Equal(115_000L, data.StopPx.Mantissa);
+        Assert.Equal(10UL, data.MinQty);
+        Assert.Equal(25UL, data.MaxFloor);
+        Assert.Equal(SbeAccountType.REGULAR_ACCOUNT, data.AccountType);
+        Assert.Equal(expireDays, data.ExpireDate);
+        // Sanity: also confirm the basic fields encoded correctly.
+        Assert.Equal(2UL, data.ClOrdID.Value);
+        Assert.Equal(7UL, data.SecurityID.Value);
+        Assert.Equal(50UL, data.OrderQty.Value);
+        Assert.Equal(123_400L, data.Price.Mantissa);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #145 — the `EncodeOrderCancelReplace` method in `OrderEntryEncoder` was writing several fields at offsets shifted by **-8 bytes** from the actual V6 SBE struct layout, because they were hard-coded before `orderID@76` was added to the V6 schema. The first wrong write (`StopPx` at offset 84) silently **clobbered `OrigClOrdID` with `long.MinValue`** on every replace, making cancel/replace effectively unusable in V6.

### Root cause

The encoder mixed generated SBE setters with hand-coded `BinaryPrimitives.Write*` calls at literal byte offsets. Verified against the generated `OrderCancelReplaceRequestData` struct in `B3.EntryPoint.Sbe`:

| Field         | Correct offset (generated) | Old hand-coded offset |
|---------------|----------------------------|------------------------|
| orderID       | 76                         | (not written)          |
| origClOrdID   | 84                         | 84 (set, then overwritten) |
| stopPx        | 92                         | 84 ❌ (overwrote origClOrdID) |
| minQty        | 100                        | 92 ❌                   |
| maxFloor      | 108                        | 100 ❌                  |
| accountType   | 121                        | 113 ❌                  |
| expireDate    | 122                        | 114 ❌                  |

### Fix

Use the generated SBE setters wherever they exist: `SetOrigClOrdID`, `SetMinQty`, `SetMaxFloor`, `SetAccountType`, `SetExpireDate`. Only `StopPx` still needs a hand-coded mantissa write because `PriceOptional` exposes no public setter — and it now uses the correct offset `92`. This aligns with the architectural rule that encoders must not duplicate SBE layout knowledge.

### Test

Added `EncodeOrderCancelReplace_RoundTrips_OptionalFields_ToSbeDecoder` in `tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs`. It builds a `ReplaceOrderRequest` with non-default `OrigClOrdID`, `StopPrice`, `MinQty`, `MaxFloor`, `AccountType` and `ExpireDate`, encodes it, and decodes the resulting frame via the generated `OrderCancelReplaceRequestData.TryParse`. It asserts every field round-trips and that `OrigClOrdID` is the original ULID, **not** `unchecked((ulong)long.MinValue)`.

Verified that the new test **fails on `main`** (`OrigClOrdID = 9223372036854775808`) and **passes** with this fix.

### Related

* Downstream simulator: pedrosakuma/B3MatchingPlatform#252 — the matcher will now see the correct `OrigClOrdID` on incoming OCRR.
* No public API surface change; `PublicAPI.Unshipped.txt` not updated.
* `EncodeNewOrderSingle` was reviewed; its hand-coded offsets for `Price`, `StopPx`, `MinQty`, `MaxFloor` and `ExpireDate` are correct against the V6 `NewOrderSingleData` struct, so it is **not** touched.

### Verification

```
dotnet restore SbeB3EntryPointClient.slnx          # OK
dotnet build   SbeB3EntryPointClient.slnx -c Release  # 0 warnings, 0 errors
dotnet test    SbeB3EntryPointClient.slnx -c Release  # 154 passed, 2 pre-existing failures unrelated to this change (TerminateApiTests.ReconnectAsync_AcceptsIncreasingVerId_AttemptsTcpConnect, DropCopyClientTests.ConnectAsync_AttemptsTcpConnect — both fail identically on main)
dotnet format  SbeB3EntryPointClient.slnx --verify-no-changes --severity warn  # clean
```