### PR TITLE
fix(client): defensive throw on outbound MsgSeqNum uint32 exhaustion

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -278,8 +278,38 @@ internal sealed class FixpClientSession : IAsyncDisposable
     public Task FlushOutboundAsync(CancellationToken ct) => _stream.FlushAsync(ct);
 
     /// <summary>Returns the next outbound MsgSeqNum and increments the counter.</summary>
-    public ulong NextOutboundSeqNum() =>
-        (ulong)System.Threading.Interlocked.Increment(ref _outboundSeqNum);
+    /// <remarks>
+    /// Throws <see cref="InvalidOperationException"/> when the counter would exceed
+    /// <see cref="SeqNumGuard.MaxWireSeqNum"/> — FIXP <c>MsgSeqNum</c> is scoped to
+    /// a single <c>SessionID</c>/<c>SessionVerID</c> pair and must not wrap. The
+    /// counter is rolled back so the failed allocation does not consume a slot.
+    /// Logs a one-shot warning when crossing
+    /// <see cref="SeqNumGuard.NearExhaustionThreshold"/> so operators can rotate
+    /// <c>SessionVerID</c> proactively via <c>ReconnectAsync</c>.
+    /// </remarks>
+    public ulong NextOutboundSeqNum()
+    {
+        var next = (ulong)System.Threading.Interlocked.Increment(ref _outboundSeqNum);
+        if (next > SeqNumGuard.MaxWireSeqNum)
+        {
+            // Roll back so the counter never reports a value that cannot be encoded.
+            System.Threading.Interlocked.Decrement(ref _outboundSeqNum);
+            throw new InvalidOperationException(
+                $"Outbound MsgSeqNum {next} exceeds the FIXP wire SeqNum (uint32) limit " +
+                $"of {SeqNumGuard.MaxWireSeqNum}. Per schema v8.4.2, MsgSeqNum is scoped " +
+                "to a single SessionID/SessionVerID pair and must not wrap. Rotate by " +
+                "calling EntryPointClient.ReconnectAsync(nextSessionVerId, ...) with a " +
+                "strictly greater SessionVerID before exhausting the counter.");
+        }
+        if (next >= SeqNumGuard.NearExhaustionThreshold &&
+            System.Threading.Interlocked.Exchange(ref _seqNumNearExhaustionLogged, 1) == 0)
+        {
+            _options.Logger.OutboundSeqNumNearExhaustion(next, SeqNumGuard.MaxWireSeqNum);
+        }
+        return next;
+    }
+
+    private int _seqNumNearExhaustionLogged;
 
     /// <summary>
     /// Reads the last outbound MsgSeqNum that was assigned via <see cref="NextOutboundSeqNum"/>
@@ -315,7 +345,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
         SequenceData.WriteHeader(buffer.AsSpan(SofhSize));
         var payload = new SequenceData
         {
-            NextSeqNo = new SeqNum(checked((uint)nextSeqNo)),
+            NextSeqNo = SeqNumGuard.ToWireSeqNum(nextSeqNo),
         };
         if (!payload.TryEncode(buffer.AsSpan(SofhSize + SbeHeaderSize), out _))
             throw new InvalidOperationException("Failed to encode Sequence payload.");
@@ -335,7 +365,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
         {
             SessionID = _options.SessionId,
             Timestamp = new UTCTimestampNanos { Time = (ulong)NowUnixNanos() },
-            FromSeqNo = new SeqNum(checked((uint)fromSeqNo)),
+            FromSeqNo = SeqNumGuard.ToWireSeqNum(fromSeqNo),
             Count = new MessageCounter(count),
         };
         if (!payload.TryEncode(buffer.AsSpan(SofhSize + SbeHeaderSize), out _))

--- a/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
@@ -39,7 +39,7 @@ internal static class OrderEntryEncoder
     {
         var header = default(InboundBusinessHeader);
         header.SessionID = new SessionID(options.SessionId);
-        header.MsgSeqNum = new SeqNum(checked((uint)msgSeqNum));
+        header.MsgSeqNum = SeqNumGuard.ToWireSeqNum(msgSeqNum);
         header.SendingTime = default;
         header.MarketSegmentID = new MarketSegmentID(options.DefaultMarketSegmentId);
         return header;
@@ -49,7 +49,7 @@ internal static class OrderEntryEncoder
     {
         var header = default(BidirectionalBusinessHeader);
         header.SessionID = new SessionID(options.SessionId);
-        header.MsgSeqNum = new SeqNum(checked((uint)msgSeqNum));
+        header.MsgSeqNum = SeqNumGuard.ToWireSeqNum(msgSeqNum);
         header.SendingTime = default;
         // MarketSegmentID is optional on bidirectional messages; left at NullValue (0) to mean "not set".
         if (options.DefaultMarketSegmentId != 0)

--- a/src/B3.EntryPoint.Client/Fixp/SeqNumGuard.cs
+++ b/src/B3.EntryPoint.Client/Fixp/SeqNumGuard.cs
@@ -1,0 +1,51 @@
+using B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.EntryPoint.Client.Fixp;
+
+/// <summary>
+/// Centralized guard for the FIXP/SBE 8.4.2 outbound <see cref="SeqNum"/> boundary.
+///
+/// Per <c>schemas/b3-entrypoint-messages-8.4.2.xml</c>:
+/// <list type="bullet">
+///   <item><c>SeqNum</c> is <c>uint32</c>, scoped to a <c>SessionID</c> + <c>SessionVerID</c> pair.</item>
+///   <item><c>SessionVerID</c> "need to be incremented each time Negotiate message is sent to gateway".</item>
+/// </list>
+/// FIXP does not authorise silent wrap of <c>MsgSeqNum</c> back to 0/1 on the same
+/// <c>SessionVerID</c>: the peer would treat the next frame as a massive backwards
+/// gap and tear the session down. The correct recovery is to renegotiate with a
+/// new <c>SessionVerID</c> (see <c>EntryPointClient.ReconnectAsync(uint nextSessionVerId, ...)</c>).
+///
+/// This helper converts the internal <c>ulong</c> counter to the wire <c>SeqNum</c>
+/// and throws a clear, actionable <see cref="InvalidOperationException"/> when the
+/// counter would exceed <c>uint.MaxValue</c> — instead of letting a deeply nested
+/// <c>checked((uint)…)</c> cast surface as an opaque <see cref="OverflowException"/>.
+/// </summary>
+internal static class SeqNumGuard
+{
+    /// <summary>Largest value that fits in the wire <c>SeqNum</c> (uint32).</summary>
+    public const ulong MaxWireSeqNum = uint.MaxValue;
+
+    /// <summary>
+    /// Threshold at which the session emits a single warning advising the operator
+    /// to rotate <c>SessionVerID</c> proactively.
+    /// </summary>
+    public const ulong NearExhaustionThreshold = 0xFFFF_FF00UL;
+
+    /// <summary>
+    /// Converts an internal outbound counter value to a wire <see cref="SeqNum"/>.
+    /// Throws <see cref="InvalidOperationException"/> when <paramref name="seqNum"/>
+    /// exceeds <see cref="MaxWireSeqNum"/>; callers should rotate
+    /// <c>SessionVerID</c> via <c>EntryPointClient.ReconnectAsync</c>.
+    /// </summary>
+    public static SeqNum ToWireSeqNum(ulong seqNum)
+    {
+        if (seqNum > MaxWireSeqNum)
+            throw new InvalidOperationException(
+                $"Outbound MsgSeqNum {seqNum} exceeds the FIXP wire SeqNum (uint32) limit " +
+                $"of {MaxWireSeqNum}. Per schema v8.4.2, MsgSeqNum is scoped to a single " +
+                "SessionID/SessionVerID pair and must not wrap. Rotate by calling " +
+                "EntryPointClient.ReconnectAsync(nextSessionVerId, ...) with a strictly " +
+                "greater SessionVerID before exhausting the counter.");
+        return new SeqNum((uint)seqNum);
+    }
+}

--- a/src/B3.EntryPoint.Client/Logging/LogMessages.cs
+++ b/src/B3.EntryPoint.Client/Logging/LogMessages.cs
@@ -139,6 +139,10 @@ internal static partial class LogMessages
         Message = "Reconnect carries unrecovered inbound gap from prior session ver={PriorSessionVerId}: fromSeqNo={FromSeqNo} count={Count} — out-of-band reconciliation required")]
     public static partial void InboundGapAtReconnect(this ILogger logger, ulong priorSessionVerId, ulong fromSeqNo, uint count);
 
+    [LoggerMessage(EventId = 4013, Level = LogLevel.Warning,
+        Message = "Outbound MsgSeqNum approaching uint32 boundary (assigned={Assigned}, max={Max}); rotate SessionVerID via ReconnectAsync before exhaustion")]
+    public static partial void OutboundSeqNumNearExhaustion(this ILogger logger, ulong assigned, ulong max);
+
     // ---------------- Error (5000–5999) ----------------
 
     [LoggerMessage(EventId = 5000, Level = LogLevel.Error,

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/OutboundSeqNumBoundaryTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/OutboundSeqNumBoundaryTests.cs
@@ -1,0 +1,145 @@
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client.Tests.Fixp;
+
+/// <summary>
+/// Audit regression: outbound MsgSeqNum must not silently wrap past the FIXP
+/// uint32 boundary. The previous implementation surfaced a deeply nested
+/// <see cref="OverflowException"/> from a <c>checked((uint)…)</c> cast inside
+/// the encoder; this suite asserts that callers now get a clear, actionable
+/// <see cref="InvalidOperationException"/> instead, that the counter does not
+/// advance past the limit, and that a one-shot warning fires near the threshold.
+/// </summary>
+public class OutboundSeqNumBoundaryTests
+{
+    private static EntryPointClientOptions Opts() => new()
+    {
+        Endpoint = new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 1),
+        SessionId = 42,
+        SessionVerId = 7,
+        EnteringFirm = 100,
+        Credentials = Credentials.FromUtf8("k"),
+        SenderLocation = "SP-001",
+        EnteringTrader = "T0001",
+        DefaultMarketSegmentId = 1,
+    };
+
+    private static FixpClientSession NewSession(EntryPointClientOptions? opts = null) =>
+        new(new MemoryStream(), opts ?? Opts());
+
+    [Fact]
+    public void ToWireSeqNum_AtMaxUint32_Encodes_Successfully()
+    {
+        var seq = SeqNumGuard.ToWireSeqNum(uint.MaxValue);
+        Assert.Equal(uint.MaxValue, seq.Value);
+    }
+
+    [Fact]
+    public void ToWireSeqNum_PastMaxUint32_Throws_InvalidOperation_With_Rotation_Hint()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => SeqNumGuard.ToWireSeqNum((ulong)uint.MaxValue + 1UL));
+        Assert.Contains("ReconnectAsync", ex.Message);
+        Assert.Contains("SessionVerID", ex.Message);
+    }
+
+    [Fact]
+    public void NextOutboundSeqNum_At_Boundary_Returns_MaxUint32()
+    {
+        var session = NewSession();
+        session.ResumeOutboundSeqNum(uint.MaxValue);
+        Assert.Equal((ulong)uint.MaxValue, session.NextOutboundSeqNum());
+        Assert.Equal((ulong)uint.MaxValue, session.LastAssignedOutboundSeqNum());
+    }
+
+    [Fact]
+    public void NextOutboundSeqNum_Past_Boundary_Throws_And_Does_Not_Advance_Counter()
+    {
+        var session = NewSession();
+        session.ResumeOutboundSeqNum((ulong)uint.MaxValue + 1UL);
+        Assert.Equal((ulong)uint.MaxValue, session.LastAssignedOutboundSeqNum());
+
+        var ex = Assert.Throws<InvalidOperationException>(() => session.NextOutboundSeqNum());
+        Assert.Contains("ReconnectAsync", ex.Message);
+
+        // Counter rolled back; subsequent calls keep failing rather than silently advancing.
+        Assert.Equal((ulong)uint.MaxValue, session.LastAssignedOutboundSeqNum());
+        Assert.Throws<InvalidOperationException>(() => session.NextOutboundSeqNum());
+        Assert.Equal((ulong)uint.MaxValue, session.LastAssignedOutboundSeqNum());
+    }
+
+    [Fact]
+    public void OrderEntryEncoder_At_MaxUint32_Encodes_Successfully()
+    {
+        var req = new SimpleNewOrderRequest
+        {
+            ClOrdID = new ClOrdID(1UL),
+            SecurityId = 7,
+            Side = Side.Buy,
+            OrderType = SimpleOrderType.Limit,
+            OrderQty = 100,
+            Price = 12.34m,
+            Account = 555,
+        };
+        var buffer = new byte[256];
+        var len = OrderEntryEncoder.EncodeSimpleNewOrder(buffer, req, Opts(), msgSeqNum: uint.MaxValue);
+        Assert.True(len > 0);
+    }
+
+    [Fact]
+    public void OrderEntryEncoder_Past_MaxUint32_Throws_InvalidOperation()
+    {
+        var req = new SimpleNewOrderRequest
+        {
+            ClOrdID = new ClOrdID(1UL),
+            SecurityId = 7,
+            Side = Side.Buy,
+            OrderType = SimpleOrderType.Limit,
+            OrderQty = 100,
+            Price = 12.34m,
+            Account = 555,
+        };
+        var buffer = new byte[256];
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => OrderEntryEncoder.EncodeSimpleNewOrder(buffer, req, Opts(), msgSeqNum: (ulong)uint.MaxValue + 1UL));
+        Assert.Contains("ReconnectAsync", ex.Message);
+    }
+
+    [Fact]
+    public void NextOutboundSeqNum_Crossing_NearExhaustionThreshold_Logs_Warning_Once()
+    {
+        var captured = new List<(int eventId, string message)>();
+        var opts = Opts();
+        opts.Logger = new CapturingLogger(captured);
+        var session = NewSession(opts);
+
+        session.ResumeOutboundSeqNum(SeqNumGuard.NearExhaustionThreshold - 1UL);
+        _ = session.NextOutboundSeqNum(); // assigns NearExhaustionThreshold - 1, still below
+        Assert.DoesNotContain(captured, e => e.eventId == 4013);
+
+        _ = session.NextOutboundSeqNum(); // assigns NearExhaustionThreshold — first crossing
+        Assert.Single(captured, e => e.eventId == 4013);
+
+        _ = session.NextOutboundSeqNum();
+        _ = session.NextOutboundSeqNum();
+        Assert.Single(captured, e => e.eventId == 4013); // still exactly one
+    }
+
+    private sealed class CapturingLogger(List<(int eventId, string message)> sink)
+        : Microsoft.Extensions.Logging.ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            sink.Add((eventId.Id, formatter(state, exception)));
+        }
+    }
+}


### PR DESCRIPTION
## Audit finding

The audit flagged outbound sequence-number behaviour at the uint32 boundary in
`src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs` (lines 312, 332) and
`src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs` (lines 42, 52). The four
call sites used `new SeqNum(checked((uint)x))` against a wider internal
`ulong`/`long` counter. After 2^32 outbound frames on a single session, the
next allocation surfaced as an opaque `OverflowException` from a deeply
nested `checked` cast inside the encoder, killing both the inbound and
outbound paths mid-session with no actionable signal to the caller.

## Chosen approach: (B) defensive throw

The vendored schema at `schemas/b3-entrypoint-messages-8.4.2.xml` is decisive:

- Line 597 — `SeqNum` is `uint32`, "Sequence number of a given SessionID/SessionVerID".
- Line 781 — `SessionVerID` "need to be incremented each time Negotiate
  message is sent to gateway".

FIXP scopes `MsgSeqNum` to a single `SessionID`/`SessionVerID` pair and does
not authorise silent wrap on the same `SessionVerID` — the peer would treat
the next frame as a massive backwards gap and tear the session down. Option
(A) (`unchecked` wrap) would be a wire-protocol violation. Option (B) — a
clear `InvalidOperationException` pointing the caller at
`EntryPointClient.ReconnectAsync(uint nextSessionVerId, …)` — preserves spec
compliance and gives operators an actionable recovery path.

## Changes

- New `src/B3.EntryPoint.Client/Fixp/SeqNumGuard.cs` centralises the
  conversion behind `SeqNumGuard.ToWireSeqNum(ulong)`. All four flagged
  call sites now go through it.
- `FixpClientSession.NextOutboundSeqNum()` validates at the boundary,
  rolls the counter back on failure (so a failed allocation doesn't
  silently consume a slot or report a non-encodable value), and emits a
  one-shot `Warning` (`LogMessages` event 4013,
  `OutboundSeqNumNearExhaustion`) when the counter crosses
  `SeqNumGuard.NearExhaustionThreshold` (`0xFFFFFF00`). This gives
  operators a proactive nudge to call `ReconnectAsync` with a strictly
  greater `SessionVerID` before exhaustion.
- New tests in
  `tests/B3.EntryPoint.Client.Tests/Fixp/OutboundSeqNumBoundaryTests.cs`
  cover: encoding succeeds at exactly `uint.MaxValue`; both the helper
  and `NextOutboundSeqNum` throw past the limit; the counter does not
  advance past the limit on repeated calls; and the threshold warning
  fires exactly once.

No public-API surface change — every touched symbol is `internal`, so
`PublicAPI.Unshipped.txt` is untouched.

## Pre-PR checks

```
dotnet restore SbeB3EntryPointClient.slnx
dotnet build   SbeB3EntryPointClient.slnx --no-restore -c Release   # 0 Warning(s) 0 Error(s)
dotnet test    SbeB3EntryPointClient.slnx --no-build   -c Release   # all green except the 2 pre-existing
                                                                    # failures noted in the audit task
                                                                    # (TerminateApiTests.ReconnectAsync_*,
                                                                    # DropCopyClientTests.ConnectAsync_*)
dotnet format  SbeB3EntryPointClient.slnx --verify-no-changes --no-restore --severity warn  # clean
```