### PR TITLE
fix(client): release partial-connect resources when ConnectOnceAsync fails

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -196,77 +196,93 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         }
 
         _tcp = tcp;
-        var transportStream = await EstablishTransportStreamAsync(tcp, ct).ConfigureAwait(false);
-        _session = new FixpClientSession(transportStream, _options);
-
-        using (var negotiate = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.negotiate", ActivityKind.Client))
+        try
         {
-            await _session.NegotiateAsync(ct).ConfigureAwait(false);
-            _options.Logger.Negotiated(_options.Endpoint);
+            var transportStream = await EstablishTransportStreamAsync(tcp, ct).ConfigureAwait(false);
+            _session = new FixpClientSession(transportStream, _options);
+
+            using (var negotiate = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.negotiate", ActivityKind.Client))
+            {
+                await _session.NegotiateAsync(ct).ConfigureAwait(false);
+                _options.Logger.Negotiated(_options.Endpoint);
+            }
+            using (var establish = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.establish", ActivityKind.Client))
+            {
+                await _session.EstablishAsync(ct).ConfigureAwait(false);
+                _options.Logger.Established(_options.Endpoint);
+            }
+
+            await HydrateFromSnapshotAsync(ct).ConfigureAwait(false);
+
+            StartPersistenceWorker();
+
+            _session.OnInboundEvent = OnInboundEventForPersistence;
+
+            _session.StartInboundLoop(_events.Writer);
+
+            _keepAlive = new KeepAliveScheduler(
+                _options.KeepAliveInterval,
+                sendSequence: (seq, token) => _session.SendSequenceAsync(seq, token),
+                nextSeqNo: () => _session.PeekNextOutboundSeqNum());
+            _session.OnInboundSequence = nextSeq =>
+            {
+                _lastInboundUtc = DateTime.UtcNow;
+                _keepAlive!.RaiseFrameReceived(nextSeq, DateTimeOffset.UtcNow);
+            };
+            _keepAlive.Start();
+
+            _retransmit = new RetransmitRequestHandler(
+                sendRequest: (from, count, token) => _session.SendRetransmitRequestAsync(from, count, token));
+            _session.OnInboundRetransmission = (nextSeq, count, reqNanos) =>
+            {
+                _lastInboundUtc = DateTime.UtcNow;
+                // The peer's reply to our outstanding RetransmitRequest. Whether
+                // it carries frames (count>0) or is an empty completion (count=0,
+                // observed against TestPeer / some gateway error paths), we clear
+                // the in-flight flag so a future gap can issue a new request.
+                // The retransmitted frames themselves flow through the inbound
+                // loop and OnInboundEventForPersistence advances the contiguous
+                // tail accordingly. (#138)
+                lock (_inboundGapGate) { _gapRequestInFlight = false; }
+                _retransmit!.RaiseRetransmissionReceived(nextSeq, count, NanosToOffset(reqNanos));
+            };
+            _session.OnInboundRetransmitReject = (code, reqNanos) =>
+            {
+                _lastInboundUtc = DateTime.UtcNow;
+                // Reject clears the in-flight flag — a later gap may need to
+                // re-request after a transient peer-side condition lifts. (#138)
+                lock (_inboundGapGate) { _gapRequestInFlight = false; }
+                _retransmit!.RaiseRetransmitRejected((B3.EntryPoint.Client.Fixp.RetransmitRejectCode)(byte)code, NanosToOffset(reqNanos));
+            };
+            _session.OnInboundNotApplied = (from, count) =>
+            {
+                _lastInboundUtc = DateTime.UtcNow;
+                _retransmit!.RaiseNotAppliedReceived(from, count);
+            };
+            _session.OnInboundTerminate = code =>
+            {
+                _lastInboundUtc = DateTime.UtcNow;
+                _options.Logger.InboundTerminate(code);
+                EntryPointTelemetry.Terminations.Add(1,
+                    new KeyValuePair<string, object?>("direction", "inbound"),
+                    new KeyValuePair<string, object?>("code", code.ToString()));
+                RaiseTerminated((TerminationCode)code, reason: null, initiatedByClient: false);
+            };
+            _lastInboundUtc = DateTime.UtcNow;
         }
-        using (var establish = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.establish", ActivityKind.Client))
+        catch
         {
-            await _session.EstablishAsync(ct).ConfigureAwait(false);
-            _options.Logger.Established(_options.Endpoint);
+            // Any failure after the TCP connect has succeeded leaves a partially
+            // initialized session: _tcp, _session (maybe), the persistence
+            // worker, keep-alive and inbound loop may all be live. Without this
+            // cleanup, the outer ConnectAsync retry loop would create a brand
+            // new TcpClient and orphan everything started here. StopActive-
+            // SessionAsync is idempotent and null-safe across all these fields,
+            // and intentionally does NOT complete _events.Writer (#144) so the
+            // event channel survives across reconnect attempts.
+            await StopActiveSessionAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
         }
-
-        await HydrateFromSnapshotAsync(ct).ConfigureAwait(false);
-
-        StartPersistenceWorker();
-
-        _session.OnInboundEvent = OnInboundEventForPersistence;
-
-        _session.StartInboundLoop(_events.Writer);
-
-        _keepAlive = new KeepAliveScheduler(
-            _options.KeepAliveInterval,
-            sendSequence: (seq, token) => _session.SendSequenceAsync(seq, token),
-            nextSeqNo: () => _session.PeekNextOutboundSeqNum());
-        _session.OnInboundSequence = nextSeq =>
-        {
-            _lastInboundUtc = DateTime.UtcNow;
-            _keepAlive!.RaiseFrameReceived(nextSeq, DateTimeOffset.UtcNow);
-        };
-        _keepAlive.Start();
-
-        _retransmit = new RetransmitRequestHandler(
-            sendRequest: (from, count, token) => _session.SendRetransmitRequestAsync(from, count, token));
-        _session.OnInboundRetransmission = (nextSeq, count, reqNanos) =>
-        {
-            _lastInboundUtc = DateTime.UtcNow;
-            // The peer's reply to our outstanding RetransmitRequest. Whether
-            // it carries frames (count>0) or is an empty completion (count=0,
-            // observed against TestPeer / some gateway error paths), we clear
-            // the in-flight flag so a future gap can issue a new request.
-            // The retransmitted frames themselves flow through the inbound
-            // loop and OnInboundEventForPersistence advances the contiguous
-            // tail accordingly. (#138)
-            lock (_inboundGapGate) { _gapRequestInFlight = false; }
-            _retransmit!.RaiseRetransmissionReceived(nextSeq, count, NanosToOffset(reqNanos));
-        };
-        _session.OnInboundRetransmitReject = (code, reqNanos) =>
-        {
-            _lastInboundUtc = DateTime.UtcNow;
-            // Reject clears the in-flight flag — a later gap may need to
-            // re-request after a transient peer-side condition lifts. (#138)
-            lock (_inboundGapGate) { _gapRequestInFlight = false; }
-            _retransmit!.RaiseRetransmitRejected((B3.EntryPoint.Client.Fixp.RetransmitRejectCode)(byte)code, NanosToOffset(reqNanos));
-        };
-        _session.OnInboundNotApplied = (from, count) =>
-        {
-            _lastInboundUtc = DateTime.UtcNow;
-            _retransmit!.RaiseNotAppliedReceived(from, count);
-        };
-        _session.OnInboundTerminate = code =>
-        {
-            _lastInboundUtc = DateTime.UtcNow;
-            _options.Logger.InboundTerminate(code);
-            EntryPointTelemetry.Terminations.Add(1,
-                new KeyValuePair<string, object?>("direction", "inbound"),
-                new KeyValuePair<string, object?>("code", code.ToString()));
-            RaiseTerminated((TerminationCode)code, reason: null, initiatedByClient: false);
-        };
-        _lastInboundUtc = DateTime.UtcNow;
     }
 
     private async Task<System.IO.Stream> EstablishTransportStreamAsync(TcpClient tcp, CancellationToken ct)
@@ -626,6 +642,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
 
     internal void HandleInboundEventForTesting(EntryPointEvent evt) => OnInboundEventForPersistence(evt);
     internal void BindRetransmitForTesting(RetransmitRequestHandler handler) => _retransmit = handler;
+    internal bool HasActiveSessionForTesting => _session is not null || _tcp is not null;
     internal (ulong contiguous, ulong highest, int pending, bool gapInFlight) GetInboundGapStateForTesting()
     {
         lock (_inboundGapGate)

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -278,8 +278,38 @@ internal sealed class FixpClientSession : IAsyncDisposable
     public Task FlushOutboundAsync(CancellationToken ct) => _stream.FlushAsync(ct);
 
     /// <summary>Returns the next outbound MsgSeqNum and increments the counter.</summary>
-    public ulong NextOutboundSeqNum() =>
-        (ulong)System.Threading.Interlocked.Increment(ref _outboundSeqNum);
+    /// <remarks>
+    /// Throws <see cref="InvalidOperationException"/> when the counter would exceed
+    /// <see cref="SeqNumGuard.MaxWireSeqNum"/> — FIXP <c>MsgSeqNum</c> is scoped to
+    /// a single <c>SessionID</c>/<c>SessionVerID</c> pair and must not wrap. The
+    /// counter is rolled back so the failed allocation does not consume a slot.
+    /// Logs a one-shot warning when crossing
+    /// <see cref="SeqNumGuard.NearExhaustionThreshold"/> so operators can rotate
+    /// <c>SessionVerID</c> proactively via <c>ReconnectAsync</c>.
+    /// </remarks>
+    public ulong NextOutboundSeqNum()
+    {
+        var next = (ulong)System.Threading.Interlocked.Increment(ref _outboundSeqNum);
+        if (next > SeqNumGuard.MaxWireSeqNum)
+        {
+            // Roll back so the counter never reports a value that cannot be encoded.
+            System.Threading.Interlocked.Decrement(ref _outboundSeqNum);
+            throw new InvalidOperationException(
+                $"Outbound MsgSeqNum {next} exceeds the FIXP wire SeqNum (uint32) limit " +
+                $"of {SeqNumGuard.MaxWireSeqNum}. Per schema v8.4.2, MsgSeqNum is scoped " +
+                "to a single SessionID/SessionVerID pair and must not wrap. Rotate by " +
+                "calling EntryPointClient.ReconnectAsync(nextSessionVerId, ...) with a " +
+                "strictly greater SessionVerID before exhausting the counter.");
+        }
+        if (next >= SeqNumGuard.NearExhaustionThreshold &&
+            System.Threading.Interlocked.Exchange(ref _seqNumNearExhaustionLogged, 1) == 0)
+        {
+            _options.Logger.OutboundSeqNumNearExhaustion(next, SeqNumGuard.MaxWireSeqNum);
+        }
+        return next;
+    }
+
+    private int _seqNumNearExhaustionLogged;
 
     /// <summary>
     /// Reads the last outbound MsgSeqNum that was assigned via <see cref="NextOutboundSeqNum"/>
@@ -315,7 +345,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
         SequenceData.WriteHeader(buffer.AsSpan(SofhSize));
         var payload = new SequenceData
         {
-            NextSeqNo = new SeqNum(checked((uint)nextSeqNo)),
+            NextSeqNo = SeqNumGuard.ToWireSeqNum(nextSeqNo),
         };
         if (!payload.TryEncode(buffer.AsSpan(SofhSize + SbeHeaderSize), out _))
             throw new InvalidOperationException("Failed to encode Sequence payload.");
@@ -335,7 +365,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
         {
             SessionID = _options.SessionId,
             Timestamp = new UTCTimestampNanos { Time = (ulong)NowUnixNanos() },
-            FromSeqNo = new SeqNum(checked((uint)fromSeqNo)),
+            FromSeqNo = SeqNumGuard.ToWireSeqNum(fromSeqNo),
             Count = new MessageCounter(count),
         };
         if (!payload.TryEncode(buffer.AsSpan(SofhSize + SbeHeaderSize), out _))

--- a/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
@@ -39,7 +39,7 @@ internal static class OrderEntryEncoder
     {
         var header = default(InboundBusinessHeader);
         header.SessionID = new SessionID(options.SessionId);
-        header.MsgSeqNum = new SeqNum(checked((uint)msgSeqNum));
+        header.MsgSeqNum = SeqNumGuard.ToWireSeqNum(msgSeqNum);
         header.SendingTime = default;
         header.MarketSegmentID = new MarketSegmentID(options.DefaultMarketSegmentId);
         return header;
@@ -49,7 +49,7 @@ internal static class OrderEntryEncoder
     {
         var header = default(BidirectionalBusinessHeader);
         header.SessionID = new SessionID(options.SessionId);
-        header.MsgSeqNum = new SeqNum(checked((uint)msgSeqNum));
+        header.MsgSeqNum = SeqNumGuard.ToWireSeqNum(msgSeqNum);
         header.SendingTime = default;
         // MarketSegmentID is optional on bidirectional messages; left at NullValue (0) to mean "not set".
         if (options.DefaultMarketSegmentId != 0)

--- a/src/B3.EntryPoint.Client/Fixp/SeqNumGuard.cs
+++ b/src/B3.EntryPoint.Client/Fixp/SeqNumGuard.cs
@@ -1,0 +1,51 @@
+using B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.EntryPoint.Client.Fixp;
+
+/// <summary>
+/// Centralized guard for the FIXP/SBE 8.4.2 outbound <see cref="SeqNum"/> boundary.
+///
+/// Per <c>schemas/b3-entrypoint-messages-8.4.2.xml</c>:
+/// <list type="bullet">
+///   <item><c>SeqNum</c> is <c>uint32</c>, scoped to a <c>SessionID</c> + <c>SessionVerID</c> pair.</item>
+///   <item><c>SessionVerID</c> "need to be incremented each time Negotiate message is sent to gateway".</item>
+/// </list>
+/// FIXP does not authorise silent wrap of <c>MsgSeqNum</c> back to 0/1 on the same
+/// <c>SessionVerID</c>: the peer would treat the next frame as a massive backwards
+/// gap and tear the session down. The correct recovery is to renegotiate with a
+/// new <c>SessionVerID</c> (see <c>EntryPointClient.ReconnectAsync(uint nextSessionVerId, ...)</c>).
+///
+/// This helper converts the internal <c>ulong</c> counter to the wire <c>SeqNum</c>
+/// and throws a clear, actionable <see cref="InvalidOperationException"/> when the
+/// counter would exceed <c>uint.MaxValue</c> — instead of letting a deeply nested
+/// <c>checked((uint)…)</c> cast surface as an opaque <see cref="OverflowException"/>.
+/// </summary>
+internal static class SeqNumGuard
+{
+    /// <summary>Largest value that fits in the wire <c>SeqNum</c> (uint32).</summary>
+    public const ulong MaxWireSeqNum = uint.MaxValue;
+
+    /// <summary>
+    /// Threshold at which the session emits a single warning advising the operator
+    /// to rotate <c>SessionVerID</c> proactively.
+    /// </summary>
+    public const ulong NearExhaustionThreshold = 0xFFFF_FF00UL;
+
+    /// <summary>
+    /// Converts an internal outbound counter value to a wire <see cref="SeqNum"/>.
+    /// Throws <see cref="InvalidOperationException"/> when <paramref name="seqNum"/>
+    /// exceeds <see cref="MaxWireSeqNum"/>; callers should rotate
+    /// <c>SessionVerID</c> via <c>EntryPointClient.ReconnectAsync</c>.
+    /// </summary>
+    public static SeqNum ToWireSeqNum(ulong seqNum)
+    {
+        if (seqNum > MaxWireSeqNum)
+            throw new InvalidOperationException(
+                $"Outbound MsgSeqNum {seqNum} exceeds the FIXP wire SeqNum (uint32) limit " +
+                $"of {MaxWireSeqNum}. Per schema v8.4.2, MsgSeqNum is scoped to a single " +
+                "SessionID/SessionVerID pair and must not wrap. Rotate by calling " +
+                "EntryPointClient.ReconnectAsync(nextSessionVerId, ...) with a strictly " +
+                "greater SessionVerID before exhausting the counter.");
+        return new SeqNum((uint)seqNum);
+    }
+}

--- a/src/B3.EntryPoint.Client/Logging/LogMessages.cs
+++ b/src/B3.EntryPoint.Client/Logging/LogMessages.cs
@@ -139,6 +139,10 @@ internal static partial class LogMessages
         Message = "Reconnect carries unrecovered inbound gap from prior session ver={PriorSessionVerId}: fromSeqNo={FromSeqNo} count={Count} — out-of-band reconciliation required")]
     public static partial void InboundGapAtReconnect(this ILogger logger, ulong priorSessionVerId, ulong fromSeqNo, uint count);
 
+    [LoggerMessage(EventId = 4013, Level = LogLevel.Warning,
+        Message = "Outbound MsgSeqNum approaching uint32 boundary (assigned={Assigned}, max={Max}); rotate SessionVerID via ReconnectAsync before exhaustion")]
+    public static partial void OutboundSeqNumNearExhaustion(this ILogger logger, ulong assigned, ulong max);
+
     // ---------------- Error (5000–5999) ----------------
 
     [LoggerMessage(EventId = 5000, Level = LogLevel.Error,

--- a/src/B3.EntryPoint.Client/SegmentedEntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/SegmentedEntryPointClient.cs
@@ -78,7 +78,23 @@ public sealed class SegmentedEntryPointClient : IAsyncDisposable, ISubmitOrder, 
     {
         if (_connected)
             throw new InvalidOperationException("SegmentedEntryPointClient is already connected.");
-        await Task.WhenAll(_clients.Values.Select(c => c.ConnectAsync(ct))).ConfigureAwait(false);
+        try
+        {
+            await Task.WhenAll(_clients.Values.Select(c => c.ConnectAsync(ct))).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Partial fan-out failure: some segments may have established
+            // successfully while others threw. Tear them all down so we don't
+            // leak per-segment TCP sockets and background tasks. Each
+            // EntryPointClient self-cleans on a single failed ConnectAsync, so
+            // we only need to dispose siblings that succeeded.
+            foreach (var c in _clients.Values)
+            {
+                try { await c.DisposeAsync().ConfigureAwait(false); } catch { }
+            }
+            throw;
+        }
         foreach (var (_, client) in _clients)
             _pumps.Add(Task.Run(() => PumpAsync(client, _pumpCts.Token)));
         _connected = true;

--- a/tests/B3.EntryPoint.Client.Tests/ConnectFailureCleanupTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/ConnectFailureCleanupTests.cs
@@ -1,0 +1,78 @@
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.TestPeer;
+
+namespace B3.EntryPoint.Client.Tests;
+
+/// <summary>
+/// Audit regression: when <c>ConnectOnceAsync</c> fails after the TCP socket
+/// is established (e.g. peer rejects Establish), the client must dispose the
+/// socket, FIXP session, persistence worker, keep-alive scheduler and inbound
+/// loop before propagating the exception to the outer retry loop. Without
+/// this cleanup, a subsequent retry (or successful reconnect) would orphan
+/// the previously-allocated resources because <c>DisposeAsync</c> only frees
+/// the *currently bound* fields.
+/// </summary>
+public class ConnectFailureCleanupTests
+{
+    private static EntryPointClientOptions Options(InProcessFixpTestPeer peer) => new()
+    {
+        Endpoint = peer.LocalEndpoint,
+        SessionId = 42u,
+        SessionVerId = 1u,
+        EnteringFirm = 7u,
+        Credentials = Credentials.FromUtf8("k"),
+        KeepAliveIntervalMs = 60_000u,
+        ConnectMaxAttempts = 1,
+        SessionTeardownTimeout = TimeSpan.FromSeconds(5),
+    };
+
+    [Fact]
+    public async Task ConnectAsync_WhenEstablishRejected_DisposesAllPartialResources()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        // Reject the very first Establish — TCP connect + Negotiate succeed,
+        // EstablishAsync throws FixpRejectedException, which must trigger the
+        // partial-connect cleanup before propagating.
+        peer.Options.EstablishRejectAfter = 1;
+        peer.Start();
+
+        await using var client = new EntryPointClient(Options(peer));
+
+        await Assert.ThrowsAsync<FixpRejectedException>(() => client.ConnectAsync());
+
+        // Internal state must be fully reset: _session and _tcp both null,
+        // and the public State accessor must report Disconnected (which it
+        // derives from _session). On unfixed code _session/_tcp would still
+        // reference the orphaned partial connect.
+        Assert.False(client.HasActiveSessionForTesting,
+            "ConnectOnceAsync must release _session/_tcp on failure.");
+        Assert.Equal(FixpClientState.Disconnected, client.State);
+        Assert.Null(client.KeepAlive);
+        Assert.Null(client.Retransmit);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_AfterFailedAttempt_CanReconnectWithoutLeakingPriorSocket()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        // First Establish rejected; second accepted.
+        peer.Options.EstablishRejectAfter = 1;
+        peer.Start();
+
+        await using var client = new EntryPointClient(Options(peer));
+
+        await Assert.ThrowsAsync<FixpRejectedException>(() => client.ConnectAsync());
+        Assert.False(client.HasActiveSessionForTesting);
+
+        // Flip the peer back to accept-mode and reconnect. If the prior
+        // failure had leaked a TcpClient/inbound loop, this second connect
+        // would either reuse stale fields (InvalidOperationException because
+        // _session is non-null) or simply orphan them silently. The fix
+        // ensures a clean slate.
+        peer.Options.EstablishRejectAfter = null;
+        await client.ConnectAsync();
+        Assert.True(client.HasActiveSessionForTesting);
+        Assert.Equal(FixpClientState.Established, client.State);
+    }
+}

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/OutboundSeqNumBoundaryTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/OutboundSeqNumBoundaryTests.cs
@@ -1,0 +1,145 @@
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client.Tests.Fixp;
+
+/// <summary>
+/// Audit regression: outbound MsgSeqNum must not silently wrap past the FIXP
+/// uint32 boundary. The previous implementation surfaced a deeply nested
+/// <see cref="OverflowException"/> from a <c>checked((uint)…)</c> cast inside
+/// the encoder; this suite asserts that callers now get a clear, actionable
+/// <see cref="InvalidOperationException"/> instead, that the counter does not
+/// advance past the limit, and that a one-shot warning fires near the threshold.
+/// </summary>
+public class OutboundSeqNumBoundaryTests
+{
+    private static EntryPointClientOptions Opts() => new()
+    {
+        Endpoint = new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 1),
+        SessionId = 42,
+        SessionVerId = 7,
+        EnteringFirm = 100,
+        Credentials = Credentials.FromUtf8("k"),
+        SenderLocation = "SP-001",
+        EnteringTrader = "T0001",
+        DefaultMarketSegmentId = 1,
+    };
+
+    private static FixpClientSession NewSession(EntryPointClientOptions? opts = null) =>
+        new(new MemoryStream(), opts ?? Opts());
+
+    [Fact]
+    public void ToWireSeqNum_AtMaxUint32_Encodes_Successfully()
+    {
+        var seq = SeqNumGuard.ToWireSeqNum(uint.MaxValue);
+        Assert.Equal(uint.MaxValue, seq.Value);
+    }
+
+    [Fact]
+    public void ToWireSeqNum_PastMaxUint32_Throws_InvalidOperation_With_Rotation_Hint()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => SeqNumGuard.ToWireSeqNum((ulong)uint.MaxValue + 1UL));
+        Assert.Contains("ReconnectAsync", ex.Message);
+        Assert.Contains("SessionVerID", ex.Message);
+    }
+
+    [Fact]
+    public void NextOutboundSeqNum_At_Boundary_Returns_MaxUint32()
+    {
+        var session = NewSession();
+        session.ResumeOutboundSeqNum(uint.MaxValue);
+        Assert.Equal((ulong)uint.MaxValue, session.NextOutboundSeqNum());
+        Assert.Equal((ulong)uint.MaxValue, session.LastAssignedOutboundSeqNum());
+    }
+
+    [Fact]
+    public void NextOutboundSeqNum_Past_Boundary_Throws_And_Does_Not_Advance_Counter()
+    {
+        var session = NewSession();
+        session.ResumeOutboundSeqNum((ulong)uint.MaxValue + 1UL);
+        Assert.Equal((ulong)uint.MaxValue, session.LastAssignedOutboundSeqNum());
+
+        var ex = Assert.Throws<InvalidOperationException>(() => session.NextOutboundSeqNum());
+        Assert.Contains("ReconnectAsync", ex.Message);
+
+        // Counter rolled back; subsequent calls keep failing rather than silently advancing.
+        Assert.Equal((ulong)uint.MaxValue, session.LastAssignedOutboundSeqNum());
+        Assert.Throws<InvalidOperationException>(() => session.NextOutboundSeqNum());
+        Assert.Equal((ulong)uint.MaxValue, session.LastAssignedOutboundSeqNum());
+    }
+
+    [Fact]
+    public void OrderEntryEncoder_At_MaxUint32_Encodes_Successfully()
+    {
+        var req = new SimpleNewOrderRequest
+        {
+            ClOrdID = new ClOrdID(1UL),
+            SecurityId = 7,
+            Side = Side.Buy,
+            OrderType = SimpleOrderType.Limit,
+            OrderQty = 100,
+            Price = 12.34m,
+            Account = 555,
+        };
+        var buffer = new byte[256];
+        var len = OrderEntryEncoder.EncodeSimpleNewOrder(buffer, req, Opts(), msgSeqNum: uint.MaxValue);
+        Assert.True(len > 0);
+    }
+
+    [Fact]
+    public void OrderEntryEncoder_Past_MaxUint32_Throws_InvalidOperation()
+    {
+        var req = new SimpleNewOrderRequest
+        {
+            ClOrdID = new ClOrdID(1UL),
+            SecurityId = 7,
+            Side = Side.Buy,
+            OrderType = SimpleOrderType.Limit,
+            OrderQty = 100,
+            Price = 12.34m,
+            Account = 555,
+        };
+        var buffer = new byte[256];
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => OrderEntryEncoder.EncodeSimpleNewOrder(buffer, req, Opts(), msgSeqNum: (ulong)uint.MaxValue + 1UL));
+        Assert.Contains("ReconnectAsync", ex.Message);
+    }
+
+    [Fact]
+    public void NextOutboundSeqNum_Crossing_NearExhaustionThreshold_Logs_Warning_Once()
+    {
+        var captured = new List<(int eventId, string message)>();
+        var opts = Opts();
+        opts.Logger = new CapturingLogger(captured);
+        var session = NewSession(opts);
+
+        session.ResumeOutboundSeqNum(SeqNumGuard.NearExhaustionThreshold - 1UL);
+        _ = session.NextOutboundSeqNum(); // assigns NearExhaustionThreshold - 1, still below
+        Assert.DoesNotContain(captured, e => e.eventId == 4013);
+
+        _ = session.NextOutboundSeqNum(); // assigns NearExhaustionThreshold — first crossing
+        Assert.Single(captured, e => e.eventId == 4013);
+
+        _ = session.NextOutboundSeqNum();
+        _ = session.NextOutboundSeqNum();
+        Assert.Single(captured, e => e.eventId == 4013); // still exactly one
+    }
+
+    private sealed class CapturingLogger(List<(int eventId, string message)> sink)
+        : Microsoft.Extensions.Logging.ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+        public void Log<TState>(
+            Microsoft.Extensions.Logging.LogLevel logLevel,
+            Microsoft.Extensions.Logging.EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            sink.Add((eventId.Id, formatter(state, exception)));
+        }
+    }
+}


### PR DESCRIPTION
## Bug

`ConnectOnceAsync` allocates `TcpClient`, `FixpClientSession`, the persistence worker, the keep-alive scheduler and the inbound loop in sequence after the TCP connect succeeds. If any post-TCP step (TLS handshake, Negotiate, Establish, snapshot hydration, worker startup) throws, the exception propagates to the outer `ConnectAsync` retry loop with `_tcp`/`_session`/`_keepAlive`/`_retransmit`/`_persistWorker` still bound to the dead partial connect.

A subsequent retry attempt then creates a new `TcpClient` and overwrites those fields, **orphaning the prior socket and any started background tasks forever**. `DisposeAsync` only frees the *currently bound* fields, so on a failed-then-retried-then-successful connect the orphaned resources are never disposed — leaked sockets, leaked worker tasks, leaked timers.

## Fix

- Wrap the body of `ConnectOnceAsync` after the TCP connect in `try/catch` and call `StopActiveSessionAsync` (the same idempotent teardown helper used by `ReconnectAsync`/`DisposeAsync`) on any exception before rethrowing. The helper is null-safe for partially-initialized state and, per #144's contract, intentionally does **not** complete `_events.Writer` so the channel survives across reconnect attempts.
- `SegmentedEntryPointClient.ConnectAsync`: a partial fan-out failure across per-segment `ConnectAsync` calls now disposes every sibling client before propagating, so a successful segment can't leak when a sibling fails.

## Tests

`tests/B3.EntryPoint.Client.Tests/ConnectFailureCleanupTests.cs` adds two tests driven by `InProcessFixpTestPeer` with `EstablishRejectAfter = 1`:

1. `ConnectAsync_WhenEstablishRejected_DisposesAllPartialResources` — asserts `State`, `KeepAlive`, `Retransmit` and the new `HasActiveSessionForTesting` hook all return to a clean disconnected state after the rejected establish.
2. `ConnectAsync_AfterFailedAttempt_CanReconnectWithoutLeakingPriorSocket` — flips the peer back to accept-mode and verifies a follow-up `ConnectAsync` succeeds. On unfixed code this trips the 'Client is already connected' guard because the orphaned `_session` field is non-null.

## Pre-PR checklist

- `dotnet build … -c Release` — succeeds, 0 warnings.
- `dotnet test … -c Release` — 164/166 passing; the 2 failures (`TerminateApiTests.ReconnectAsync_AcceptsIncreasingVerId_AttemptsTcpConnect`, `DropCopyClientTests.ConnectAsync_AttemptsTcpConnect`) are pre-existing and unrelated to this change.
- `dotnet format … --verify-no-changes` — clean.