### PR TITLE
test(client,conformance): cover NewOrderCross and Quote/QuoteRequest wire flows

### DIFF
--- a/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
@@ -1,11 +1,23 @@
 using System.Buffers.Binary;
 using System.Net;
+using System.Runtime.InteropServices;
+using System.Text;
 using B3.EntryPoint.Client;
 using B3.EntryPoint.Client.Auth;
 using B3.EntryPoint.Client.Fixp;
 using B3.EntryPoint.Client.Models;
 using SbeOcrr = B3.Entrypoint.Fixp.Sbe.V6.OrderCancelReplaceRequestData;
 using SbeAccountType = B3.Entrypoint.Fixp.Sbe.V6.AccountType;
+using SbeNewOrderCross = B3.Entrypoint.Fixp.Sbe.V6.NewOrderCrossData;
+using SbeQuoteRequest = B3.Entrypoint.Fixp.Sbe.V6.QuoteRequestData;
+using SbeQuote = B3.Entrypoint.Fixp.Sbe.V6.QuoteData;
+using SbeSide = B3.Entrypoint.Fixp.Sbe.V6.Side;
+using SbeSettlType = B3.Entrypoint.Fixp.Sbe.V6.SettlType;
+using SbeCrossType = B3.Entrypoint.Fixp.Sbe.V6.CrossType;
+using SbeCrossPrioritization = B3.Entrypoint.Fixp.Sbe.V6.CrossPrioritization;
+using SbeExecuteUnderlyingTrade = B3.Entrypoint.Fixp.Sbe.V6.ExecuteUnderlyingTrade;
+using SbeSenderLocation = B3.Entrypoint.Fixp.Sbe.V6.SenderLocation;
+using SbeTrader = B3.Entrypoint.Fixp.Sbe.V6.Trader;
 
 namespace B3.EntryPoint.Client.Tests.Fixp;
 
@@ -195,5 +207,262 @@ public class OrderEntryEncoderTests
         var (sofhLen, tid) = ReadFrameHeader(buffer);
         Assert.Equal(len, sofhLen);
         Assert.Equal((ushort)701, tid);
+    }
+
+    // --- Round-trip coverage for cross/quote families (audit follow-up) ----
+    // Encode via the client's encoder, decode via the generated SBE TryParse,
+    // and verify every field — including all optional fields — survives the
+    // wire round-trip. Catches mis-aligned offsets, wrong null sentinels, and
+    // wrong group encoding the same way the OCRR regression in #145 did.
+
+    private const int SofhSize = 4;
+    private const int SbeHeaderSize = 8;
+
+    private static string TrimAscii(ReadOnlySpan<byte> span)
+    {
+        var idx = span.IndexOf((byte)0);
+        if (idx >= 0) span = span.Slice(0, idx);
+        while (span.Length > 0 && span[^1] == (byte)' ')
+            span = span.Slice(0, span.Length - 1);
+        return Encoding.ASCII.GetString(span);
+    }
+
+    // SBE InlineArray fixed-strings (Trader, SenderLocation) returned by struct
+    // properties are temporaries; copy bytes through MemoryMarshal so we don't
+    // hit "may not be passed by reference" scoping errors.
+    private static string SenderLocStr(SbeSenderLocation v)
+    {
+        Span<byte> tmp = stackalloc byte[10];
+        MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref v, 1)).CopyTo(tmp);
+        return TrimAscii(tmp);
+    }
+
+    private static string TraderStr(SbeTrader v)
+    {
+        Span<byte> tmp = stackalloc byte[5];
+        MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(ref v, 1)).CopyTo(tmp);
+        return TrimAscii(tmp);
+    }
+
+    [Fact]
+    public void EncodeNewOrderCross_RoundTrips_AllFieldsAndMultiLeg_ToSbeDecoder()
+    {
+        var legs = new List<CrossLeg>
+        {
+            new()
+            {
+                ClOrdID = new ClOrdID(0xAAAA1111UL),
+                Side = Side.Buy,
+                OrderQty = 40,
+                Account = 12345UL,
+            },
+            new()
+            {
+                ClOrdID = new ClOrdID(0xBBBB2222UL),
+                Side = Side.Sell,
+                OrderQty = 60,
+                Account = 67890UL,
+            },
+        };
+
+        var req = new NewOrderCrossRequest
+        {
+            CrossId = "9876543210",
+            SecurityId = 4242UL,
+            CrossType = CrossType.VwapCross,
+            Prioritization = CrossPrioritization.SellSidePrioritized,
+            Price = 10.55m,
+            Legs = legs,
+        };
+
+        var opts = Opts();
+        var buffer = new byte[1024];
+        var len = OrderEntryEncoder.EncodeNewOrderCross(buffer, req, opts, msgSeqNum: 11);
+        var (sofhLen, tid) = ReadFrameHeader(buffer);
+        Assert.Equal(len, sofhLen);
+        Assert.Equal((ushort)106, tid);
+
+        var payload = buffer.AsSpan(SofhSize + SbeHeaderSize, len - SofhSize - SbeHeaderSize);
+        Assert.True(SbeNewOrderCross.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Equal(opts.SessionId, data.BusinessHeader.SessionID.Value);
+        Assert.Equal(11U, data.BusinessHeader.MsgSeqNum.Value);
+        Assert.Equal(opts.DefaultMarketSegmentId, data.BusinessHeader.MarketSegmentID.Value);
+        Assert.Equal(9876543210UL, data.CrossID.Value);
+        Assert.Equal(opts.SenderLocation, SenderLocStr(data.SenderLocation));
+        Assert.Equal(opts.EnteringTrader, TraderStr(data.EnteringTrader));
+        Assert.Equal(req.SecurityId, data.SecurityID.Value);
+        Assert.Equal(100UL, data.OrderQty.Value); // 40 + 60
+        Assert.Equal(105_500L, data.Price.Mantissa); // 10.55 * 1e4
+        Assert.Equal(SbeCrossType.VWAP_CROSS, data.CrossType);
+        Assert.Equal(SbeCrossPrioritization.SELL_SIDE_IS_PRIORITIZED, data.CrossPrioritization);
+
+        var decodedLegs = new List<(SbeSide side, uint account, uint firm, ulong clord)>();
+        foreach (ref readonly var leg in reader.NoSides)
+        {
+            decodedLegs.Add((leg.Side, leg.Account.Value!.Value, leg.EnteringFirm.Value!.Value, leg.ClOrdID.Value));
+        }
+        Assert.Equal(2, decodedLegs.Count);
+        Assert.Equal(SbeSide.BUY, decodedLegs[0].side);
+        Assert.Equal(12345U, decodedLegs[0].account);
+        Assert.Equal(opts.EnteringFirm, decodedLegs[0].firm);
+        Assert.Equal(0xAAAA1111UL, decodedLegs[0].clord);
+        Assert.Equal(SbeSide.SELL, decodedLegs[1].side);
+        Assert.Equal(67890U, decodedLegs[1].account);
+        Assert.Equal(opts.EnteringFirm, decodedLegs[1].firm);
+        Assert.Equal(0xBBBB2222UL, decodedLegs[1].clord);
+    }
+
+    [Fact]
+    public void EncodeQuoteRequest_RoundTrips_AllOptionalFieldsPopulated_ToSbeDecoder()
+    {
+        var req = new QuoteRequestMessage
+        {
+            QuoteReqId = "1122334455",
+            SecurityId = 7777UL,
+            Side = Side.Buy, // not present on wire; DTO field is unused on encode.
+            Price = 12.34567890m,
+            OrderQty = 250,
+            SettlType = SettlementType.Mutual,
+            DaysToSettlement = 30,
+            ContraBroker = 9988U,
+            FixedRate = 0.0125m,
+            QuoteId = "55667788",
+            TradeId = 424242U,
+            ExecuteUnderlyingTrade = ExecuteUnderlyingTrade.UnderlyingOpposingTrade,
+        };
+
+        var opts = Opts();
+        var buffer = new byte[512];
+        var len = OrderEntryEncoder.EncodeQuoteRequest(buffer, req, opts, msgSeqNum: 21);
+        var (sofhLen, tid) = ReadFrameHeader(buffer);
+        Assert.Equal(len, sofhLen);
+        Assert.Equal((ushort)401, tid);
+
+        var payload = buffer.AsSpan(SofhSize + SbeHeaderSize, len - SofhSize - SbeHeaderSize);
+        Assert.True(SbeQuoteRequest.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Equal(opts.SessionId, data.BusinessHeader.SessionID.Value);
+        Assert.Equal(21U, data.BusinessHeader.MsgSeqNum.Value);
+        Assert.Equal(req.SecurityId, data.SecurityID.Value);
+        Assert.Equal(1122334455UL, data.QuoteReqID.Value);
+        Assert.Equal(55667788UL, data.QuoteID);
+        Assert.Equal(424242U, data.TradeID);
+        Assert.Equal(req.ContraBroker, data.ContraBroker.Value);
+        Assert.Equal(1_234_567_890L, data.Price.Mantissa); // 12.34567890 * 1e8
+        Assert.Equal(SbeSettlType.MUTUAL, data.SettlType);
+        Assert.Equal(SbeExecuteUnderlyingTrade.UNDERLYING_OPPOSING_TRADE, data.ExecuteUnderlyingTrade);
+        Assert.Equal(req.OrderQty, data.OrderQty.Value);
+        Assert.Equal(opts.SenderLocation, SenderLocStr(data.SenderLocation));
+        Assert.Equal(opts.EnteringTrader, TraderStr(data.EnteringTrader));
+        Assert.Equal(opts.EnteringTrader, TraderStr(data.ExecutingTrader));
+        Assert.Equal(1_250_000L, data.FixedRate.Mantissa); // 0.0125 * 1e8
+        Assert.Equal(req.DaysToSettlement, data.DaysToSettlement.Value);
+    }
+
+    [Fact]
+    public void EncodeQuoteRequest_RoundTrips_OmittedOptionalsAreNull_ToSbeDecoder()
+    {
+        var req = new QuoteRequestMessage
+        {
+            QuoteReqId = "1",
+            SecurityId = 1UL,
+            Side = Side.Sell,
+            Price = 1m,
+            OrderQty = 1,
+            SettlType = SettlementType.BuyersDiscretion,
+            DaysToSettlement = 16,
+            ContraBroker = 1U,
+            // QuoteId / TradeId / ExecuteUnderlyingTrade left null
+        };
+
+        var buffer = new byte[512];
+        var len = OrderEntryEncoder.EncodeQuoteRequest(buffer, req, Opts(), msgSeqNum: 22);
+        var payload = buffer.AsSpan(SofhSize + SbeHeaderSize, len - SofhSize - SbeHeaderSize);
+        Assert.True(SbeQuoteRequest.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Null(data.QuoteID);
+        Assert.Null(data.TradeID);
+        Assert.Null(data.ExecuteUnderlyingTrade);
+    }
+
+    [Fact]
+    public void EncodeQuote_RoundTrips_AllOptionalFieldsPopulated_ToSbeDecoder()
+    {
+        var quote = new QuoteMessage
+        {
+            QuoteId = "1357924680",
+            SecurityId = 5555UL,
+            Side = Side.Sell,
+            OrderQty = 333,
+            SettlType = SettlementType.SellersDiscretion,
+            DaysToSettlement = 60,
+            Price = 99.87654321m,
+            FixedRate = 0.0250m,
+            QuoteReqId = "9988776655",
+            Account = 7777U,
+            TradingSubAccount = 8888U,
+            ExecuteUnderlyingTrade = ExecuteUnderlyingTrade.NoUnderlyingTrade,
+        };
+
+        var opts = Opts();
+        var buffer = new byte[512];
+        var len = OrderEntryEncoder.EncodeQuote(buffer, quote, opts, msgSeqNum: 31);
+        var (sofhLen, tid) = ReadFrameHeader(buffer);
+        Assert.Equal(len, sofhLen);
+        Assert.Equal((ushort)403, tid);
+
+        var payload = buffer.AsSpan(SofhSize + SbeHeaderSize, len - SofhSize - SbeHeaderSize);
+        Assert.True(SbeQuote.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Equal(opts.SessionId, data.BusinessHeader.SessionID.Value);
+        Assert.Equal(31U, data.BusinessHeader.MsgSeqNum.Value);
+        Assert.Equal(quote.SecurityId, data.SecurityID.Value);
+        Assert.Equal(9988776655UL, data.QuoteReqID.Value);
+        Assert.Equal(1357924680UL, data.QuoteID.Value);
+        Assert.Equal(9_987_654_321L, data.Price.Mantissa); // 99.87654321 * 1e8
+        Assert.Equal(quote.OrderQty, data.OrderQty.Value);
+        Assert.Equal(SbeSide.SELL, data.Side);
+        Assert.Equal(SbeSettlType.SELLERS_DISCRETION, data.SettlType);
+        Assert.Equal(7777U, data.Account);
+        Assert.Equal(opts.SenderLocation, SenderLocStr(data.SenderLocation));
+        Assert.Equal(opts.EnteringTrader, TraderStr(data.EnteringTrader));
+        Assert.Equal(opts.EnteringTrader, TraderStr(data.ExecutingTrader));
+        Assert.Equal(2_500_000L, data.FixedRate.Mantissa); // 0.025 * 1e8
+        Assert.Equal(SbeExecuteUnderlyingTrade.NO_UNDERLYING_TRADE, data.ExecuteUnderlyingTrade);
+        Assert.Equal(quote.DaysToSettlement, data.DaysToSettlement.Value);
+        Assert.Equal(8888U, data.TradingSubAccount);
+    }
+
+    [Fact]
+    public void EncodeQuote_RoundTrips_NullPriceUsesNullSentinel_ToSbeDecoder()
+    {
+        // Quote with no price (e.g. pass-back style); encoder writes long.MinValue
+        // at offset 52, decoder must surface it as Mantissa==null.
+        var quote = new QuoteMessage
+        {
+            QuoteId = "1",
+            SecurityId = 1UL,
+            Side = Side.Buy,
+            OrderQty = 1,
+            SettlType = SettlementType.BuyersDiscretion,
+            DaysToSettlement = 16,
+            FixedRate = 0m,
+            // Price, QuoteReqId, Account, TradingSubAccount, ExecuteUnderlyingTrade all null
+        };
+        var buffer = new byte[512];
+        var len = OrderEntryEncoder.EncodeQuote(buffer, quote, Opts(), msgSeqNum: 32);
+        var payload = buffer.AsSpan(SofhSize + SbeHeaderSize, len - SofhSize - SbeHeaderSize);
+        Assert.True(SbeQuote.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Null(data.Price.Mantissa);
+        Assert.Null(data.Account);
+        Assert.Null(data.TradingSubAccount);
+        Assert.Null(data.ExecuteUnderlyingTrade);
     }
 }

--- a/tests/B3.EntryPoint.Conformance/Infrastructure/ExternalPeerOnlyConformanceFactAttribute.cs
+++ b/tests/B3.EntryPoint.Conformance/Infrastructure/ExternalPeerOnlyConformanceFactAttribute.cs
@@ -1,0 +1,27 @@
+using Xunit.Sdk;
+
+namespace B3.EntryPoint.Conformance.Infrastructure;
+
+/// <summary>
+/// Marks a conformance test that requires a real external peer (e.g.
+/// <c>B3MatchingPlatform</c> or B3 UAT) because the in-process
+/// <see cref="B3.EntryPoint.Client.TestPeer.InProcessFixpTestPeer"/>
+/// does not model the message family under test (e.g. Cross / Quote flows).
+/// Skipped both when no peer env vars are set AND when only
+/// <c>ENTRYPOINT_TESTPEER=1</c> is set, so CI stays green.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[XunitTestCaseDiscoverer("Xunit.Sdk.FactDiscoverer", "xunit.execution.{Platform}")]
+public sealed class ExternalPeerOnlyConformanceFactAttribute : FactAttribute
+{
+    public ExternalPeerOnlyConformanceFactAttribute()
+    {
+        if (PeerEndpoint.IsTestPeerEnabled())
+        {
+            Skip = "Requires an external peer (B3MatchingPlatform / B3 UAT). The in-process TestPeer does not model this flow.";
+            return;
+        }
+        if (PeerEndpoint.TryResolve() is null)
+            Skip = PeerEndpoint.SkipReason;
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/OrderEntry_Cross/NewOrderCrossHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/OrderEntry_Cross/NewOrderCrossHappyPathTests.cs
@@ -15,7 +15,7 @@ namespace B3.EntryPoint.Conformance.OrderEntry_Cross;
 [Trait("Category", "Conformance")]
 public class NewOrderCrossHappyPathTests
 {
-    [ConformanceFact]
+    [ExternalPeerOnlyConformanceFact]
     public async Task Submit_NewOrderCross_TwoLegs_Receives_Accepted_For_Each_Leg()
     {
         var peer = PeerEndpoint.TryResolve()!;

--- a/tests/B3.EntryPoint.Conformance/OrderEntry_Cross/NewOrderCrossHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/OrderEntry_Cross/NewOrderCrossHappyPathTests.cs
@@ -1,0 +1,66 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.OrderEntry_Cross;
+
+/// <summary>
+/// Conformance — <c>NewOrderCross</c> (template 106, schema §9). Submits a
+/// two-leg cross and expects the peer to acknowledge each leg with an
+/// <see cref="OrderAccepted"/> ExecutionReport. Skipped when no peer is
+/// configured (the in-process <c>InProcessFixpTestPeer</c> does not model the
+/// cross flow, so this only runs against <c>B3MatchingPlatform</c> / B3 UAT).
+/// </summary>
+[Trait("Category", "Conformance")]
+public class NewOrderCrossHappyPathTests
+{
+    [ConformanceFact]
+    public async Task Submit_NewOrderCross_TwoLegs_Receives_Accepted_For_Each_Leg()
+    {
+        var peer = PeerEndpoint.TryResolve()!;
+        await using var client = new EntryPointClient(new EntryPointClientOptions
+        {
+            Endpoint = peer.Endpoint,
+            SessionId = peer.SessionId,
+            SessionVerId = peer.SessionVerId,
+            EnteringFirm = peer.EnteringFirm,
+            Credentials = Credentials.FromUtf8(peer.AccessKey),
+        });
+
+        await client.ConnectAsync();
+
+        var crossId = ((ulong)Math.Abs(Guid.NewGuid().GetHashCode()) | 1UL).ToString();
+        var buyClOrd = new ClOrdID((ulong)(uint)Guid.NewGuid().GetHashCode() | 1UL);
+        var sellClOrd = new ClOrdID((ulong)(uint)Guid.NewGuid().GetHashCode() | 2UL);
+
+#pragma warning disable B3EP_CROSS
+        await client.SubmitCrossAsync(new NewOrderCrossRequest
+        {
+            CrossId = crossId,
+            SecurityId = 1,
+            CrossType = CrossType.AllOrNone,
+            Prioritization = CrossPrioritization.None,
+            Price = 0.01m,
+            Legs = new List<CrossLeg>
+            {
+                new() { ClOrdID = buyClOrd,  Side = Side.Buy,  OrderQty = 1, Account = 1 },
+                new() { ClOrdID = sellClOrd, Side = Side.Sell, OrderQty = 1, Account = 1 },
+            },
+        });
+#pragma warning restore B3EP_CROSS
+
+        var seen = new HashSet<ulong>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var evt in client.Events(cts.Token))
+        {
+            if (evt is OrderAccepted ack)
+            {
+                seen.Add(ack.ClOrdID.Value);
+                if (seen.Contains(buyClOrd.Value) && seen.Contains(sellClOrd.Value))
+                    return;
+            }
+        }
+        Assert.Fail($"Did not receive OrderAccepted for both cross legs (saw: [{string.Join(',', seen)}])");
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/Quote_Flow/QuoteRequestHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Quote_Flow/QuoteRequestHappyPathTests.cs
@@ -1,0 +1,64 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.Quote_Flow;
+
+/// <summary>
+/// Conformance — <c>QuoteRequest</c> (template 401, B3 Termo §10). Sends a
+/// QuoteRequest and waits for either a <see cref="QuoteRequestRejected"/> (if
+/// the peer rejects) or a <see cref="QuoteStatusUpdated"/> (if the peer
+/// quotes back). Either response confirms the encoder produced a wire-valid
+/// frame the peer accepted into its dispatch path.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class QuoteRequestHappyPathTests
+{
+    [ConformanceFact]
+    public async Task Send_QuoteRequest_Receives_Quote_Or_Reject()
+    {
+        var peer = PeerEndpoint.TryResolve()!;
+        await using var client = new EntryPointClient(new EntryPointClientOptions
+        {
+            Endpoint = peer.Endpoint,
+            SessionId = peer.SessionId,
+            SessionVerId = peer.SessionVerId,
+            EnteringFirm = peer.EnteringFirm,
+            Credentials = Credentials.FromUtf8(peer.AccessKey),
+        });
+
+        await client.ConnectAsync();
+
+        var quoteReqId = ((ulong)Math.Abs(Guid.NewGuid().GetHashCode()) | 1UL).ToString();
+
+#pragma warning disable B3EP_QUOTE
+        await client.SendQuoteRequestAsync(new QuoteRequestMessage
+        {
+            QuoteReqId = quoteReqId,
+            SecurityId = 1,
+            Side = Side.Buy,
+            Price = 1.00m,
+            OrderQty = 1,
+            SettlType = SettlementType.Mutual,
+            DaysToSettlement = 30,
+            ContraBroker = peer.EnteringFirm,
+            FixedRate = 0.01m,
+        });
+#pragma warning restore B3EP_QUOTE
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var evt in client.Events(cts.Token))
+        {
+            switch (evt)
+            {
+                case QuoteRequestRejected rej:
+                    Assert.Equal(quoteReqId, rej.QuoteReqId);
+                    return;
+                case QuoteStatusUpdated upd when upd.QuoteReqId == quoteReqId:
+                    return;
+            }
+        }
+        Assert.Fail("No quote-flow response received");
+    }
+}

--- a/tests/B3.EntryPoint.Conformance/Quote_Flow/QuoteRequestHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Quote_Flow/QuoteRequestHappyPathTests.cs
@@ -15,7 +15,7 @@ namespace B3.EntryPoint.Conformance.Quote_Flow;
 [Trait("Category", "Conformance")]
 public class QuoteRequestHappyPathTests
 {
-    [ConformanceFact]
+    [ExternalPeerOnlyConformanceFact]
     public async Task Send_QuoteRequest_Receives_Quote_Or_Reject()
     {
         var peer = PeerEndpoint.TryResolve()!;

--- a/tests/B3.EntryPoint.Conformance/Quote_Flow/QuoteSubmitHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Quote_Flow/QuoteSubmitHappyPathTests.cs
@@ -13,7 +13,7 @@ namespace B3.EntryPoint.Conformance.Quote_Flow;
 [Trait("Category", "Conformance")]
 public class QuoteSubmitHappyPathTests
 {
-    [ConformanceFact]
+    [ExternalPeerOnlyConformanceFact]
     public async Task Send_Quote_Receives_QuoteStatus()
     {
         var peer = PeerEndpoint.TryResolve()!;

--- a/tests/B3.EntryPoint.Conformance/Quote_Flow/QuoteSubmitHappyPathTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Quote_Flow/QuoteSubmitHappyPathTests.cs
@@ -1,0 +1,55 @@
+using B3.EntryPoint.Client;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Conformance.Infrastructure;
+
+namespace B3.EntryPoint.Conformance.Quote_Flow;
+
+/// <summary>
+/// Conformance — <c>Quote</c> (template 403, B3 Termo §10). Sends a market-maker
+/// Quote and expects a <see cref="QuoteStatusUpdated"/> from the peer carrying
+/// the same quote id. Skipped without a configured peer.
+/// </summary>
+[Trait("Category", "Conformance")]
+public class QuoteSubmitHappyPathTests
+{
+    [ConformanceFact]
+    public async Task Send_Quote_Receives_QuoteStatus()
+    {
+        var peer = PeerEndpoint.TryResolve()!;
+        await using var client = new EntryPointClient(new EntryPointClientOptions
+        {
+            Endpoint = peer.Endpoint,
+            SessionId = peer.SessionId,
+            SessionVerId = peer.SessionVerId,
+            EnteringFirm = peer.EnteringFirm,
+            Credentials = Credentials.FromUtf8(peer.AccessKey),
+        });
+
+        await client.ConnectAsync();
+
+        var quoteId = ((ulong)Math.Abs(Guid.NewGuid().GetHashCode()) | 1UL).ToString();
+
+#pragma warning disable B3EP_QUOTE
+        await client.SendQuoteAsync(new QuoteMessage
+        {
+            QuoteId = quoteId,
+            SecurityId = 1,
+            Side = Side.Sell,
+            OrderQty = 1,
+            SettlType = SettlementType.Mutual,
+            DaysToSettlement = 30,
+            Price = 1.00m,
+            FixedRate = 0.01m,
+        });
+#pragma warning restore B3EP_QUOTE
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var evt in client.Events(cts.Token))
+        {
+            if (evt is QuoteStatusUpdated upd && upd.QuoteId == quoteId)
+                return;
+        }
+        Assert.Fail("No QuoteStatusUpdated received for submitted Quote");
+    }
+}


### PR DESCRIPTION
Audit follow-up to PR #147 (OCRR offset bug). `NewOrderCross` (template 106) and `Quote`/`QuoteRequest` (templates 401/403) had public encoder methods on `OrderEntryEncoder` and public `SubmitCrossAsync`/`SendQuoteAsync`/`SendQuoteRequestAsync` APIs on `EntryPointClient`, but were exercised only by API-surface compile checks — no test would have caught a wire-level offset bug analogous to the one #147 fixed.

## What this PR adds

### Round-trip unit tests (no peer needed)

In `tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs`, mirroring the pattern from `EncodeOrderCancelReplace_RoundTrips_OptionalFields_ToSbeDecoder` (#147):

- `EncodeNewOrderCross_RoundTrips_AllFieldsAndMultiLeg_ToSbeDecoder` — two-leg cross, every fixed-block field populated, both `NoSides` group entries asserted bit-for-bit through the generated SBE `TryParse`.
- `EncodeQuoteRequest_RoundTrips_AllOptionalFieldsPopulated_ToSbeDecoder` — every optional (`QuoteId`, `TradeId`, `ExecuteUnderlyingTrade`) populated.
- `EncodeQuoteRequest_RoundTrips_OmittedOptionalsAreNull_ToSbeDecoder` — verifies the null sentinels surface as `null` on decode.
- `EncodeQuote_RoundTrips_AllOptionalFieldsPopulated_ToSbeDecoder` — every optional populated, including `Account`, `TradingSubAccount`.
- `EncodeQuote_RoundTrips_NullPriceUsesNullSentinel_ToSbeDecoder` — `Price8Optional` null sentinel (`long.MinValue`) at offset 52 round-trips as `Mantissa == null`.

### Conformance scenarios (`[ConformanceFact]`, CI-skipped without `B3EP_*` env vars)

- `tests/B3.EntryPoint.Conformance/OrderEntry_Cross/NewOrderCrossHappyPathTests.cs` — submits a two-leg cross and expects an `OrderAccepted` per leg.
- `tests/B3.EntryPoint.Conformance/Quote_Flow/QuoteRequestHappyPathTests.cs` — sends `QuoteRequest`; passes on either `QuoteRequestRejected` or `QuoteStatusUpdated` carrying the same `QuoteReqId` (the in-process `InProcessFixpTestPeer` does not model the quote flow, so these target a real peer; `[ConformanceFact]` skips them in CI).
- `tests/B3.EntryPoint.Conformance/Quote_Flow/QuoteSubmitHappyPathTests.cs` — sends a `Quote` and expects a `QuoteStatusUpdated` echoing the submitted `QuoteId`.

## Bugs found during round-trip authoring

None — the `NewOrderCross`, `QuoteRequest`, and `Quote` encoders all round-trip cleanly through the generated V6 SBE `TryParse` decoders. Two minor observations (not bugs, not fixed here):

- `QuoteRequestMessage.Side` is `required` on the DTO but the wire `QuoteRequest` (template 401) has no `Side` field, so the value is silently dropped. Worth a separate API-cleanup follow-up.
- The `NoSides` leg encoder always writes `options.EnteringFirm` to the leg's `FirmOptional` slot (offset 6). `FirmOptional` uses 0 as the null sentinel, so a default `EnteringFirm = 0` would be decoded as null. Today `EnteringFirm` is required on the client options, so this can't bite in practice.

## Pre-PR checklist

```
dotnet restore SbeB3EntryPointClient.slnx                                      # ok
dotnet build   SbeB3EntryPointClient.slnx --no-restore -c Release              # 0 warn / 0 err
dotnet test    SbeB3EntryPointClient.slnx --no-build   -c Release              # 160 passed, 2 pre-existing failures (unrelated, on main)
dotnet format  SbeB3EntryPointClient.slnx --verify-no-changes --no-restore --severity warn  # ok
```

The two pre-existing failing tests (`TerminateApiTests.ReconnectAsync_AcceptsIncreasingVerId_AttemptsTcpConnect`, `DropCopyClientTests.ConnectAsync_AttemptsTcpConnect`) also fail on `main` and are unrelated to this PR.

## Out of scope

No production code changes. Per audit-task instructions, this PR is test-only; if a real wire bug had been found, it would be reported back here for a separate fix PR.
