### PR TITLE
fix(client): persist SessionVerId snapshot at lifecycle boundaries (#152)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -214,6 +214,14 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
 
             await HydrateFromSnapshotAsync(ct).ConfigureAwait(false);
 
+            // #152: persist the session identity (SessionId/SessionVerId) at
+            // lifecycle boundaries, not on a delta count. Writing immediately
+            // after a successful Establish guarantees `snapshot.json` exists
+            // even if the host restarts before `StateCompactEveryDeltas`
+            // appends accumulate, so warm-restart and Reconnect can resolve
+            // the verId the peer actually accepted.
+            await PersistSnapshotAsync(ct).ConfigureAwait(false);
+
             StartPersistenceWorker();
 
             _session.OnInboundEvent = OnInboundEventForPersistence;
@@ -462,6 +470,35 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         {
             await store.SaveAsync(BuildSnapshot(), ct).ConfigureAwait(false);
             await store.CompactAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _options.Logger.SnapshotCompactionFailed(ex);
+        }
+    }
+
+    /// <summary>
+    /// Best-effort persistence of the current <see cref="SessionSnapshot"/>
+    /// at a lifecycle boundary (post-Establish, pre-teardown). Unlike
+    /// <see cref="MaybeCompactAsync"/> this is unconditional — it does not
+    /// gate on <see cref="EntryPointClientOptions.StateCompactEveryDeltas"/>
+    /// — and is therefore the mechanism that makes <c>SessionId</c> /
+    /// <c>SessionVerId</c> durable across restarts even when fewer than
+    /// <c>StateCompactEveryDeltas</c> deltas have been appended (#152).
+    /// Failures are logged via <see cref="LogMessages.SnapshotCompactionFailed"/>
+    /// and swallowed: persistence is advisory and must never break the
+    /// connect or teardown path.
+    /// </summary>
+    private async ValueTask PersistSnapshotAsync(CancellationToken ct)
+    {
+        var store = _options.SessionStateStore;
+        if (store is null || _session is null) return;
+        try
+        {
+            await store.SaveAsync(BuildSnapshot(), ct).ConfigureAwait(false);
+            // SaveAsync subsumes the delta log; reset the in-memory counter
+            // so the next MaybeCompactAsync threshold is measured from here.
+            System.Threading.Interlocked.Exchange(ref _deltasSinceCompact, 0);
         }
         catch (Exception ex)
         {
@@ -1041,6 +1078,14 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     {
         var timeout = _options.SessionTeardownTimeout;
         if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromSeconds(5);
+
+        // 0. Flush a final snapshot before tearing down. This must happen
+        //    while `_session` is still live (BuildSnapshot reads
+        //    `_session.LastAssignedOutboundSeqNum()`) and before the persist
+        //    CTS below is cancelled. Guarantees the on-disk snapshot is
+        //    contiguous with the last in-memory state on graceful shutdown
+        //    and on Reconnect (#152).
+        await PersistSnapshotAsync(ct).ConfigureAwait(false);
 
         // 1. Cancel session-scoped CTSs and complete the persistence channel
         //    so its worker drains the in-flight queue and exits.

--- a/tests/B3.EntryPoint.Client.Tests/State/SnapshotDurabilityTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/State/SnapshotDurabilityTests.cs
@@ -1,0 +1,122 @@
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Client.State;
+using B3.EntryPoint.Client.TestPeer;
+
+namespace B3.EntryPoint.Client.Tests.State;
+
+/// <summary>
+/// Regression tests for #152 — <c>FileSessionStateStore</c> previously only
+/// wrote <c>snapshot.json</c> after <see cref="EntryPointClientOptions.StateCompactEveryDeltas"/>
+/// (default 1024) appends. Restarts before that threshold lost the
+/// <c>SessionId</c>/<c>SessionVerId</c>, causing the matching peer to reject
+/// the next Establish with <c>InvalidSessionVerId</c>.
+///
+/// Fix: persist the snapshot at lifecycle boundaries — immediately after
+/// Establish, and once on graceful teardown — so the on-disk identity is
+/// always current regardless of delta volume.
+/// </summary>
+public class SnapshotDurabilityTests
+{
+    private static EntryPointClientOptions Options(InProcessFixpTestPeer peer, ISessionStateStore store) => new()
+    {
+        Endpoint = peer.LocalEndpoint,
+        SessionId = 4242u,
+        SessionVerId = 7u,
+        EnteringFirm = 7u,
+        Credentials = Credentials.FromUtf8("test-key"),
+        KeepAliveIntervalMs = 60_000u,
+        SessionTeardownTimeout = TimeSpan.FromSeconds(5),
+        SessionStateStore = store,
+        // Default of 1024 — proves the snapshot lands without ever crossing
+        // the compaction threshold.
+    };
+
+    [Fact]
+    public async Task Snapshot_IsPersisted_ImmediatelyAfterEstablish()
+    {
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions
+        {
+            Scenario = TestPeerScenarios.AcceptAll,
+        });
+        peer.Start();
+
+        var dir = Path.Combine(Path.GetTempPath(), "b3epc-152-establish-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new FileSessionStateStore(dir);
+            var opts = Options(peer, store);
+
+            await using (var client = new EntryPointClient(opts))
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+                await client.ConnectAsync(cts.Token);
+
+                // Snapshot must already exist on disk after Establish, before
+                // any orders/deltas are produced. Pre-fix this would only
+                // happen after 1024 deltas.
+                var snapshotPath = Path.Combine(dir, "snapshot.json");
+                Assert.True(File.Exists(snapshotPath),
+                    $"expected {snapshotPath} to exist immediately after Establish");
+
+                var loaded = await store.LoadAsync(cts.Token);
+                Assert.NotNull(loaded);
+                Assert.Equal(opts.SessionId, loaded!.SessionId);
+                Assert.Equal(opts.SessionVerId, loaded.SessionVerId);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task Snapshot_SurvivesGracefulShutdown_BelowCompactionThreshold()
+    {
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions
+        {
+            Scenario = TestPeerScenarios.AcceptAll,
+        });
+        peer.Start();
+
+        var dir = Path.Combine(Path.GetTempPath(), "b3epc-152-shutdown-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new FileSessionStateStore(dir);
+            var opts = Options(peer, store);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await using (var client = new EntryPointClient(opts))
+            {
+                await client.ConnectAsync(cts.Token);
+                // A handful of orders — far below StateCompactEveryDeltas (1024).
+                for (ulong i = 1; i <= 3; i++)
+                {
+                    await client.SubmitAsync(new NewOrderRequest
+                    {
+                        ClOrdID = (ClOrdID)i,
+                        SecurityId = 1001,
+                        Side = Side.Buy,
+                        OrderType = OrderType.Limit,
+                        Price = 10m,
+                        OrderQty = 5,
+                    }, cts.Token);
+                }
+            }
+            // DisposeAsync ran StopActiveSessionAsync, which must have flushed
+            // a final snapshot containing the last contiguous outbound seq.
+
+            var loaded = await store.LoadAsync(cts.Token);
+            Assert.NotNull(loaded);
+            Assert.Equal(opts.SessionId, loaded!.SessionId);
+            Assert.Equal(opts.SessionVerId, loaded.SessionVerId);
+            Assert.True(loaded.LastOutboundSeqNum >= 3UL,
+                $"expected snapshot to capture ≥3 outbound seqs, got {loaded.LastOutboundSeqNum}");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Closes #152.

`FileSessionStateStore` previously only wrote `snapshot.json` after `StateCompactEveryDeltas` (default **1024**) appends. Any host that restarted before that threshold — normal dev/dogfood, graceful redeploys — lost `SessionId`/`SessionVerId`, so the matching peer rejected the next Establish with `InvalidSessionVerId`.

### Fix

Persist the snapshot at **lifecycle boundaries** instead of on a delta count:

- New `PersistSnapshotAsync` helper — unconditional best-effort `SaveAsync(BuildSnapshot())`, failures logged via `SnapshotCompactionFailed` and swallowed; resets `_deltasSinceCompact` since the fresh snapshot subsumes the delta log.
- `ConnectAsync` — invoke immediately after `HydrateFromSnapshotAsync`, so `snapshot.json` reflects the verId the peer just accepted. Also covers the Reconnect path (it routes through `ConnectAsync` after the verId bump).
- `StopActiveSessionAsync` — invoke as step 0, while `_session` is still live (`BuildSnapshot` reads `_session.LastAssignedOutboundSeqNum()`), so graceful shutdown / pre-Reconnect teardown leave the on-disk snapshot contiguous with the last in-memory state.

### Scope

- No public API surface change (verified — `PublicAPI.Unshipped.txt` untouched).
- No protocol-visible behaviour change.
- Defaults unchanged; existing `StateCompactEveryDeltas` semantics preserved.

### Tests

`SnapshotDurabilityTests` (new):
1. `Snapshot_IsPersisted_ImmediatelyAfterEstablish` — `snapshot.json` exists right after `ConnectAsync` returns, before any orders.
2. `Snapshot_SurvivesGracefulShutdown_BelowCompactionThreshold` — after sending 3 orders (≪ 1024) and disposing the client, the snapshot reflects the current `SessionId`/`SessionVerId` and `LastOutboundSeqNum ≥ 3`.

Both fail on `main` and pass with this change.

### Pre-PR checklist

- [x] `dotnet build` clean (0 warnings, TreatWarningsAsErrors)
- [x] `dotnet test` — 168/168 unit tests pass; conformance auto-skipped (no peer env)
- [x] `dotnet format --verify-no-changes` clean