### PR TITLE
release: v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-05-05
+
+### Fixed
+- **client (#149)**: `EntryPointClient` now throws a deterministic
+  `InvalidOperationException` ("outbound MsgSeqNum exhausted; reconnect with
+  next SessionVerID") when the outbound counter would exceed `uint.MaxValue`,
+  instead of surfacing an opaque `OverflowException` from a deeply nested
+  `checked` cast inside the encoder. The four `new SeqNum(checked((uint)x))`
+  call sites in `FixpClientSession` and `OrderEntryEncoder` now share a
+  single guard so the failure mode is named and points the host at the right
+  recovery (Reconnect with the next `SessionVerID`).
+- **client (#150)**: `ConnectOnceAsync` no longer leaks partial-connect
+  resources when a post-TCP step (TLS handshake, Negotiate, Establish,
+  snapshot hydrate, worker startup) throws. Previously `_tcp`/`_session`/
+  `_keepAlive`/`_retransmit`/`_persistWorker` stayed bound to the dead
+  attempt, and the next retry overwrote those fields and orphaned the prior
+  socket / background tasks. Failures now route through
+  `StopActiveSessionAsync` before the exception propagates, so retry attempts
+  start from a clean slate.
+- **client (#152)**: `EntryPointClient` now persists the
+  `SessionSnapshot` at lifecycle boundaries (immediately after Establish, and
+  again on graceful teardown) instead of only after
+  `StateCompactEveryDeltas` (default 1024) appends. Hosts that restarted
+  before the threshold previously lost `SessionId`/`SessionVerId` because
+  `snapshot.json` never existed — `LoadAsync` returned `null`, the host
+  reused the configured verId, and the matching peer rejected the next
+  Establish with `InvalidSessionVerId`. The new `PersistSnapshotAsync`
+  helper is unconditional and best-effort (failures logged via
+  `SnapshotCompactionFailed`); it covers initial Establish, the Reconnect
+  path (which routes through `ConnectAsync` after the verId bump), and
+  graceful shutdown / pre-Reconnect teardown. No public API surface change;
+  no protocol-visible behaviour change.
+
+### Tests
+- **conformance, client (#151)**: added round-trip encoder coverage for
+  `NewOrderCross` (template 106) and `Quote`/`QuoteRequest` (templates
+  401/403) plus matching conformance scenarios. Audit follow-up to #147 —
+  these templates had public encoder/API surface but no wire-level offset
+  test would have caught a bug analogous to the OCRR one.
+
 ## [0.14.1] - 2026-05-04
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- NuGet metadata shared by all packable projects. -->
-    <Version>0.14.1</Version>
+    <Version>0.14.2</Version>
     <Authors>pedrosakuma</Authors>
     <Company>pedrosakuma</Company>
     <Copyright>Copyright (c) pedrosakuma</Copyright>


### PR DESCRIPTION
Patch release bundling three bug fixes since v0.14.1.

### Fixed
- **#149** — `EntryPointClient` throws a deterministic `InvalidOperationException` ("outbound MsgSeqNum exhausted; reconnect with next SessionVerID") when the outbound counter would exceed `uint.MaxValue`, instead of an opaque `OverflowException` from a deeply nested `checked` cast inside the encoder. Single shared guard across the four `new SeqNum(checked((uint)x))` call sites in `FixpClientSession` / `OrderEntryEncoder`; failure now points the host at Reconnect with the next `SessionVerID`.
- **#150** — `ConnectOnceAsync` no longer leaks partial-connect resources when a post-TCP step (TLS, Negotiate, Establish, hydrate, worker startup) throws. Failures route through `StopActiveSessionAsync` before propagating, so retries no longer overwrite a still-bound socket / background tasks.
- **#152** — `EntryPointClient` persists the `SessionSnapshot` at lifecycle boundaries (immediately after Establish, and again on graceful teardown) instead of only after `StateCompactEveryDeltas` (default 1024) appends. Fixes `InvalidSessionVerId` after restarts that did not cross the threshold. New `PersistSnapshotAsync` helper is unconditional and best-effort.

### Tests
- **#151** — round-trip encoder coverage for `NewOrderCross` (template 106) and `Quote` / `QuoteRequest` (templates 401/403), plus matching conformance scenarios. Audit follow-up to #147.

No public API changes; downgrade-safe.

Tag `v0.14.2` should be pushed after merge to trigger `publish.yml`.