### PR TITLE
fix(client): surface OrigClOrdID on OrderCancelled events (#155)

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/InboundDecoder.cs
@@ -143,7 +143,11 @@ internal static class InboundDecoder
             SeqNum = msg.BusinessHeader.MsgSeqNum.Value,
             SendingTime = ToDateTime(msg.BusinessHeader.SendingTime.Time),
             ClOrdID = new ClientClOrdID(msg.ClOrdID.Value),
-            OrigClOrdID = null,
+            // #155: surface OrigClOrdID from the wire (ClOrdIDOptional id=41,
+            // present in v6.3 schema). Previously hard-coded to null, which
+            // forced participants to maintain a cancel-side → original map
+            // out-of-band to resolve cancel acks back to the working order.
+            OrigClOrdID = msg.OrigClOrdID is { } orig ? new ClientClOrdID(orig) : null,
             OrderId = msg.OrderID.Value,
             OrderStatus = (OrderStatus)(byte)msg.OrdStatus,
             TransactTime = ToDateTime(msg.TransactTime.Time),

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/InboundDecoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/InboundDecoderTests.cs
@@ -165,6 +165,77 @@ public class InboundDecoderTests
     }
 
     [Fact]
+    public void TryDecode_ExecutionReportCancel_PopulatesOrigClOrdID()
+    {
+        // Regression for #155: DecodeCancel previously hard-coded
+        // OrigClOrdID = null, dropping the original-order identity that
+        // every B3 ExecutionReport_Cancel carries on the wire (id=41,
+        // ClOrdIDOptional, present since v6.3 of the schema).
+        var msg = new ExecutionReport_CancelData
+        {
+            BusinessHeader = new OutboundBusinessHeader
+            {
+                SessionID = 1,
+                MsgSeqNum = new SeqNum(99),
+            },
+            Side = B3.Entrypoint.Fixp.Sbe.V6.Side.BUY,
+            OrdStatus = OrdStatus.CANCELED,
+            ClOrdID = new B3.Entrypoint.Fixp.Sbe.V6.ClOrdID(2UL), // cancel-side ClOrdID
+            OrderID = new OrderID(123456UL),
+            TransactTime = new UTCTimestampNanos { Time = 1_700_000_000_000_000_000UL },
+        };
+        msg.SetOrigClOrdID(1UL); // original order ClOrdID
+        msg.SetMassActionReportID(null);
+
+        var frame = BuildFrame(ExecutionReport_CancelData.MESSAGE_ID, ExecutionReport_CancelData.MESSAGE_SIZE, span =>
+        {
+            if (!ExecutionReport_CancelData.TryEncode(msg, span, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, out _))
+                throw new InvalidOperationException("encode failed");
+        });
+
+        Assert.True(InboundDecoder.TryDecode(frame, out var evt));
+        var cancelled = Assert.IsType<OrderCancelled>(evt);
+        Assert.Equal(99UL, cancelled.SeqNum);
+        Assert.Equal(2UL, cancelled.ClOrdID.Value);
+        Assert.NotNull(cancelled.OrigClOrdID);
+        Assert.Equal(1UL, cancelled.OrigClOrdID!.Value.Value);
+        Assert.Equal(123456UL, cancelled.OrderId);
+    }
+
+    [Fact]
+    public void TryDecode_ExecutionReportCancel_OrigClOrdIDAbsent_StaysNull()
+    {
+        // Unsolicited cancellations (Market Operations / Cancel On Disconnect)
+        // may legitimately omit OrigClOrdID; the decoder must still surface
+        // null in that case, not a synthetic ClOrdID(0).
+        var msg = new ExecutionReport_CancelData
+        {
+            BusinessHeader = new OutboundBusinessHeader
+            {
+                SessionID = 1,
+                MsgSeqNum = new SeqNum(100),
+            },
+            Side = B3.Entrypoint.Fixp.Sbe.V6.Side.SELL,
+            OrdStatus = OrdStatus.CANCELED,
+            ClOrdID = new B3.Entrypoint.Fixp.Sbe.V6.ClOrdID(5UL),
+            OrderID = new OrderID(654321UL),
+            TransactTime = new UTCTimestampNanos { Time = 1_700_000_000_000_000_000UL },
+        };
+        msg.SetOrigClOrdID(null);
+        msg.SetMassActionReportID(null);
+
+        var frame = BuildFrame(ExecutionReport_CancelData.MESSAGE_ID, ExecutionReport_CancelData.MESSAGE_SIZE, span =>
+        {
+            if (!ExecutionReport_CancelData.TryEncode(msg, span, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, out _))
+                throw new InvalidOperationException("encode failed");
+        });
+
+        Assert.True(InboundDecoder.TryDecode(frame, out var evt));
+        var cancelled = Assert.IsType<OrderCancelled>(evt);
+        Assert.Null(cancelled.OrigClOrdID);
+    }
+
+    [Fact]
     public void TryDecode_OrderMassActionReport_ReturnsMassActionExecuted()
     {
         var msg = new OrderMassActionReportData


### PR DESCRIPTION
Closes #155.

### Bug

`InboundDecoder.DecodeCancel` hard-coded `OrigClOrdID = null`, dropping the original order's identity that `ExecutionReport_Cancel` (template 202, schema 8.4.2) carries as `origClOrdID` (id=41, `ClOrdIDOptional`, present since v6.3 of the schema).

Participants routing ER lookups by the **original** ClOrdID — every sane implementation, since the cancel-side ClOrdID is request-only and was never registered as an order — could not resolve cancel acks back to the working order. The order stayed `Working` forever from the participant's perspective even after the matching engine removed it from the book.

### Fix

`DecodeCancel` now reads `msg.OrigClOrdID` from the SBE binding (`ulong?`, `NullValue = 0`) and maps it to the model:

```csharp
OrigClOrdID = msg.OrigClOrdID is { } orig ? new ClientClOrdID(orig) : null,
```

- Present on the wire → `OrderCancelled.OrigClOrdID = new ClOrdID(value)`.
- Absent (NullValue=0) → stays `null`. Preserves the legitimate-null path for unsolicited cancellations from Market Operations / Cancel On Disconnect, which omit the field.

### Scope

- No public API surface change. `OrderCancelled.OrigClOrdID` was already typed `ClOrdID?` and `required`.
- Behaviour change is strictly additive — callers that previously coded for `null` will now see the populated value when the peer sends one, matching the documented model and what `ExecutionReport_Modify` already does.

### Tests

`InboundDecoderTests` adds two regressions:

1. `TryDecode_ExecutionReportCancel_PopulatesOrigClOrdID` — round-trip through the SBE encoder with `SetOrigClOrdID(1)` and `ClOrdID(2)` (cancel-side); decoded event carries `ClOrdID=2`, `OrigClOrdID=1`.
2. `TryDecode_ExecutionReportCancel_OrigClOrdIDAbsent_StaysNull` — with `SetOrigClOrdID(null)`, decoded `OrigClOrdID` stays `null` (no synthetic `ClOrdID(0)`).

Both fail on `main` and pass with this change.

### Pre-PR checklist

- [x] `dotnet build` clean (0 warnings)
- [x] `dotnet test` for `InboundDecoderTests` — 10/10 pass
- [x] `dotnet format --verify-no-changes` clean

### Note on baseline

Two pre-existing test failures observed on `main` (also reproducible on `v0.14.2` HEAD): `DropCopyClientTests.ConnectAsync_AttemptsTcpConnect` and `TerminateApiTests.ReconnectAsync_AcceptsIncreasingVerId_AttemptsTcpConnect` — both expect `SocketException` but now see `EndOfStreamException` from the negotiate path. Unrelated to this fix; flagging for a follow-up issue.