### PR TITLE
test: relax port-9999 connect assertions to any non-validation exception (#157)

### DIFF
--- a/tests/B3.EntryPoint.Client.Tests/DropCopy/DropCopyClientTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/DropCopy/DropCopyClientTests.cs
@@ -28,8 +28,17 @@ public class DropCopyClientTests
     public async Task ConnectAsync_AttemptsTcpConnect()
     {
         await using var c = new DropCopyClient(Opts(SessionProfile.DropCopy));
-        // No socket listening on port 9999 → TCP connect must fail. Confirms the
-        // delegating wire-up to EntryPointClient.ConnectAsync is in place.
-        await Assert.ThrowsAnyAsync<System.Net.Sockets.SocketException>(() => c.ConnectAsync());
+        // Confirms the delegating wire-up to EntryPointClient.ConnectAsync is
+        // in place. We deliberately do not assert on a specific exception
+        // type: depending on what (if anything) is listening on the unused
+        // port, the post-validation failure may surface as SocketException
+        // (connection refused), EndOfStreamException (a stray peer that
+        // closes immediately), or another transport exception. The profile
+        // guard, in contrast, throws ArgumentException synchronously in the
+        // constructor — so observing anything else here proves we got past
+        // construction and into the connect path. (#157)
+        var ex = await Assert.ThrowsAnyAsync<Exception>(() => c.ConnectAsync());
+        Assert.IsNotType<ArgumentException>(ex);
+        Assert.IsNotType<InvalidOperationException>(ex);
     }
 }

--- a/tests/B3.EntryPoint.Client.Tests/TerminateApiTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/TerminateApiTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Net.Sockets;
 using B3.EntryPoint.Client;
 using B3.EntryPoint.Client.Auth;
 
@@ -29,9 +28,18 @@ public class TerminateApiTests
     public async Task ReconnectAsync_AcceptsIncreasingVerId_AttemptsTcpConnect()
     {
         await using var c = MakeClient(sessionVerId: 5);
-        // No socket listening on port 9999 → TCP connect must fail. The point is
-        // that the version check passes and ReconnectAsync proceeds to ConnectAsync.
-        await Assert.ThrowsAnyAsync<SocketException>(() => c.ReconnectAsync(6));
+        // The point is that the version check passes and ReconnectAsync
+        // proceeds to ConnectAsync. We deliberately do not assert on a
+        // specific exception type: depending on what (if anything) is
+        // listening on the unused port, the post-validation failure may
+        // surface as SocketException (connection refused), EndOfStreamException
+        // (a stray peer that closes immediately), or another transport
+        // exception. The validation guard, in contrast, throws
+        // ArgumentOutOfRangeException synchronously before any I/O — so
+        // observing anything else proves we got past it. (#157)
+        var ex = await Assert.ThrowsAnyAsync<Exception>(() => c.ReconnectAsync(6));
+        Assert.IsNotType<ArgumentOutOfRangeException>(ex);
+        Assert.IsNotType<InvalidOperationException>(ex);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #157.

### Problem

Two tests asserted `Assert.ThrowsAnyAsync<SocketException>` on the basis that `127.0.0.1:9999` would have nothing listening:

- `DropCopyClientTests.ConnectAsync_AttemptsTcpConnect`
- `TerminateApiTests.ReconnectAsync_AcceptsIncreasingVerId_AttemptsTcpConnect`

Holds on CI, breaks on dev machines that happen to have anything bound to 9999 (TCP connect succeeds → `NegotiateAsync` → `EndOfStreamException` from FIN). False-positive failure during normal local `dotnet test`.

### Fix (Option 2 from the issue)

The documented intent of both tests is *"the version/profile guard passed and we proceeded into the connect path"* — the failure *type* is irrelevant. Reframe the assertions accordingly:

```csharp
var ex = await Assert.ThrowsAnyAsync<Exception>(...);
Assert.IsNotType<ArgumentOutOfRangeException>(ex); // or ArgumentException
Assert.IsNotType<InvalidOperationException>(ex);
```

Any exception that is *not* the synchronous validation guard proves the post-validation code ran. This is exactly what the tests were trying to verify in the first place.

### Validation

- Targeted run (these two tests) — green locally even with port 9999 occupied (was failing pre-fix).
- Full suite — 175/175 pass.
- No production code touched.

### Why not Option 1 (bind/release ephemeral port)?

More moving parts and a (narrow) race window without buying anything: the tests don't care about *which* failure mode occurs, only that they got past validation.