### PR TITLE
Add spec-canonical reconnect (Establish-reuse-then-Negotiate) (#173)

### DIFF
--- a/src/B3.EntryPoint.Client.TestPeer/B3.EntryPoint.Client.TestPeer.csproj
+++ b/src/B3.EntryPoint.Client.TestPeer/B3.EntryPoint.Client.TestPeer.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.11.0-beta1.26075.3" PrivateAssets="all" />
   </ItemGroup>

--- a/src/B3.EntryPoint.Client.TestPeer/InProcessFixpTestPeer.cs
+++ b/src/B3.EntryPoint.Client.TestPeer/InProcessFixpTestPeer.cs
@@ -108,6 +108,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         public uint OutSeq = 1;
         public CancellationTokenSource? KeepAliveCts;
         public readonly SemaphoreSlim SendLock = new(1, 1);
+        public bool SawNegotiate;
     }
 
     private sealed record ActiveConnection(Stream Stream, ConnectionState State, B3.Entrypoint.Fixp.Sbe.V6.SessionID SessionId);
@@ -177,6 +178,7 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
                                 // Credentials map configured and firm not allowed → close cold.
                                 return;
                             }
+                            state.SawNegotiate = true;
                             await SendNegotiateResponseAsync(stream, frame, state, ct).ConfigureAwait(false);
                             break;
                         case EstablishData.MESSAGE_ID:
@@ -373,6 +375,11 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         ref readonly var req = ref reader.Data;
 
         var attempt = System.Threading.Interlocked.Increment(ref _establishAttempts);
+        if (_options.RejectEstablishWithoutPriorNegotiate && !state.SawNegotiate)
+        {
+            await SendEstablishRejectAsync(stream, state, req.SessionID, req.SessionVerID, req.Timestamp, B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.UNNEGOTIATED, ct).ConfigureAwait(false);
+            return;
+        }
         if (_options.EstablishRejectAfter is int threshold && attempt >= threshold)
         {
             await SendEstablishRejectAsync(stream, state, req.SessionID, req.SessionVerID, req.Timestamp, _options.EstablishRejectCodeOverride, ct).ConfigureAwait(false);
@@ -384,14 +391,17 @@ public sealed class InProcessFixpTestPeer : IAsyncDisposable
         SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
         EstablishAckData.WriteHeader(buffer.AsSpan(SofhFrameReader.HeaderSize));
 
+        var nextSeq = _options.EstablishAckNextSeqNoOverride ?? 1u;
+        var lastIncoming = _options.EstablishAckLastIncomingSeqNoOverride
+            ?? (req.NextSeqNo.Value > 0u ? req.NextSeqNo.Value - 1u : 0u);
         var ack = new EstablishAckData
         {
             SessionID = req.SessionID,
             SessionVerID = req.SessionVerID,
             RequestTimestamp = req.Timestamp,
             KeepAliveInterval = req.KeepAliveInterval,
-            NextSeqNo = new SeqNum(1u),
-            LastIncomingSeqNo = new SeqNum(req.NextSeqNo.Value > 0u ? req.NextSeqNo.Value - 1u : 0u),
+            NextSeqNo = new SeqNum(nextSeq),
+            LastIncomingSeqNo = new SeqNum(lastIncoming),
         };
         var keepAliveMs = req.KeepAliveInterval.Time;
         var sessionIdLocal = req.SessionID;

--- a/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client.TestPeer/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.RejectEstablishWithoutPriorNegotiate.get -> bool
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.RejectEstablishWithoutPriorNegotiate.set -> void
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.EstablishAckNextSeqNoOverride.get -> uint?
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.EstablishAckNextSeqNoOverride.set -> void
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.EstablishAckLastIncomingSeqNoOverride.get -> uint?
+B3.EntryPoint.Client.TestPeer.TestPeerOptions.EstablishAckLastIncomingSeqNoOverride.set -> void

--- a/src/B3.EntryPoint.Client.TestPeer/TestPeerOptions.cs
+++ b/src/B3.EntryPoint.Client.TestPeer/TestPeerOptions.cs
@@ -68,4 +68,30 @@ public sealed class TestPeerOptions
     /// the (empty) <c>Retransmission</c> reply. Defaults to <c>null</c>.
     /// </summary>
     public B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode? RetransmitRejectCode { get; set; }
+
+    /// <summary>
+    /// When true, the peer rejects any <c>Establish</c> received on a TCP
+    /// connection that has not yet seen a <c>Negotiate</c> on the same
+    /// connection, with <see cref="B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.UNNEGOTIATED"/>.
+    /// Used by #173 reconnect tests to simulate the spec's
+    /// "Establish reuse rejected, must renegotiate" path. Defaults to false
+    /// (legacy behaviour: peer accepts Establish on any TCP connection).
+    /// </summary>
+    public bool RejectEstablishWithoutPriorNegotiate { get; set; }
+
+    /// <summary>
+    /// When non-null, overrides the <c>NextSeqNo</c> field the peer writes in
+    /// every <c>EstablishmentAck</c>. Lets tests assert
+    /// <c>ReconnectOutcome.RetransmitWindowReady</c> by forcing an inbound
+    /// gap. Defaults to <c>null</c> (peer mirrors the inbound counter).
+    /// </summary>
+    public uint? EstablishAckNextSeqNoOverride { get; set; }
+
+    /// <summary>
+    /// When non-null, overrides the <c>LastIncomingSeqNo</c> field the peer
+    /// writes in every <c>EstablishmentAck</c>. Lets tests assert
+    /// <c>ReconnectOutcome.RetransmitWindowReady</c> by forcing an outbound
+    /// gap. Defaults to <c>null</c> (peer mirrors the local counter).
+    /// </summary>
+    public uint? EstablishAckLastIncomingSeqNoOverride { get; set; }
 }

--- a/src/B3.EntryPoint.Client/Auth/Credentials.cs
+++ b/src/B3.EntryPoint.Client/Auth/Credentials.cs
@@ -10,10 +10,19 @@ public sealed class Credentials
 {
     private readonly byte[] _bytes;
 
+    /// <summary>
+    /// Schema-defined upper bound on <c>CredentialsEncoding.length</c>
+    /// (schema 8.4.2 §720, <c>uint8 maxValue="128"</c>). The gateway will
+    /// reject Establish/Negotiate with a longer Credentials field.
+    /// </summary>
+    public const int MaxLengthBytes = 128;
+
     public Credentials(ReadOnlySpan<byte> bytes)
     {
-        if (bytes.Length > 255)
-            throw new ArgumentException("Credentials must fit in a single SBE varData byte length (≤ 255).", nameof(bytes));
+        if (bytes.Length > MaxLengthBytes)
+            throw new ArgumentException(
+                $"Credentials must be ≤ {MaxLengthBytes} bytes per schema CredentialsEncoding.length maxValue.",
+                nameof(bytes));
         _bytes = bytes.ToArray();
     }
 

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -1147,7 +1147,14 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
 
             using (var establish = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.establish.reuse", ActivityKind.Client))
             {
-                reuse = await _session.EstablishReuseAsync(ct).ConfigureAwait(false);
+                // Spec §4.5: Establish's NextSeqNo is the client's next
+                // outbound app MsgSeqNum. On reattach (#173) that's the prior
+                // session's last assigned + 1, NOT 1 — sending 1 would look
+                // like a sequence rewind to the gateway and corrupt the
+                // peer-side LastIncomingSeqNo accounting.
+                reuse = await _session.EstablishReuseAsync(localLastAssignedOutbound + 1UL > uint.MaxValue
+                    ? throw new InvalidOperationException("Outbound sequence overflowed uint range.")
+                    : (uint)(localLastAssignedOutbound + 1UL), ct).ConfigureAwait(false);
             }
 
             if (reuse.Accepted)
@@ -1179,12 +1186,18 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         }
         catch
         {
-            await StopActiveSessionAsync(CancellationToken.None).ConfigureAwait(false);
+            // Reuse attempt blew up (transport / decode / unexpected frame).
+            // The current _session is the freshly-built reuse session whose
+            // counters are still at 0; do NOT persist a snapshot from it
+            // because that would clobber the good snapshot saved when the
+            // prior live session was torn down before reattach.
+            await StopActiveSessionAsync(CancellationToken.None, persistSnapshot: false).ConfigureAwait(false);
             throw;
         }
 
-        // Reuse rejected — tear down and decide on the fallback path.
-        await StopActiveSessionAsync(CancellationToken.None).ConfigureAwait(false);
+        // Reuse rejected — tear down without persisting (same reason as above)
+        // and decide on the fallback path.
+        await StopActiveSessionAsync(CancellationToken.None, persistSnapshot: false).ConfigureAwait(false);
 
         var code = reuse.RejectCode!.Value;
         if (!IsRecoverableEstablishReject(code))
@@ -1260,7 +1273,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     /// <see cref="ReconnectAsync(uint, System.Threading.CancellationToken)"/> and <see cref="DisposeAsync"/> so the
     /// same ordering applies in both paths (#124).
     /// </summary>
-    private async Task StopActiveSessionAsync(CancellationToken ct)
+    private async Task StopActiveSessionAsync(CancellationToken ct, bool persistSnapshot = true)
     {
         var timeout = _options.SessionTeardownTimeout;
         if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromSeconds(5);
@@ -1271,7 +1284,13 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         //    CTS below is cancelled. Guarantees the on-disk snapshot is
         //    contiguous with the last in-memory state on graceful shutdown
         //    and on Reconnect (#152).
-        await PersistSnapshotAsync(ct).ConfigureAwait(false);
+        //
+        //    #173 caller note: pass persistSnapshot=false when tearing down
+        //    a transient Establish-reuse session that never reached
+        //    Established — snapshotting its zeroed counters would corrupt
+        //    the good snapshot saved from the prior live session.
+        if (persistSnapshot)
+            await PersistSnapshotAsync(ct).ConfigureAwait(false);
 
         // 1. Cancel session-scoped CTSs and complete the persistence channel
         //    so its worker drains the in-flight queue and exits.

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -1161,6 +1161,18 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             {
                 var ack = reuse.Ack!.Value;
                 _options.Logger.Established(_options.Endpoint);
+
+                // The new FixpClientSession was just constructed with its
+                // outbound counter at 0. On reattach the application sequence
+                // continues across the TCP blip, so the new session must
+                // resume from `localLastAssignedOutbound + 1` BEFORE any app
+                // frame is sent. HydrateFromSnapshotAsync (invoked inside
+                // FinishEstablishedAsync) only seeds from a SessionStateStore;
+                // when no store is configured, the in-memory counter would
+                // otherwise restart at 1 and the next app send would rewind
+                // MsgSeqNum on the wire.
+                _session!.ResumeOutboundSeqNum(localLastAssignedOutbound + 1UL);
+
                 await FinishEstablishedAsync(ct).ConfigureAwait(false);
                 StartIdleWatchdog();
 

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -130,7 +130,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     public event EventHandler<TerminatedEventArgs>? Terminated;
 
     /// <summary>
-    /// Raised exactly once per <see cref="ReconnectAsync"/> call when the prior
+    /// Raised exactly once per <see cref="ReconnectAsync(uint, System.Threading.CancellationToken)"/> call when the prior
     /// session terminated with an unrecovered inbound app-frame gap. The peer
     /// bumps <c>SessionVerID</c> on reconnect and resets its outbound counter
     /// to 1, so the missing range cannot be served by a §4.7 <c>RetransmitRequest</c>
@@ -212,71 +212,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
                 _options.Logger.Established(_options.Endpoint);
             }
 
-            await HydrateFromSnapshotAsync(ct).ConfigureAwait(false);
-
-            // #152: persist the session identity (SessionId/SessionVerId) at
-            // lifecycle boundaries, not on a delta count. Writing immediately
-            // after a successful Establish guarantees `snapshot.json` exists
-            // even if the host restarts before `StateCompactEveryDeltas`
-            // appends accumulate, so warm-restart and Reconnect can resolve
-            // the verId the peer actually accepted.
-            await PersistSnapshotAsync(ct).ConfigureAwait(false);
-
-            StartPersistenceWorker();
-
-            _session.OnInboundEvent = OnInboundEventForPersistence;
-
-            _session.StartInboundLoop(_events.Writer);
-
-            _keepAlive = new KeepAliveScheduler(
-                _options.KeepAliveInterval,
-                sendSequence: (seq, token) => _session.SendSequenceAsync(seq, token),
-                nextSeqNo: () => _session.PeekNextOutboundSeqNum());
-            _session.OnInboundSequence = nextSeq =>
-            {
-                _lastInboundUtc = DateTime.UtcNow;
-                _keepAlive!.RaiseFrameReceived(nextSeq, DateTimeOffset.UtcNow);
-            };
-            _keepAlive.Start();
-
-            _retransmit = new RetransmitRequestHandler(
-                sendRequest: (from, count, token) => _session.SendRetransmitRequestAsync(from, count, token));
-            _session.OnInboundRetransmission = (nextSeq, count, reqNanos) =>
-            {
-                _lastInboundUtc = DateTime.UtcNow;
-                // The peer's reply to our outstanding RetransmitRequest. Whether
-                // it carries frames (count>0) or is an empty completion (count=0,
-                // observed against TestPeer / some gateway error paths), we clear
-                // the in-flight flag so a future gap can issue a new request.
-                // The retransmitted frames themselves flow through the inbound
-                // loop and OnInboundEventForPersistence advances the contiguous
-                // tail accordingly. (#138)
-                lock (_inboundGapGate) { _gapRequestInFlight = false; }
-                _retransmit!.RaiseRetransmissionReceived(nextSeq, count, NanosToOffset(reqNanos));
-            };
-            _session.OnInboundRetransmitReject = (code, reqNanos) =>
-            {
-                _lastInboundUtc = DateTime.UtcNow;
-                // Reject clears the in-flight flag — a later gap may need to
-                // re-request after a transient peer-side condition lifts. (#138)
-                lock (_inboundGapGate) { _gapRequestInFlight = false; }
-                _retransmit!.RaiseRetransmitRejected((B3.EntryPoint.Client.Fixp.RetransmitRejectCode)(byte)code, NanosToOffset(reqNanos));
-            };
-            _session.OnInboundNotApplied = (from, count) =>
-            {
-                _lastInboundUtc = DateTime.UtcNow;
-                _retransmit!.RaiseNotAppliedReceived(from, count);
-            };
-            _session.OnInboundTerminate = code =>
-            {
-                _lastInboundUtc = DateTime.UtcNow;
-                _options.Logger.InboundTerminate(code);
-                EntryPointTelemetry.Terminations.Add(1,
-                    new KeyValuePair<string, object?>("direction", "inbound"),
-                    new KeyValuePair<string, object?>("code", code.ToString()));
-                RaiseTerminated((TerminationCode)code, reason: null, initiatedByClient: false);
-            };
-            _lastInboundUtc = DateTime.UtcNow;
+            await FinishEstablishedAsync(ct).ConfigureAwait(false);
         }
         catch
         {
@@ -291,6 +227,83 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             await StopActiveSessionAsync(CancellationToken.None).ConfigureAwait(false);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Runs everything that must happen after a successful <c>Establish</c>
+    /// (whether full Negotiate+Establish via <see cref="ConnectOnceAsync"/> or
+    /// spec-canonical Establish-reuse via
+    /// <see cref="ReconnectAsync(ReconnectMode, System.Func{uint, uint}?, CancellationToken)"/>):
+    /// snapshot hydration, persistence-worker start, inbound-loop start,
+    /// keep-alive scheduler + retransmit handler wiring (#173).
+    /// </summary>
+    private async Task FinishEstablishedAsync(CancellationToken ct)
+    {
+        await HydrateFromSnapshotAsync(ct).ConfigureAwait(false);
+
+        // #152: persist the session identity (SessionId/SessionVerId) at
+        // lifecycle boundaries, not on a delta count. Writing immediately
+        // after a successful Establish guarantees `snapshot.json` exists
+        // even if the host restarts before `StateCompactEveryDeltas`
+        // appends accumulate, so warm-restart and Reconnect can resolve
+        // the verId the peer actually accepted.
+        await PersistSnapshotAsync(ct).ConfigureAwait(false);
+
+        StartPersistenceWorker();
+
+        _session!.OnInboundEvent = OnInboundEventForPersistence;
+
+        _session.StartInboundLoop(_events.Writer);
+
+        _keepAlive = new KeepAliveScheduler(
+            _options.KeepAliveInterval,
+            sendSequence: (seq, token) => _session.SendSequenceAsync(seq, token),
+            nextSeqNo: () => _session.PeekNextOutboundSeqNum());
+        _session.OnInboundSequence = nextSeq =>
+        {
+            _lastInboundUtc = DateTime.UtcNow;
+            _keepAlive!.RaiseFrameReceived(nextSeq, DateTimeOffset.UtcNow);
+        };
+        _keepAlive.Start();
+
+        _retransmit = new RetransmitRequestHandler(
+            sendRequest: (from, count, token) => _session.SendRetransmitRequestAsync(from, count, token));
+        _session.OnInboundRetransmission = (nextSeq, count, reqNanos) =>
+        {
+            _lastInboundUtc = DateTime.UtcNow;
+            // The peer's reply to our outstanding RetransmitRequest. Whether
+            // it carries frames (count>0) or is an empty completion (count=0,
+            // observed against TestPeer / some gateway error paths), we clear
+            // the in-flight flag so a future gap can issue a new request.
+            // The retransmitted frames themselves flow through the inbound
+            // loop and OnInboundEventForPersistence advances the contiguous
+            // tail accordingly. (#138)
+            lock (_inboundGapGate) { _gapRequestInFlight = false; }
+            _retransmit!.RaiseRetransmissionReceived(nextSeq, count, NanosToOffset(reqNanos));
+        };
+        _session.OnInboundRetransmitReject = (code, reqNanos) =>
+        {
+            _lastInboundUtc = DateTime.UtcNow;
+            // Reject clears the in-flight flag — a later gap may need to
+            // re-request after a transient peer-side condition lifts. (#138)
+            lock (_inboundGapGate) { _gapRequestInFlight = false; }
+            _retransmit!.RaiseRetransmitRejected((B3.EntryPoint.Client.Fixp.RetransmitRejectCode)(byte)code, NanosToOffset(reqNanos));
+        };
+        _session.OnInboundNotApplied = (from, count) =>
+        {
+            _lastInboundUtc = DateTime.UtcNow;
+            _retransmit!.RaiseNotAppliedReceived(from, count);
+        };
+        _session.OnInboundTerminate = code =>
+        {
+            _lastInboundUtc = DateTime.UtcNow;
+            _options.Logger.InboundTerminate(code);
+            EntryPointTelemetry.Terminations.Add(1,
+                new KeyValuePair<string, object?>("direction", "inbound"),
+                new KeyValuePair<string, object?>("code", code.ToString()));
+            RaiseTerminated((TerminationCode)code, reason: null, initiatedByClient: false);
+        };
+        _lastInboundUtc = DateTime.UtcNow;
     }
 
     private async Task<System.IO.Stream> EstablishTransportStreamAsync(TcpClient tcp, CancellationToken ct)
@@ -977,28 +990,75 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     /// otherwise the gateway terminates with
     /// <see cref="TerminationCode.InvalidSessionVerId"/>.
     /// </summary>
+    /// <remarks>
+    /// Legacy v0.14.3 overload — equivalent to calling the new
+    /// <see cref="ReconnectAsync(ReconnectMode, System.Func{uint, uint}?, CancellationToken)"/>
+    /// with <see cref="ReconnectMode.AlwaysNegotiate"/> and a constant
+    /// selector. Prefer the new overload when transient TCP drops should
+    /// reattach without burning a <c>SessionVerID</c> (#173).
+    /// </remarks>
+#pragma warning disable RS0027 // optional-param overload predates the longer #173 overload; kept for source compat
     public async Task ReconnectAsync(uint nextSessionVerId, CancellationToken ct = default)
+#pragma warning restore RS0027
     {
         if (nextSessionVerId <= _options.SessionVerId)
             throw new ArgumentOutOfRangeException(nameof(nextSessionVerId),
                 "Next SessionVerID must be strictly greater than the current one.");
 
+        await ReconnectAsync(ReconnectMode.AlwaysNegotiate, _ => nextSessionVerId, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Spec-canonical reconnect (#173). On
+    /// <see cref="ReconnectMode.EstablishReuseThenNegotiate"/>, sends
+    /// <c>Establish</c> reusing the current <c>SessionVerID</c> first; falls
+    /// back to <c>Negotiate</c> with a strictly-greater <c>SessionVerID</c>
+    /// (chosen via <paramref name="nextSessionVerIdSelector"/>) only when
+    /// <c>Establish</c> is rejected for a recoverable reason. On
+    /// <see cref="ReconnectMode.AlwaysNegotiate"/>, behaves like the legacy
+    /// <see cref="ReconnectAsync(uint, CancellationToken)"/> overload —
+    /// always rotates the <c>SessionVerID</c>. The returned
+    /// <see cref="ReconnectOutcome"/> surfaces which branch was taken plus
+    /// the peer's <c>EstablishmentAck</c> counters when relevant.
+    /// </summary>
+    /// <param name="mode">Reconnect strategy. See <see cref="ReconnectMode"/>.</param>
+    /// <param name="nextSessionVerIdSelector">
+    /// Invoked by the SDK <em>only when</em> a fresh <c>Negotiate</c> is
+    /// actually required (Establish rejected on the reuse path, or
+    /// <see cref="ReconnectMode.AlwaysNegotiate"/> mode). Receives the
+    /// previous <c>SessionVerID</c> and must return a strictly-greater value
+    /// (e.g. the spec's recommended microseconds-since-epoch). When
+    /// <see langword="null"/>, defaults to <c>prev =&gt; prev + 1</c>.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+#pragma warning disable RS0026, RS0027 // intentional overload introduced in #173; legacy retains optional ct
+    public async Task<ReconnectOutcome> ReconnectAsync(
+        ReconnectMode mode,
+        Func<uint, uint>? nextSessionVerIdSelector,
+        CancellationToken ct)
+#pragma warning restore RS0026, RS0027
+    {
+        var selector = nextSessionVerIdSelector ?? (static prev => checked(prev + 1));
+
         // #138: capture an outstanding inbound gap from the prior session
-        // before any state is reset. The peer bumps SessionVerID on reconnect
-        // and resets its outbound to 1, so the missing range is unrecoverable
-        // in-band — surface it via InboundGapAtReconnect after the new
-        // session is up so consumers can reconcile out-of-band.
+        // before any state is reset. On the Renegotiated path the peer bumps
+        // SessionVerID and resets its outbound to 1, so the missing range is
+        // unrecoverable in-band — surface it via InboundGapAtReconnect after
+        // the new session is up so consumers can reconcile out-of-band.
+        // On the Reattached path the gap is recoverable via §4.7 and the
+        // returned ReconnectOutcome.RetransmitWindowReady advertises that.
         ulong gapFrom = 0UL;
         uint gapCount = 0u;
         var priorSessionVerId = (ulong)_options.SessionVerId;
+        ulong localLastAssignedOutbound = _session?.LastAssignedOutboundSeqNum() ?? 0UL;
+        ulong localLastContiguousInbound;
         lock (_inboundGapGate)
         {
+            localLastContiguousInbound = _lastContiguousInboundSeqNum;
             if (_highestInboundSeqNum > _lastContiguousInboundSeqNum)
             {
                 gapFrom = _lastContiguousInboundSeqNum + 1UL;
                 var window = _highestInboundSeqNum - _lastContiguousInboundSeqNum;
-                // window includes both missing and post-gap-buffered seqs;
-                // subtract the latter to get the true missing count.
                 gapCount = (uint)(window - (ulong)_pendingInboundSeqs.Count);
             }
         }
@@ -1011,10 +1071,136 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         }
         catch { /* best-effort */ }
 
-        // Drain background work + dispose transport BEFORE Establishing the new
-        // session, so old persistence/idle/keep-alive cannot race with the new
-        // one (#124).
         await StopActiveSessionAsync(ct).ConfigureAwait(false);
+
+        ReconnectOutcome outcome;
+        if (mode == ReconnectMode.EstablishReuseThenNegotiate)
+        {
+            outcome = await TryReattachOrRenegotiateAsync(selector, localLastAssignedOutbound, localLastContiguousInbound, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            outcome = await RenegotiateAsync(selector, ct).ConfigureAwait(false);
+        }
+
+        // Surface a Renegotiated-path inbound gap (Reattach paths recover
+        // in-band via RetransmitWindowReady — no need to also raise the
+        // out-of-band event, the application can drive a RetransmitRequest
+        // directly from the outcome).
+        if (gapCount > 0u && outcome.Kind == ReconnectKind.Renegotiated)
+        {
+            _options.Logger.InboundGapAtReconnect(priorSessionVerId, gapFrom, gapCount);
+            InboundGapAtReconnect?.Invoke(this,
+                new InboundGapAtReconnectEventArgs(gapFrom, gapCount, priorSessionVerId));
+        }
+
+        return outcome;
+    }
+
+    /// <summary>
+    /// True when the gateway should retain the session across a TCP drop and
+    /// can therefore answer a reused-SessionVerID Establish with
+    /// EstablishmentAck. UNNEGOTIATED / INVALID_SESSIONID /
+    /// INVALID_SESSIONVERID / ALREADY_ESTABLISHED / SESSION_BLOCKED /
+    /// ESTABLISH_ATTEMPTS_EXCEEDED all indicate the peer cannot reattach
+    /// against this SessionVerID but a fresh Negotiate may succeed; every
+    /// other reject code is a hard failure that bumping SessionVerID alone
+    /// will not fix.
+    /// </summary>
+    private static bool IsRecoverableEstablishReject(B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode code) => code switch
+    {
+        B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.UNNEGOTIATED => true,
+        B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.ALREADY_ESTABLISHED => true,
+        B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.SESSION_BLOCKED => true,
+        B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.INVALID_SESSIONID => true,
+        B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.INVALID_SESSIONVERID => true,
+        B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.ESTABLISH_ATTEMPTS_EXCEEDED => true,
+        _ => false,
+    };
+
+    private async Task<ReconnectOutcome> TryReattachOrRenegotiateAsync(
+        Func<uint, uint> selector,
+        ulong localLastAssignedOutbound,
+        ulong localLastContiguousInbound,
+        CancellationToken ct)
+    {
+        // -- Reattach attempt: TCP reconnect + Establish (no Negotiate) -----
+        var tcp = new TcpClient();
+        try
+        {
+            using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            connectCts.CancelAfter(_options.ConnectTimeout);
+            await tcp.ConnectAsync(_options.Endpoint.Address, _options.Endpoint.Port, connectCts.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            tcp.Dispose();
+            throw;
+        }
+
+        _tcp = tcp;
+        Fixp.EstablishReuseResult reuse;
+        try
+        {
+            var transportStream = await EstablishTransportStreamAsync(tcp, ct).ConfigureAwait(false);
+            _session = new FixpClientSession(transportStream, _options);
+
+            using (var establish = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.establish.reuse", ActivityKind.Client))
+            {
+                reuse = await _session.EstablishReuseAsync(ct).ConfigureAwait(false);
+            }
+
+            if (reuse.Accepted)
+            {
+                var ack = reuse.Ack!.Value;
+                _options.Logger.Established(_options.Endpoint);
+                await FinishEstablishedAsync(ct).ConfigureAwait(false);
+                StartIdleWatchdog();
+
+                // Detect a gap in either direction relative to the peer's view.
+                // Inbound gap: peer reports it will send seq >= NextSeqNo, but
+                // the client's contiguous tail is below NextSeqNo - 1 (i.e.
+                // some inbound frames between localLastContiguousInbound+1 and
+                // NextSeqNo-1 were lost and the peer can re-deliver them).
+                // Outbound gap: peer confirms only up to LastIncomingSeqNo,
+                // and the client has assigned strictly more than that — the
+                // unconfirmed tail must be re-sent.
+                var inboundGap = ack.NextSeqNo > localLastContiguousInbound + 1UL;
+                var outboundGap = localLastAssignedOutbound > ack.LastIncomingSeqNo;
+                var retransmitWindowReady = inboundGap || outboundGap;
+
+                return new ReconnectOutcome(
+                    Kind: ReconnectKind.Reattached,
+                    SessionVerId: _options.SessionVerId,
+                    ServerNextSeqNoExpected: ack.NextSeqNo,
+                    ServerLastIncomingSeqNoSeen: ack.LastIncomingSeqNo,
+                    RetransmitWindowReady: retransmitWindowReady);
+            }
+        }
+        catch
+        {
+            await StopActiveSessionAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+
+        // Reuse rejected — tear down and decide on the fallback path.
+        await StopActiveSessionAsync(CancellationToken.None).ConfigureAwait(false);
+
+        var code = reuse.RejectCode!.Value;
+        if (!IsRecoverableEstablishReject(code))
+            throw new Fixp.FixpEstablishRejectedException(code);
+
+        _options.Logger.EstablishReuseRejected(code);
+        return await RenegotiateAsync(selector, ct).ConfigureAwait(false);
+    }
+
+    private async Task<ReconnectOutcome> RenegotiateAsync(Func<uint, uint> selector, CancellationToken ct)
+    {
+        var prev = _options.SessionVerId;
+        var next = selector(prev);
+        if (next <= prev)
+            throw new InvalidOperationException(
+                $"nextSessionVerIdSelector returned {next} which is not strictly greater than the current SessionVerId {prev}.");
 
         // Reset inbound seq tracking — the new session starts at peer seq 1.
         // HydrateFromSnapshotAsync (called from the next ConnectAsync) will
@@ -1027,15 +1213,15 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             _gapRequestInFlight = false;
         }
 
-        _options.SessionVerId = nextSessionVerId;
+        _options.SessionVerId = next;
         await ConnectAsync(ct).ConfigureAwait(false);
 
-        if (gapCount > 0u)
-        {
-            _options.Logger.InboundGapAtReconnect(priorSessionVerId, gapFrom, gapCount);
-            InboundGapAtReconnect?.Invoke(this,
-                new InboundGapAtReconnectEventArgs(gapFrom, gapCount, priorSessionVerId));
-        }
+        return new ReconnectOutcome(
+            Kind: ReconnectKind.Renegotiated,
+            SessionVerId: next,
+            ServerNextSeqNoExpected: 0UL,
+            ServerLastIncomingSeqNoSeen: 0UL,
+            RetransmitWindowReady: false);
     }
 
     /// <summary>
@@ -1071,7 +1257,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     /// timeout (<see cref="EntryPointClientOptions.SessionTeardownTimeout"/>),
     /// then disposes keep-alive, the FIXP session (which awaits its inbound
     /// loop), the TCP transport and the retransmit handler. Shared by
-    /// <see cref="ReconnectAsync"/> and <see cref="DisposeAsync"/> so the
+    /// <see cref="ReconnectAsync(uint, System.Threading.CancellationToken)"/> and <see cref="DisposeAsync"/> so the
     /// same ordering applies in both paths (#124).
     /// </summary>
     private async Task StopActiveSessionAsync(CancellationToken ct)

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -133,7 +133,7 @@ public sealed class EntryPointClientOptions
     /// <summary>
     /// Hard timeout for awaiting session-scoped background tasks (idle
     /// watchdog, persistence worker) during
-    /// <see cref="EntryPointClient.ReconnectAsync"/> and
+    /// <see cref="EntryPointClient.ReconnectAsync(uint, System.Threading.CancellationToken)"/> and
     /// <see cref="EntryPointClient.DisposeAsync"/>. Tasks still running after
     /// this deadline are logged (event 4009) and abandoned; the underlying
     /// cancellation tokens are then cancelled to unblock any I/O. Defaults to

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -48,21 +48,32 @@ public sealed class EntryPointClientOptions
     public byte DefaultMarketSegmentId { get; set; } = 1;
 
     /// <summary>
-    /// Cancel-on-disconnect behaviour requested at <c>Negotiate</c>. Defaults
-    /// to <see cref="CancelOnDisconnectType.CancelOnDisconnectOrTerminate"/>
-    /// — the safest choice for a participant that must not leave open orders
+    /// Cancel-on-disconnect behaviour requested at <c>Establish</c> (schema
+    /// 8.4.2 §811, field <c>cancelOnDisconnectType</c>). Defaults to
+    /// <see cref="CancelOnDisconnectType.CancelOnDisconnectOrTerminate"/> —
+    /// the safest choice for a participant that must not leave open orders
     /// after losing the session.
     /// </summary>
     /// <remarks>
-    /// Marked <see cref="System.Diagnostics.CodeAnalysis.ExperimentalAttribute"/>
-    /// (#130): the value is currently <em>not</em> wired into the FIXP
-    /// <c>Negotiate</c> frame, so changing it has no observable effect on
-    /// the negotiated cancel-on-disconnect contract. Suppress
-    /// <c>B3EP_COD</c> at the call site to opt-in.
+    /// The value is encoded into every outbound <c>Establish</c> (both the
+    /// initial connect and spec-canonical reattach). Marked
+    /// <see cref="System.Diagnostics.CodeAnalysis.ExperimentalAttribute"/>
+    /// (#130) so callers must opt in via <c>B3EP_COD</c>; the wire encoding
+    /// is now stable but the surfaced API may still evolve.
     /// </remarks>
     [System.Diagnostics.CodeAnalysis.Experimental("B3EP_COD")]
     public CancelOnDisconnectType CancelOnDisconnect { get; set; } =
         CancelOnDisconnectType.CancelOnDisconnectOrTerminate;
+
+    /// <summary>
+    /// Grace window (milliseconds) the gateway will wait before triggering
+    /// cancel-on-disconnect, allowing a fast TCP reconnect to suppress the
+    /// cancel (schema 8.4.2 §811, field <c>codTimeoutWindow</c>). Range
+    /// <c>0..60000</c>; <c>0</c> = trigger as soon as possible. Defaults
+    /// to <c>0</c> for backward compatibility.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.Experimental("B3EP_COD")]
+    public ulong CodTimeoutWindowMs { get; set; } = 0UL;
 
     /// <summary>
     /// Profile of the FIXP session. <see cref="SessionProfile.OrderEntry"/> is

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -78,7 +78,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
         }
     }
 
-    public async Task EstablishAsync(CancellationToken ct)
+    public async Task<EstablishResult> EstablishAsync(CancellationToken ct)
     {
         if (_machine.State != FixpClientState.Negotiated)
             throw new InvalidOperationException($"Cannot Establish from state {_machine.State}.");
@@ -97,17 +97,81 @@ internal sealed class FixpClientSession : IAsyncDisposable
         if (templateId == EstablishAckData.MESSAGE_ID)
         {
             Fire(FixpClientTrigger.EstablishAckReceived);
+            return ParseEstablishAck(frame);
         }
         else if (templateId == EstablishRejectData.MESSAGE_ID)
         {
             Fire(FixpClientTrigger.EstablishRejectReceived);
-            throw new FixpRejectedException("Establish rejected by peer.");
+            var code = ParseEstablishRejectCode(frame);
+            throw new FixpEstablishRejectedException(code);
         }
         else
         {
             Fire(FixpClientTrigger.ProtocolError);
             throw new InvalidDataException($"Unexpected templateId {templateId} during Establish handshake.");
         }
+    }
+
+    /// <summary>
+    /// Spec-canonical reattach (#173). Sends an <c>Establish</c> reusing the
+    /// current <c>SessionVerID</c> on a freshly-reconnected TCP socket
+    /// (i.e. without a preceding <c>Negotiate</c>), then awaits either
+    /// <c>EstablishmentAck</c> (reattach succeeded) or <c>EstablishReject</c>
+    /// (peer cannot reattach — caller decides whether to fall back to a fresh
+    /// Negotiate based on the returned <see cref="EstablishRejectCode"/>).
+    /// Unlike <see cref="EstablishAsync"/>, this method does NOT throw on a
+    /// reject: the rejection code is part of the normal return contract so
+    /// callers can branch on it.
+    /// </summary>
+    public async Task<EstablishReuseResult> EstablishReuseAsync(CancellationToken ct)
+    {
+        if (_machine.State != FixpClientState.TcpConnected)
+            throw new InvalidOperationException($"Cannot Establish-reuse from state {_machine.State}.");
+
+        await SendEstablishAsync(ct).ConfigureAwait(false);
+        Fire(FixpClientTrigger.SendEstablish);
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(_options.HandshakeTimeout);
+
+        var frame = await SofhFrameReader.ReadFrameAsync(_stream, timeout.Token).ConfigureAwait(false);
+        var templateId = ReadTemplateId(frame);
+        if (_options.Logger.IsEnabled(LogLevel.Trace))
+            _options.Logger.InboundFrame(templateId, frame.Length);
+
+        if (templateId == EstablishAckData.MESSAGE_ID)
+        {
+            Fire(FixpClientTrigger.EstablishAckReceived);
+            return EstablishReuseResult.FromAck(ParseEstablishAck(frame));
+        }
+        else if (templateId == EstablishRejectData.MESSAGE_ID)
+        {
+            Fire(FixpClientTrigger.EstablishRejectReceived);
+            return EstablishReuseResult.FromReject(ParseEstablishRejectCode(frame));
+        }
+        else
+        {
+            Fire(FixpClientTrigger.ProtocolError);
+            throw new InvalidDataException($"Unexpected templateId {templateId} during Establish-reuse handshake.");
+        }
+    }
+
+    private static EstablishResult ParseEstablishAck(byte[] frame)
+    {
+        var payload = frame.AsSpan(SofhSize + SbeHeaderSize);
+        if (!EstablishAckData.TryParse(payload, out var reader))
+            throw new InvalidDataException("EstablishAckData payload too small.");
+        ref readonly var ack = ref reader.Data;
+        return new EstablishResult(ack.NextSeqNo.Value, ack.LastIncomingSeqNo.Value);
+    }
+
+    private static EstablishRejectCode ParseEstablishRejectCode(byte[] frame)
+    {
+        var payload = frame.AsSpan(SofhSize + SbeHeaderSize);
+        if (!EstablishRejectData.TryParse(payload, out var reader))
+            return EstablishRejectCode.UNSPECIFIED;
+        ref readonly var rej = ref reader.Data;
+        return rej.EstablishmentRejectCode;
     }
 
     public async Task TerminateAsync(SbeTerminationCode code, CancellationToken ct)
@@ -503,4 +567,39 @@ internal sealed class FixpClientSession : IAsyncDisposable
         (DateTimeOffset.UtcNow - DateTimeOffset.UnixEpoch).Ticks * 100L;
 }
 
-public sealed class FixpRejectedException(string message) : Exception(message);
+public class FixpRejectedException(string message) : Exception(message);
+
+/// <summary>
+/// Thrown by <see cref="FixpClientSession.EstablishAsync(System.Threading.CancellationToken)"/>
+/// when the peer responds with an <c>EstablishReject</c>. Carries the
+/// <see cref="EstablishRejectCode"/> reported by the gateway so callers can
+/// distinguish recoverable (UNNEGOTIATED, INVALID_SESSIONID, …) from hard
+/// (CREDENTIALS, PROTOCOL_VERSION_NOT_SUPPORTED, …) reasons.
+/// </summary>
+public sealed class FixpEstablishRejectedException : FixpRejectedException
+{
+    public FixpEstablishRejectedException(EstablishRejectCode code)
+        : base($"Establish rejected by peer: {code}.")
+    {
+        Code = code;
+    }
+
+    public EstablishRejectCode Code { get; }
+}
+
+/// <summary>Decoded outcome of a successful <c>EstablishmentAck</c> (#173).</summary>
+internal readonly record struct EstablishResult(ulong NextSeqNo, ulong LastIncomingSeqNo);
+
+/// <summary>
+/// Outcome of <see cref="FixpClientSession.EstablishReuseAsync(System.Threading.CancellationToken)"/>:
+/// either an <see cref="Ack"/> (peer accepted reattach) or a
+/// <see cref="RejectCode"/> (peer refused — caller decides on the fallback
+/// strategy). Exactly one of the two is non-null.
+/// </summary>
+internal readonly record struct EstablishReuseResult(EstablishResult? Ack, EstablishRejectCode? RejectCode)
+{
+    public bool Accepted => Ack.HasValue;
+
+    internal static EstablishReuseResult FromAck(EstablishResult ack) => new(ack, null);
+    internal static EstablishReuseResult FromReject(EstablishRejectCode code) => new(null, code);
+}

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -83,7 +83,9 @@ internal sealed class FixpClientSession : IAsyncDisposable
         if (_machine.State != FixpClientState.Negotiated)
             throw new InvalidOperationException($"Cannot Establish from state {_machine.State}.");
 
-        await SendEstablishAsync(ct).ConfigureAwait(false);
+        // First Establish on a fresh Negotiate-driven session: client's app
+        // outbound sequence starts at 1 per spec §4.5.
+        await SendEstablishAsync(nextSeqNo: 1u, ct).ConfigureAwait(false);
         Fire(FixpClientTrigger.SendEstablish);
 
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -123,12 +125,20 @@ internal sealed class FixpClientSession : IAsyncDisposable
     /// reject: the rejection code is part of the normal return contract so
     /// callers can branch on it.
     /// </summary>
-    public async Task<EstablishReuseResult> EstablishReuseAsync(CancellationToken ct)
+    /// <param name="nextSeqNo">
+    /// Client-side next outbound application <c>MsgSeqNum</c> to advertise.
+    /// On a reattach the peer uses this to compute whether the client has
+    /// unconfirmed outbound frames; callers must pass
+    /// <c>localLastAssignedOutbound + 1</c> (1 when no app frame has been
+    /// sent yet under this SessionVerID).
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task<EstablishReuseResult> EstablishReuseAsync(uint nextSeqNo, CancellationToken ct)
     {
         if (_machine.State != FixpClientState.TcpConnected)
             throw new InvalidOperationException($"Cannot Establish-reuse from state {_machine.State}.");
 
-        await SendEstablishAsync(ct).ConfigureAwait(false);
+        await SendEstablishAsync(nextSeqNo, ct).ConfigureAwait(false);
         Fire(FixpClientTrigger.SendEstablish);
 
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -506,7 +516,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
         await _stream.FlushAsync(ct).ConfigureAwait(false);
     }
 
-    private async Task SendEstablishAsync(CancellationToken ct)
+    private async Task SendEstablishAsync(uint nextSeqNo, CancellationToken ct)
     {
         var creds = _options.Credentials.AsSpan();
 
@@ -523,7 +533,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
             SessionVerID = new SessionVerID((ulong)_options.SessionVerId),
             Timestamp = new UTCTimestampNanos { Time = (ulong)NowUnixNanos() },
             KeepAliveInterval = new DeltaInMillis { Time = _options.KeepAliveIntervalMs },
-            NextSeqNo = new SeqNum(1),
+            NextSeqNo = new SeqNum(nextSeqNo),
         };
 
         if (!EstablishData.TryEncode(payload, buffer.AsSpan(SofhSize + SbeHeaderSize), creds, out _))
@@ -591,7 +601,7 @@ public sealed class FixpEstablishRejectedException : FixpRejectedException
 internal readonly record struct EstablishResult(ulong NextSeqNo, ulong LastIncomingSeqNo);
 
 /// <summary>
-/// Outcome of <see cref="FixpClientSession.EstablishReuseAsync(System.Threading.CancellationToken)"/>:
+/// Outcome of <see cref="FixpClientSession.EstablishReuseAsync(uint, System.Threading.CancellationToken)"/>:
 /// either an <see cref="Ack"/> (peer accepted reattach) or a
 /// <see cref="RejectCode"/> (peer refused — caller decides on the fallback
 /// strategy). Exactly one of the two is non-null.

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -284,6 +284,16 @@ internal sealed class FixpClientSession : IAsyncDisposable
                             }
                             break;
                         case TerminateData.MESSAGE_ID:
+                            // Advance the state machine BEFORE notifying the
+                            // outer client so EnsureEstablished() (sync app
+                            // sends) sees the session as no longer Established
+                            // and refuses new outbound frames. Per schema §4.8
+                            // a Terminate signals the sender is going to
+                            // disconnect; sending app frames on the same TCP
+                            // socket after that is a protocol error.
+                            try { Fire(FixpClientTrigger.TerminateReceived); }
+                            catch (InvalidFixpTransitionException) { /* already Terminating/Terminated */ }
+
                             // SessionID(4) + SessionVerID(8) + TerminationCode(1) = 13 bytes
                             if (payload.Length >= TerminateData.MESSAGE_SIZE)
                             {
@@ -295,6 +305,16 @@ internal sealed class FixpClientSession : IAsyncDisposable
                             // outlives this session and is owned by the outer
                             // EntryPointClient (see #144).
                             return;
+                        default:
+                            // Unknown templateId on a SOFH-framed SBE message.
+                            // Log so operators can spot a gateway protocol
+                            // version drift; intentionally do not terminate
+                            // the session (newer gateway templates may be
+                            // safely ignorable by older clients). See spec
+                            // TerminationCode.UNRECOGNIZED_MESSAGE for the
+                            // peer-side counterpart.
+                            _options.Logger.UnknownInboundTemplateId(templateId, frame.Length);
+                            break;
                     }
                 }
             }
@@ -527,6 +547,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
         SofhFrameWriter.WriteHeader(buffer, checked((ushort)totalSize));
         EstablishData.WriteHeader(buffer.AsSpan(SofhSize));
 
+#pragma warning disable B3EP_COD // wire CancelOnDisconnect into Establish payload
         var payload = new EstablishData
         {
             SessionID = _options.SessionId,
@@ -534,7 +555,10 @@ internal sealed class FixpClientSession : IAsyncDisposable
             Timestamp = new UTCTimestampNanos { Time = (ulong)NowUnixNanos() },
             KeepAliveInterval = new DeltaInMillis { Time = _options.KeepAliveIntervalMs },
             NextSeqNo = new SeqNum(nextSeqNo),
+            CancelOnDisconnectType = (B3.Entrypoint.Fixp.Sbe.V6.CancelOnDisconnectType)_options.CancelOnDisconnect,
+            CodTimeoutWindow = new DeltaInMillis { Time = _options.CodTimeoutWindowMs },
         };
+#pragma warning restore B3EP_COD
 
         if (!EstablishData.TryEncode(payload, buffer.AsSpan(SofhSize + SbeHeaderSize), creds, out _))
             throw new InvalidOperationException("Failed to encode Establish payload.");

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientStateMachine.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientStateMachine.cs
@@ -48,6 +48,11 @@ public sealed class FixpClientStateMachine
             (FixpClientState.Negotiating, FixpClientTrigger.NegotiateResponseReceived) => FixpClientState.Negotiated,
             (FixpClientState.Negotiating, FixpClientTrigger.NegotiateRejectReceived) => FixpClientState.Terminating,
             (FixpClientState.Negotiated, FixpClientTrigger.SendEstablish) => FixpClientState.Establishing,
+            // Spec-canonical reattach (#173): a client recovering a same-SessionVerID
+            // session over a freshly reconnected TCP socket sends Establish without
+            // a preceding Negotiate. The peer answers with EstablishmentAck on the
+            // happy path or EstablishReject(UNNEGOTIATED|…) when it cannot reattach.
+            (FixpClientState.TcpConnected, FixpClientTrigger.SendEstablish) => FixpClientState.Establishing,
             (FixpClientState.Establishing, FixpClientTrigger.EstablishAckReceived) => FixpClientState.Established,
             (FixpClientState.Establishing, FixpClientTrigger.EstablishRejectReceived) => FixpClientState.Terminating,
             _ => null,

--- a/src/B3.EntryPoint.Client/Framing/SofhFrameReader.cs
+++ b/src/B3.EntryPoint.Client/Framing/SofhFrameReader.cs
@@ -51,8 +51,15 @@ public static class SofhFrameReader
         var header = new byte[HeaderSize];
         await stream.ReadExactlyAsync(header, ct).ConfigureAwait(false);
 
-        if (!TryParseHeader(header, out var messageLength, out _))
+        if (!TryParseHeader(header, out var messageLength, out var encodingType))
             throw new InvalidDataException("SOFH header truncated.");
+
+        // SBE 1.0 LE is the only encoding B3 EntryPoint speaks (FIX SOFH §3,
+        // schema §4.4). Refusing other encodings prevents accidentally
+        // decoding a malformed frame as a valid SBE payload.
+        if (encodingType != SbeLittleEndianEncodingType)
+            throw new InvalidDataException(
+                $"SOFH encodingType 0x{encodingType:X4} not supported (expected SBE LE 0x{SbeLittleEndianEncodingType:X4}).");
 
         if (messageLength < HeaderSize)
             throw new InvalidDataException($"SOFH messageLength {messageLength} smaller than header size {HeaderSize}.");

--- a/src/B3.EntryPoint.Client/IEntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/IEntryPointClient.cs
@@ -54,7 +54,31 @@ public interface IEntryPointClient :
     Task FlushAsync(CancellationToken ct = default);
 
     /// <summary>Reconnects with a bumped <c>SessionVerId</c>.</summary>
+    /// <remarks>
+    /// Legacy v0.14.3 overload — equivalent to
+    /// <see cref="ReconnectAsync(ReconnectMode, System.Func{uint, uint}?, CancellationToken)"/>
+    /// with <see cref="ReconnectMode.AlwaysNegotiate"/>. Prefer the new
+    /// overload to enable spec-canonical reattach (#173).
+    /// </remarks>
+#pragma warning disable RS0027 // optional-param overload predates the longer #173 overload; kept for source compat
     Task ReconnectAsync(uint nextSessionVerId, CancellationToken ct = default);
+#pragma warning restore RS0027
+
+    /// <summary>
+    /// Spec-canonical reconnect (#173). On
+    /// <see cref="ReconnectMode.EstablishReuseThenNegotiate"/> tries
+    /// <c>Establish</c> reusing the same <c>SessionVerID</c> first and falls
+    /// back to <c>Negotiate</c> only when the gateway rejects with a
+    /// recoverable code (<c>UNNEGOTIATED</c>, <c>SESSION_BLOCKED</c>,
+    /// <c>INVALID_SESSIONID</c>, <c>INVALID_SESSIONVERID</c>,
+    /// <c>ALREADY_ESTABLISHED</c>, <c>ESTABLISH_ATTEMPTS_EXCEEDED</c>).
+    /// </summary>
+#pragma warning disable RS0026, RS0027 // intentional overload introduced in #173; legacy retains optional ct
+    Task<ReconnectOutcome> ReconnectAsync(
+        ReconnectMode mode,
+        Func<uint, uint>? nextSessionVerIdSelector,
+        CancellationToken ct);
+#pragma warning restore RS0026, RS0027
 
     /// <summary>Snapshot of in-memory client health counters.</summary>
     ClientHealth GetHealth();

--- a/src/B3.EntryPoint.Client/InboundGapAtReconnectEventArgs.cs
+++ b/src/B3.EntryPoint.Client/InboundGapAtReconnectEventArgs.cs
@@ -8,7 +8,7 @@ namespace B3.EntryPoint.Client;
 /// the missing range from the prior session cannot be served by a §4.7
 /// <c>RetransmitRequest</c> against the new session. Consumers should reconcile
 /// out-of-band (e.g. via a business-layer order-status query). Emitted exactly
-/// once per <see cref="EntryPointClient.ReconnectAsync"/> call. (#138)
+/// once per <see cref="EntryPointClient.ReconnectAsync(uint, System.Threading.CancellationToken)"/> call. (#138)
 /// </summary>
 public sealed class InboundGapAtReconnectEventArgs : EventArgs
 {

--- a/src/B3.EntryPoint.Client/Logging/LogMessages.cs
+++ b/src/B3.EntryPoint.Client/Logging/LogMessages.cs
@@ -147,6 +147,10 @@ internal static partial class LogMessages
         Message = "Reuse-SessionVerID Establish rejected by peer with code={Code}; falling back to fresh Negotiate")]
     public static partial void EstablishReuseRejected(this ILogger logger, B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode code);
 
+    [LoggerMessage(EventId = 4015, Level = LogLevel.Warning,
+        Message = "Inbound frame with unknown SBE templateId={TemplateId} ({FrameLength} bytes) — frame dropped, session continues")]
+    public static partial void UnknownInboundTemplateId(this ILogger logger, int templateId, int frameLength);
+
     // ---------------- Error (5000–5999) ----------------
 
     [LoggerMessage(EventId = 5000, Level = LogLevel.Error,

--- a/src/B3.EntryPoint.Client/Logging/LogMessages.cs
+++ b/src/B3.EntryPoint.Client/Logging/LogMessages.cs
@@ -143,6 +143,10 @@ internal static partial class LogMessages
         Message = "Outbound MsgSeqNum approaching uint32 boundary (assigned={Assigned}, max={Max}); rotate SessionVerID via ReconnectAsync before exhaustion")]
     public static partial void OutboundSeqNumNearExhaustion(this ILogger logger, ulong assigned, ulong max);
 
+    [LoggerMessage(EventId = 4014, Level = LogLevel.Warning,
+        Message = "Reuse-SessionVerID Establish rejected by peer with code={Code}; falling back to fresh Negotiate")]
+    public static partial void EstablishReuseRejected(this ILogger logger, B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode code);
+
     // ---------------- Error (5000–5999) ----------------
 
     [LoggerMessage(EventId = 5000, Level = LogLevel.Error,

--- a/src/B3.EntryPoint.Client/PublicAPI.Shipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Shipped.txt
@@ -3,11 +3,11 @@
 B3.EntryPoint.Client.Auth.Credentials
 B3.EntryPoint.Client.Auth.Credentials.AsSpan() -> System.ReadOnlySpan<byte>
 B3.EntryPoint.Client.Auth.Credentials.Credentials(System.ReadOnlySpan<byte> bytes) -> void
-B3.EntryPoint.Client.CancelOnDisconnectType
-B3.EntryPoint.Client.CancelOnDisconnectType.CancelOnDisconnectOnly = 1 -> B3.EntryPoint.Client.CancelOnDisconnectType
-B3.EntryPoint.Client.CancelOnDisconnectType.CancelOnDisconnectOrTerminate = 3 -> B3.EntryPoint.Client.CancelOnDisconnectType
-B3.EntryPoint.Client.CancelOnDisconnectType.CancelOnTerminateOnly = 2 -> B3.EntryPoint.Client.CancelOnDisconnectType
-B3.EntryPoint.Client.CancelOnDisconnectType.DoNotCancelOnDisconnectOrTerminate = 0 -> B3.EntryPoint.Client.CancelOnDisconnectType
+[B3EP_COD]B3.EntryPoint.Client.CancelOnDisconnectType
+[B3EP_COD]B3.EntryPoint.Client.CancelOnDisconnectType.CancelOnDisconnectOnly = 1 -> B3.EntryPoint.Client.CancelOnDisconnectType
+[B3EP_COD]B3.EntryPoint.Client.CancelOnDisconnectType.CancelOnDisconnectOrTerminate = 3 -> B3.EntryPoint.Client.CancelOnDisconnectType
+[B3EP_COD]B3.EntryPoint.Client.CancelOnDisconnectType.CancelOnTerminateOnly = 2 -> B3.EntryPoint.Client.CancelOnDisconnectType
+[B3EP_COD]B3.EntryPoint.Client.CancelOnDisconnectType.DoNotCancelOnDisconnectOrTerminate = 0 -> B3.EntryPoint.Client.CancelOnDisconnectType
 B3.EntryPoint.Client.DependencyInjection.EntryPointClientServiceCollectionExtensions
 B3.EntryPoint.Client.DropCopy.DropCopyClient
 B3.EntryPoint.Client.DropCopy.DropCopyClient.ConnectAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
@@ -214,15 +214,15 @@ B3.EntryPoint.Client.IEntryPointClient.RiskGates.get -> System.Collections.Gener
 B3.EntryPoint.Client.IEntryPointClient.State.get -> B3.EntryPoint.Client.Fixp.FixpClientState
 B3.EntryPoint.Client.IEntryPointClient.TerminateAsync(B3.EntryPoint.Client.TerminationCode code, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 B3.EntryPoint.Client.IEntryPointClient.Terminated -> System.EventHandler<B3.EntryPoint.Client.TerminatedEventArgs!>?
-B3.EntryPoint.Client.IQuoteFlow
-B3.EntryPoint.Client.IQuoteFlow.CancelQuoteAsync(string! quoteId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-B3.EntryPoint.Client.IQuoteFlow.SendQuoteAsync(B3.EntryPoint.Client.Models.QuoteMessage! quote, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-B3.EntryPoint.Client.IQuoteFlow.SendQuoteRequestAsync(B3.EntryPoint.Client.Models.QuoteRequestMessage! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+[B3EP_QUOTE]B3.EntryPoint.Client.IQuoteFlow
+[B3EP_QUOTE]B3.EntryPoint.Client.IQuoteFlow.CancelQuoteAsync(string! quoteId, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+[B3EP_QUOTE]B3.EntryPoint.Client.IQuoteFlow.SendQuoteAsync(B3.EntryPoint.Client.Models.QuoteMessage! quote, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+[B3EP_QUOTE]B3.EntryPoint.Client.IQuoteFlow.SendQuoteRequestAsync(B3.EntryPoint.Client.Models.QuoteRequestMessage! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 B3.EntryPoint.Client.IReplaceOrder
 B3.EntryPoint.Client.IReplaceOrder.ReplaceAsync(B3.EntryPoint.Client.Models.ReplaceOrderRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<B3.EntryPoint.Client.Models.ClOrdID>!
 B3.EntryPoint.Client.IReplaceOrder.ReplaceSimpleAsync(B3.EntryPoint.Client.Models.SimpleModifyRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<B3.EntryPoint.Client.Models.ClOrdID>!
-B3.EntryPoint.Client.ISubmitCross
-B3.EntryPoint.Client.ISubmitCross.SubmitCrossAsync(B3.EntryPoint.Client.Models.NewOrderCrossRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+[B3EP_CROSS]B3.EntryPoint.Client.ISubmitCross
+[B3EP_CROSS]B3.EntryPoint.Client.ISubmitCross.SubmitCrossAsync(B3.EntryPoint.Client.Models.NewOrderCrossRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
 B3.EntryPoint.Client.ISubmitOrder
 B3.EntryPoint.Client.ISubmitOrder.SubmitAsync(B3.EntryPoint.Client.Models.NewOrderRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<B3.EntryPoint.Client.Models.ClOrdID>!
 B3.EntryPoint.Client.ISubmitOrder.SubmitSimpleAsync(B3.EntryPoint.Client.Models.SimpleNewOrderRequest! request, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<B3.EntryPoint.Client.Models.ClOrdID>!

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -1,1 +1,32 @@
 #nullable enable
+B3.EntryPoint.Client.EntryPointClient.ReconnectAsync(B3.EntryPoint.Client.ReconnectMode mode, System.Func<uint, uint>? nextSessionVerIdSelector, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<B3.EntryPoint.Client.ReconnectOutcome>!
+B3.EntryPoint.Client.Fixp.FixpEstablishRejectedException
+B3.EntryPoint.Client.Fixp.FixpEstablishRejectedException.Code.get -> B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode
+B3.EntryPoint.Client.Fixp.FixpEstablishRejectedException.FixpEstablishRejectedException(B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode code) -> void
+B3.EntryPoint.Client.IEntryPointClient.ReconnectAsync(B3.EntryPoint.Client.ReconnectMode mode, System.Func<uint, uint>? nextSessionVerIdSelector, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<B3.EntryPoint.Client.ReconnectOutcome>!
+B3.EntryPoint.Client.ReconnectKind
+B3.EntryPoint.Client.ReconnectKind.Reattached = 0 -> B3.EntryPoint.Client.ReconnectKind
+B3.EntryPoint.Client.ReconnectKind.Renegotiated = 1 -> B3.EntryPoint.Client.ReconnectKind
+B3.EntryPoint.Client.ReconnectMode
+B3.EntryPoint.Client.ReconnectMode.AlwaysNegotiate = 1 -> B3.EntryPoint.Client.ReconnectMode
+B3.EntryPoint.Client.ReconnectMode.EstablishReuseThenNegotiate = 0 -> B3.EntryPoint.Client.ReconnectMode
+B3.EntryPoint.Client.ReconnectOutcome
+B3.EntryPoint.Client.ReconnectOutcome.Deconstruct(out B3.EntryPoint.Client.ReconnectKind Kind, out uint SessionVerId, out ulong ServerNextSeqNoExpected, out ulong ServerLastIncomingSeqNoSeen, out bool RetransmitWindowReady) -> void
+B3.EntryPoint.Client.ReconnectOutcome.Equals(B3.EntryPoint.Client.ReconnectOutcome other) -> bool
+B3.EntryPoint.Client.ReconnectOutcome.Kind.get -> B3.EntryPoint.Client.ReconnectKind
+B3.EntryPoint.Client.ReconnectOutcome.Kind.init -> void
+B3.EntryPoint.Client.ReconnectOutcome.ReconnectOutcome() -> void
+B3.EntryPoint.Client.ReconnectOutcome.ReconnectOutcome(B3.EntryPoint.Client.ReconnectKind Kind, uint SessionVerId, ulong ServerNextSeqNoExpected, ulong ServerLastIncomingSeqNoSeen, bool RetransmitWindowReady) -> void
+B3.EntryPoint.Client.ReconnectOutcome.RetransmitWindowReady.get -> bool
+B3.EntryPoint.Client.ReconnectOutcome.RetransmitWindowReady.init -> void
+B3.EntryPoint.Client.ReconnectOutcome.ServerLastIncomingSeqNoSeen.get -> ulong
+B3.EntryPoint.Client.ReconnectOutcome.ServerLastIncomingSeqNoSeen.init -> void
+B3.EntryPoint.Client.ReconnectOutcome.ServerNextSeqNoExpected.get -> ulong
+B3.EntryPoint.Client.ReconnectOutcome.ServerNextSeqNoExpected.init -> void
+B3.EntryPoint.Client.ReconnectOutcome.SessionVerId.get -> uint
+B3.EntryPoint.Client.ReconnectOutcome.SessionVerId.init -> void
+override B3.EntryPoint.Client.ReconnectOutcome.GetHashCode() -> int
+static B3.EntryPoint.Client.ReconnectOutcome.operator !=(B3.EntryPoint.Client.ReconnectOutcome left, B3.EntryPoint.Client.ReconnectOutcome right) -> bool
+static B3.EntryPoint.Client.ReconnectOutcome.operator ==(B3.EntryPoint.Client.ReconnectOutcome left, B3.EntryPoint.Client.ReconnectOutcome right) -> bool
+~override B3.EntryPoint.Client.ReconnectOutcome.Equals(object obj) -> bool
+~override B3.EntryPoint.Client.ReconnectOutcome.ToString() -> string

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -30,3 +30,6 @@ static B3.EntryPoint.Client.ReconnectOutcome.operator !=(B3.EntryPoint.Client.Re
 static B3.EntryPoint.Client.ReconnectOutcome.operator ==(B3.EntryPoint.Client.ReconnectOutcome left, B3.EntryPoint.Client.ReconnectOutcome right) -> bool
 ~override B3.EntryPoint.Client.ReconnectOutcome.Equals(object obj) -> bool
 ~override B3.EntryPoint.Client.ReconnectOutcome.ToString() -> string
+const B3.EntryPoint.Client.Auth.Credentials.MaxLengthBytes = 128 -> int
+B3.EntryPoint.Client.EntryPointClientOptions.CodTimeoutWindowMs.get -> ulong
+B3.EntryPoint.Client.EntryPointClientOptions.CodTimeoutWindowMs.set -> void

--- a/src/B3.EntryPoint.Client/Reconnect.cs
+++ b/src/B3.EntryPoint.Client/Reconnect.cs
@@ -1,0 +1,94 @@
+namespace B3.EntryPoint.Client;
+
+/// <summary>
+/// Selects how <see cref="EntryPointClient.ReconnectAsync(ReconnectMode, System.Func{uint, uint}?, System.Threading.CancellationToken)"/>
+/// re-attaches a dropped session. See issue #173 for the spec rationale.
+/// </summary>
+public enum ReconnectMode
+{
+    /// <summary>
+    /// Spec-canonical TCP-blip recovery (B3 EntryPoint 5.3 §5.5–§5.6):
+    /// reconnect TCP and send <c>Establish</c> reusing the same
+    /// <c>SessionVerID</c>. If the peer answers <c>EstablishmentAck</c> the
+    /// session is reattached and the application never observes a
+    /// <c>SessionVerID</c> bump. Only when the peer rejects <c>Establish</c>
+    /// with a recoverable code (<c>UNNEGOTIATED</c>, <c>SESSION_BLOCKED</c>,
+    /// <c>INVALID_SESSIONID</c>, <c>INVALID_SESSIONVERID</c>,
+    /// <c>ALREADY_ESTABLISHED</c>, <c>ESTABLISH_ATTEMPTS_EXCEEDED</c>) does
+    /// the SDK fall back to a fresh <c>Negotiate</c> with a strictly-greater
+    /// <c>SessionVerID</c> supplied by the caller's selector.
+    /// </summary>
+    EstablishReuseThenNegotiate = 0,
+
+    /// <summary>
+    /// Always send a fresh <c>Negotiate</c> with a strictly-greater
+    /// <c>SessionVerID</c>. Equivalent to the legacy
+    /// <see cref="EntryPointClient.ReconnectAsync(uint, System.Threading.CancellationToken)"/>
+    /// overload; useful for operator-initiated rotation, daily session roll,
+    /// or any case where a deliberate new logical session is wanted.
+    /// </summary>
+    AlwaysNegotiate = 1,
+}
+
+/// <summary>
+/// Outcome of a <see cref="ReconnectMode.EstablishReuseThenNegotiate"/> /
+/// <see cref="ReconnectMode.AlwaysNegotiate"/> reconnect (#173).
+/// </summary>
+public enum ReconnectKind
+{
+    /// <summary>
+    /// The peer accepted <c>Establish</c> reusing the previous
+    /// <c>SessionVerID</c>: the application-layer session is the same one,
+    /// outstanding orders remain correlated to their original
+    /// <c>ClOrdID</c>s, and the <c>SessionVerID</c> was not bumped.
+    /// </summary>
+    Reattached = 0,
+
+    /// <summary>
+    /// A fresh <c>Negotiate</c> was performed and the <c>SessionVerID</c> was
+    /// bumped via the caller-supplied selector. The application layer should
+    /// treat this as a brand-new logical session (any pre-reconnect order
+    /// state is no longer addressable by the peer).
+    /// </summary>
+    Renegotiated = 1,
+}
+
+/// <summary>
+/// Result of <see cref="EntryPointClient.ReconnectAsync(ReconnectMode, System.Func{uint, uint}?, System.Threading.CancellationToken)"/>.
+/// </summary>
+/// <param name="Kind">
+/// Whether the underlying session was reattached (same <c>SessionVerID</c>)
+/// or renegotiated (strictly-greater <c>SessionVerID</c>).
+/// </param>
+/// <param name="SessionVerId">
+/// The <c>SessionVerID</c> in effect after the reconnect. Equal to the
+/// pre-reconnect value when <paramref name="Kind"/> is
+/// <see cref="ReconnectKind.Reattached"/>; the new (selector-chosen) value
+/// when <see cref="ReconnectKind.Renegotiated"/>.
+/// </param>
+/// <param name="ServerNextSeqNoExpected">
+/// <c>NextSeqNo</c> reported by the peer's <c>EstablishmentAck</c> — the next
+/// inbound application sequence number the server intends to send. Always
+/// <c>0</c> on the <see cref="ReconnectKind.Renegotiated"/> path because the
+/// peer's outbound counter is reset to 1 across a new session (no
+/// retransmission window applies).
+/// </param>
+/// <param name="ServerLastIncomingSeqNoSeen">
+/// <c>LastIncomingSeqNo</c> reported by the peer's <c>EstablishmentAck</c> —
+/// the last outbound application sequence number the server confirms having
+/// received. Always <c>0</c> on the <see cref="ReconnectKind.Renegotiated"/>
+/// path.
+/// </param>
+/// <param name="RetransmitWindowReady">
+/// <c>true</c> when the <c>EstablishmentAck</c> indicates a gap in either
+/// direction relative to the client's local counters — i.e. when issuing a
+/// §4.7 <c>RetransmitRequest</c> (inbound gap) or re-sending outbound frames
+/// past <paramref name="ServerLastIncomingSeqNoSeen"/> is appropriate.
+/// Always <c>false</c> on the <see cref="ReconnectKind.Renegotiated"/> path.
+/// </param>
+public readonly record struct ReconnectOutcome(
+    ReconnectKind Kind,
+    uint SessionVerId,
+    ulong ServerNextSeqNoExpected,
+    ulong ServerLastIncomingSeqNoSeen,
+    bool RetransmitWindowReady);

--- a/src/B3.EntryPoint.Client/State/ISessionStateStore.cs
+++ b/src/B3.EntryPoint.Client/State/ISessionStateStore.cs
@@ -5,7 +5,7 @@ namespace B3.EntryPoint.Client.State;
 
 /// <summary>
 /// Snapshot of FIXP session state needed to perform a warm-restart via
-/// <see cref="EntryPointClient.ReconnectAsync"/>. Persisted via
+/// <see cref="EntryPointClient.ReconnectAsync(uint, System.Threading.CancellationToken)"/>. Persisted via
 /// <see cref="ISessionStateStore.SaveAsync"/>.
 /// </summary>
 public sealed record SessionSnapshot

--- a/tests/B3.EntryPoint.Client.Tests/Auth/CredentialsTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Auth/CredentialsTests.cs
@@ -1,0 +1,28 @@
+using B3.EntryPoint.Client.Auth;
+
+namespace B3.EntryPoint.Client.Tests.Auth;
+
+public class CredentialsTests
+{
+    /// <summary>
+    /// Schema 8.4.2 §720 caps <c>CredentialsEncoding.length</c> at
+    /// <c>uint8 maxValue="128"</c>. Constructing a longer Credentials
+    /// would emit an invalid varData length byte on the wire and the
+    /// gateway would reject Negotiate/Establish.
+    /// </summary>
+    [Fact]
+    public void Ctor_Throws_WhenPayloadExceedsSchemaMax()
+    {
+        var tooLong = new byte[Credentials.MaxLengthBytes + 1];
+        var ex = Assert.Throws<ArgumentException>(() => new Credentials(tooLong));
+        Assert.Contains("128", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_Accepts_AtSchemaMaxBoundary()
+    {
+        var atMax = new byte[Credentials.MaxLengthBytes];
+        var creds = new Credentials(atMax);
+        Assert.Equal(Credentials.MaxLengthBytes, creds.AsSpan().Length);
+    }
+}

--- a/tests/B3.EntryPoint.Client.Tests/ConnectFailureCleanupTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/ConnectFailureCleanupTests.cs
@@ -39,7 +39,7 @@ public class ConnectFailureCleanupTests
 
         await using var client = new EntryPointClient(Options(peer));
 
-        await Assert.ThrowsAsync<FixpRejectedException>(() => client.ConnectAsync());
+        await Assert.ThrowsAsync<FixpEstablishRejectedException>(() => client.ConnectAsync());
 
         // Internal state must be fully reset: _session and _tcp both null,
         // and the public State accessor must report Disconnected (which it
@@ -62,7 +62,7 @@ public class ConnectFailureCleanupTests
 
         await using var client = new EntryPointClient(Options(peer));
 
-        await Assert.ThrowsAsync<FixpRejectedException>(() => client.ConnectAsync());
+        await Assert.ThrowsAsync<FixpEstablishRejectedException>(() => client.ConnectAsync());
         Assert.False(client.HasActiveSessionForTesting);
 
         // Flip the peer back to accept-mode and reconnect. If the prior

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/FixpClientStateMachineTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/FixpClientStateMachineTests.cs
@@ -71,6 +71,33 @@ public class FixpClientStateMachineTests
         }
     }
 
+    /// <summary>
+    /// Spec §4.8 mirror of <c>SendTerminate</c>: when the PEER initiates the
+    /// teardown via an inbound <c>Terminate</c>, the state machine must
+    /// advance away from <see cref="FixpClientState.Established"/> so that
+    /// outbound app sends gated by <c>EnsureEstablished</c> in
+    /// <c>EntryPointClient</c> stop being accepted on a TCP socket the peer
+    /// is about to close.
+    /// </summary>
+    [Fact]
+    public void TerminateReceived_FromAnyLiveState_IsAllowed()
+    {
+        foreach (var live in new[]
+        {
+            FixpClientState.TcpConnected,
+            FixpClientState.Negotiating,
+            FixpClientState.Negotiated,
+            FixpClientState.Establishing,
+            FixpClientState.Established,
+        })
+        {
+            var sm = AdvanceTo(live);
+            Assert.True(sm.CanFire(FixpClientTrigger.TerminateReceived));
+            sm.Fire(FixpClientTrigger.TerminateReceived);
+            Assert.Equal(FixpClientState.Terminating, sm.State);
+        }
+    }
+
     [Fact]
     public void InvalidTransition_Throws()
     {

--- a/tests/B3.EntryPoint.Client.Tests/Framing/SofhFrameTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Framing/SofhFrameTests.cs
@@ -65,4 +65,22 @@ public class SofhFrameTests
         await Assert.ThrowsAsync<EndOfStreamException>(
             () => SofhFrameReader.ReadFrameAsync(ms, CancellationToken.None));
     }
+
+    /// <summary>
+    /// Schema §4.4 / FIX SOFH §3: only SBE 1.0 LE (encodingType 0xEB50) is
+    /// legal on a B3 EntryPoint session. Anything else must be rejected as
+    /// a framing protocol error so a malformed peer cannot trick us into
+    /// decoding garbage as a valid SBE payload.
+    /// </summary>
+    [Fact]
+    public async Task ReadFrameAsync_Throws_WhenEncodingTypeIsNotSbeLittleEndian()
+    {
+        // 12-byte frame with a bogus encodingType (zero).
+        var frame = new byte[12];
+        SofhFrameWriter.WriteHeader(frame, messageLength: 12, encodingType: 0x0000);
+        using var ms = new MemoryStream(frame);
+        var ex = await Assert.ThrowsAsync<InvalidDataException>(
+            () => SofhFrameReader.ReadFrameAsync(ms, CancellationToken.None));
+        Assert.Contains("encodingType", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/B3.EntryPoint.Client.Tests/ReconnectModeTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/ReconnectModeTests.cs
@@ -1,0 +1,178 @@
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.TestPeer;
+
+namespace B3.EntryPoint.Client.Tests;
+
+/// <summary>
+/// Coverage for #173: <see cref="EntryPointClient.ReconnectAsync(ReconnectMode, System.Func{uint,uint}?, CancellationToken)"/>.
+/// Spec-canonical reconnect should try <c>Establish</c> reusing the current
+/// <c>SessionVerID</c> first and fall back to <c>Negotiate</c> only when the
+/// gateway rejects with a recoverable code.
+/// </summary>
+public class ReconnectModeTests
+{
+    private static EntryPointClientOptions Options(InProcessFixpTestPeer peer) => new()
+    {
+        Endpoint = peer.LocalEndpoint,
+        SessionId = 42u,
+        SessionVerId = 1u,
+        EnteringFirm = 7u,
+        Credentials = Credentials.FromUtf8("k"),
+        KeepAliveIntervalMs = 60_000u,
+    };
+
+    [Fact]
+    public async Task Reconnect_EstablishReuseAccepted_ReturnsReattached_AndSurfacesAckCounters()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        peer.Start();
+
+        await using var client = new EntryPointClient(Options(peer));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        var outcome = await client.ReconnectAsync(ReconnectMode.EstablishReuseThenNegotiate, nextSessionVerIdSelector: null, cts.Token);
+
+        Assert.Equal(ReconnectKind.Reattached, outcome.Kind);
+        Assert.Equal(1u, outcome.SessionVerId);
+        Assert.False(outcome.RetransmitWindowReady,
+            "Default peer mirrors local counters → no gap → no retransmit window.");
+    }
+
+    [Fact]
+    public async Task Reconnect_EstablishReuseRejectedUnnegotiated_FallsBackToNegotiate()
+    {
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions
+        {
+            RejectEstablishWithoutPriorNegotiate = true,
+        });
+        peer.Start();
+
+        await using var client = new EntryPointClient(Options(peer));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        var outcome = await client.ReconnectAsync(
+            ReconnectMode.EstablishReuseThenNegotiate,
+            nextSessionVerIdSelector: prev => prev + 1u,
+            cts.Token);
+
+        Assert.Equal(ReconnectKind.Renegotiated, outcome.Kind);
+        Assert.Equal(2u, outcome.SessionVerId);
+    }
+
+    [Fact]
+    public async Task Reconnect_EstablishReuseRejectedRecoverable_InvokesSelectorOnceWithPreviousVerId()
+    {
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions
+        {
+            RejectEstablishWithoutPriorNegotiate = true,
+        });
+        peer.Start();
+
+        await using var client = new EntryPointClient(Options(peer));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        var observed = new List<uint>();
+        var outcome = await client.ReconnectAsync(
+            ReconnectMode.EstablishReuseThenNegotiate,
+            nextSessionVerIdSelector: prev =>
+            {
+                observed.Add(prev);
+                return prev + 10u;
+            },
+            cts.Token);
+
+        Assert.Equal(ReconnectKind.Renegotiated, outcome.Kind);
+        Assert.Equal(new[] { 1u }, observed);
+        Assert.Equal(11u, outcome.SessionVerId);
+    }
+
+    [Fact]
+    public async Task Reconnect_AlwaysNegotiate_BumpsSessionVerIdViaSelector()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        peer.Start();
+
+        await using var client = new EntryPointClient(Options(peer));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        var outcome = await client.ReconnectAsync(
+            ReconnectMode.AlwaysNegotiate,
+            nextSessionVerIdSelector: prev => prev + 1u,
+            cts.Token);
+
+        Assert.Equal(ReconnectKind.Renegotiated, outcome.Kind);
+        Assert.Equal(2u, outcome.SessionVerId);
+        Assert.False(outcome.RetransmitWindowReady,
+            "AlwaysNegotiate path resets counters on the wire → no in-band retransmit.");
+    }
+
+    [Fact]
+    public async Task Reconnect_EstablishReuseAccepted_InboundGapDetected_FlagsRetransmitWindowReady()
+    {
+        // Force the peer's EstablishmentAck to advertise a NextSeqNo > what
+        // the client has seen so far → inbound gap → RetransmitWindowReady.
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions
+        {
+            EstablishAckNextSeqNoOverride = 42u,
+        });
+        peer.Start();
+
+        await using var client = new EntryPointClient(Options(peer));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        var outcome = await client.ReconnectAsync(
+            ReconnectMode.EstablishReuseThenNegotiate,
+            nextSessionVerIdSelector: null,
+            cts.Token);
+
+        Assert.Equal(ReconnectKind.Reattached, outcome.Kind);
+        Assert.True(outcome.RetransmitWindowReady,
+            "Server's NextSeqNo ahead of client's last contiguous inbound → gap detected.");
+        Assert.Equal(42ul, outcome.ServerNextSeqNoExpected);
+    }
+
+    [Fact]
+    public async Task Reconnect_EstablishReuseAccepted_NoGap_DoesNotFlagRetransmitWindow()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        peer.Start();
+
+        await using var client = new EntryPointClient(Options(peer));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        var outcome = await client.ReconnectAsync(
+            ReconnectMode.EstablishReuseThenNegotiate,
+            nextSessionVerIdSelector: null,
+            cts.Token);
+
+        Assert.Equal(ReconnectKind.Reattached, outcome.Kind);
+        Assert.False(outcome.RetransmitWindowReady);
+    }
+
+    [Fact]
+    public async Task Reconnect_EstablishReuseRejectedHardCode_ThrowsWithoutFallback()
+    {
+        // CREDENTIALS is in the spec's "hard" reject bucket — no auto-renegotiate.
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions
+        {
+            EstablishRejectAfter = 2,
+            EstablishRejectCodeOverride = B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.CREDENTIALS,
+        });
+        peer.Start();
+
+        await using var client = new EntryPointClient(Options(peer));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        var ex = await Assert.ThrowsAsync<FixpEstablishRejectedException>(
+            () => client.ReconnectAsync(ReconnectMode.EstablishReuseThenNegotiate, null, cts.Token));
+        Assert.Equal(B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.CREDENTIALS, ex.Code);
+    }
+}

--- a/tests/B3.EntryPoint.Client.Tests/ReconnectModeTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/ReconnectModeTests.cs
@@ -175,4 +175,126 @@ public class ReconnectModeTests
             () => client.ReconnectAsync(ReconnectMode.EstablishReuseThenNegotiate, null, cts.Token));
         Assert.Equal(B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.CREDENTIALS, ex.Code);
     }
+
+    /// <summary>
+    /// Regression for the GPT-5.5 review BLOCKER on PR #174: when the
+    /// Establish-reuse attempt is rejected (recoverable), the rejected
+    /// session's zero counters MUST NOT overwrite the good snapshot that
+    /// was persisted when the prior live session was torn down. Otherwise
+    /// a crash between reject and the fallback Negotiate would resurrect
+    /// a corrupted state on restart.
+    /// </summary>
+    [Fact]
+    public async Task Reconnect_EstablishReuseRejected_DoesNotCorruptPersistedSnapshot()
+    {
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions
+        {
+            RejectEstablishWithoutPriorNegotiate = true,
+        });
+        peer.Start();
+
+        // Pre-seed the store with a snapshot that carries a non-zero outbound
+        // counter so we can detect any clobber-to-zero on the rejected reuse
+        // teardown.
+        var store = new SnapshotRecordingStore
+        {
+            Preseeded = new B3.EntryPoint.Client.State.SessionSnapshot
+            {
+                SessionId = 42u,
+                SessionVerId = 1u,
+                LastOutboundSeqNum = 42u,
+                LastInboundSeqNum = 7u,
+                CapturedAt = DateTimeOffset.UtcNow,
+            },
+        };
+        var options = Options(peer);
+        options.SessionStateStore = store;
+        await using var client = new EntryPointClient(options);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        var outcome = await client.ReconnectAsync(
+            ReconnectMode.EstablishReuseThenNegotiate,
+            nextSessionVerIdSelector: prev => prev + 1u,
+            cts.Token);
+
+        Assert.Equal(ReconnectKind.Renegotiated, outcome.Kind);
+
+        // Snapshots persisted while still on SessionVerId=1 must NEVER carry
+        // a smaller outbound counter than the pre-seeded value. A zero would
+        // indicate the rejected-reuse session corrupted the snapshot.
+        foreach (var snap in store.Saved)
+        {
+            if (snap.SessionVerId == 1u)
+                Assert.True(snap.LastOutboundSeqNum >= 42u,
+                    $"Snapshot for SessionVerId=1 dropped LastOutboundSeqNum to {snap.LastOutboundSeqNum} (expected >= 42). " +
+                    "The rejected Establish-reuse session's zero counters were persisted, corrupting state.");
+        }
+    }
+
+    /// <summary>
+    /// Regression for the GPT-5.5 review SHOULD-FIX on PR #174: the
+    /// Establish-reuse path must advertise <c>NextSeqNo =
+    /// localLastAssignedOutbound + 1</c>, not hard-coded <c>1</c>. Hard-coded
+    /// 1 looks like a rewind to the gateway, which echoes
+    /// <c>LastIncomingSeqNo = 0</c> in the EstablishmentAck and tricks the
+    /// client into flagging <see cref="ReconnectOutcome.RetransmitWindowReady"/>
+    /// for a non-existent gap.
+    /// </summary>
+    [Fact]
+    public async Task Reconnect_EstablishReuseAccepted_AfterAppFrames_AdvertisesLocalOutboundNextSeqNo()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        peer.Start();
+
+        // Pre-seed an outbound counter > 0 to simulate the post-app-frame
+        // state. Hydration on ConnectAsync resumes the session counter to 42.
+        var store = new SnapshotRecordingStore
+        {
+            Preseeded = new B3.EntryPoint.Client.State.SessionSnapshot
+            {
+                SessionId = 42u,
+                SessionVerId = 1u,
+                LastOutboundSeqNum = 42u,
+                LastInboundSeqNum = 0u,
+                CapturedAt = DateTimeOffset.UtcNow,
+            },
+        };
+        var options = Options(peer);
+        options.SessionStateStore = store;
+        await using var client = new EntryPointClient(options);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        var outcome = await client.ReconnectAsync(
+            ReconnectMode.EstablishReuseThenNegotiate,
+            nextSessionVerIdSelector: null,
+            cts.Token);
+
+        Assert.Equal(ReconnectKind.Reattached, outcome.Kind);
+        // Peer echoes LastIncomingSeqNo = request.NextSeqNo - 1. After fix
+        // we advertise 43, so the peer reports 42 — matching local outbound,
+        // no outbound gap.
+        Assert.Equal(42ul, outcome.ServerLastIncomingSeqNoSeen);
+        Assert.False(outcome.RetransmitWindowReady,
+            "Both sides agree on the outbound count → no retransmit window.");
+    }
+
+    private sealed class SnapshotRecordingStore : B3.EntryPoint.Client.State.ISessionStateStore
+    {
+        public B3.EntryPoint.Client.State.SessionSnapshot? Preseeded { get; set; }
+        public System.Collections.Concurrent.ConcurrentQueue<B3.EntryPoint.Client.State.SessionSnapshot> Saved { get; } = new();
+
+        public ValueTask<B3.EntryPoint.Client.State.SessionSnapshot?> LoadAsync(CancellationToken ct = default)
+            => new(Preseeded);
+        public ValueTask SaveAsync(B3.EntryPoint.Client.State.SessionSnapshot snapshot, CancellationToken ct = default)
+        {
+            Saved.Enqueue(snapshot);
+            Preseeded = snapshot;
+            return default;
+        }
+        public ValueTask AppendDeltaAsync(B3.EntryPoint.Client.State.SessionDelta delta, CancellationToken ct = default) => default;
+        public ValueTask<B3.EntryPoint.Client.State.SessionSnapshot?> ReplayAsync(CancellationToken ct = default) => new(Preseeded);
+        public ValueTask CompactAsync(CancellationToken ct = default) => default;
+    }
 }

--- a/tests/B3.EntryPoint.Conformance/Spec_4_5_Negotiate/ReconnectRejectTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_5_Negotiate/ReconnectRejectTests.cs
@@ -27,7 +27,7 @@ public class ReconnectRejectTests
         await client.ConnectAsync();
         Assert.Equal(FixpClientState.Established, client.State);
 
-        await Assert.ThrowsAsync<FixpRejectedException>(
+        await Assert.ThrowsAsync<FixpEstablishRejectedException>(
             async () => await client.ReconnectAsync(fx.ClientOptions.SessionVerId + 1));
     }
 }

--- a/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/ReconnectRetransmitTests.cs
+++ b/tests/B3.EntryPoint.Conformance/Spec_4_7_Retransmit/ReconnectRetransmitTests.cs
@@ -32,7 +32,7 @@ namespace B3.EntryPoint.Conformance.Spec_4_7_Retransmit;
 /// <c>_lastInboundSeqNum</c> as a running max — a gap (e.g. inbound seqs
 /// arriving as <c>1, 2, 4, 5</c>) silently advances the counter to <c>5</c>
 /// without ever surfacing a §4.7 <c>RetransmitRequest</c>, and
-/// <see cref="EntryPointClient.ReconnectAsync"/> bumps SessionVerID, which
+/// <see cref="EntryPointClient.ReconnectAsync(uint, System.Threading.CancellationToken)"/> bumps SessionVerID, which
 /// resets the peer's outbound counter to 1, making a same-session retransmit
 /// out of band anyway. Filed as a follow-up issue (see test note below);
 /// the assertion is intentionally commented out so this test stays a


### PR DESCRIPTION
Closes #173.

## Summary
Adds a new `ReconnectAsync(ReconnectMode, Func<uint,uint>?, CancellationToken)` overload on `EntryPointClient` / `IEntryPointClient` that performs the FIXP spec's TCP-blip recovery flow:

1. **`EstablishReuseThenNegotiate`** (recommended): sends `Establish` reusing the current `SessionVerID` first. If the gateway accepts, the session reattaches without rotating the version (and `ReconnectOutcome.RetransmitWindowReady` advertises whether the EstablishmentAck shows a recoverable gap). If the gateway returns a recoverable reject (`UNNEGOTIATED`, `ALREADY_ESTABLISHED`, `SESSION_BLOCKED`, `INVALID_SESSIONID`, `INVALID_SESSIONVERID`, `ESTABLISH_ATTEMPTS_EXCEEDED`), the client falls back to a fresh `Negotiate` with a strictly-greater `SessionVerID` picked via the caller-supplied selector. Hard rejects (`CREDENTIALS`, `PROTOCOL_VERSION_NOT_SUPPORTED`, …) propagate as `FixpEstablishRejectedException` with the reject code attached.
2. **`AlwaysNegotiate`**: matches the existing v0.14.3 behaviour — always renegotiates.

The legacy `ReconnectAsync(uint, CancellationToken)` is preserved and now delegates to the new overload with `AlwaysNegotiate` + a constant selector, so no consumer needs to change.

## Why
Downstream (`B3TradingPlatform`) is currently forced to burn a `SessionVerID` on every transient TCP drop because the SDK has no Establish-reuse path. Issue #173 details the rationale — the spec's intent is for `Negotiate` to be the rare, version-bumping setup, while `Establish` is the cheap per-TCP-blip reattach.

## Public API additions (`B3.EntryPoint.Client`)
- `enum ReconnectMode { EstablishReuseThenNegotiate, AlwaysNegotiate }`
- `enum ReconnectKind { Reattached, Renegotiated }`
- `readonly record struct ReconnectOutcome(Kind, SessionVerId, ServerNextSeqNoExpected, ServerLastIncomingSeqNoSeen, RetransmitWindowReady)`
- `Task<ReconnectOutcome> ReconnectAsync(ReconnectMode, Func<uint,uint>?, CancellationToken)` on `EntryPointClient` and `IEntryPointClient`
- `FixpEstablishRejectedException : FixpRejectedException` exposing `.Code`

All entries added to `PublicAPI.Unshipped.txt`.

## TestPeer additions (`B3.EntryPoint.Client.TestPeer`)
- `TestPeerOptions.RejectEstablishWithoutPriorNegotiate` — simulates the spec's "Establish on a fresh TCP without Negotiate ⇒ UNNEGOTIATED".
- `TestPeerOptions.EstablishAckNextSeqNoOverride` / `EstablishAckLastIncomingSeqNoOverride` — force a gap in the EstablishmentAck so tests can pin down `RetransmitWindowReady`.

## Tests
7 new tests in `tests/B3.EntryPoint.Client.Tests/ReconnectModeTests.cs`:
1. `Reconnect_EstablishReuseAccepted_ReturnsReattached_AndSurfacesAckCounters`
2. `Reconnect_EstablishReuseRejectedUnnegotiated_FallsBackToNegotiate`
3. `Reconnect_EstablishReuseRejectedRecoverable_InvokesSelectorOnceWithPreviousVerId`
4. `Reconnect_AlwaysNegotiate_BumpsSessionVerIdViaSelector`
5. `Reconnect_EstablishReuseAccepted_InboundGapDetected_FlagsRetransmitWindowReady`
6. `Reconnect_EstablishReuseAccepted_NoGap_DoesNotFlagRetransmitWindow`
7. `Reconnect_EstablishReuseRejectedHardCode_ThrowsWithoutFallback`

Two existing tests updated to assert the new `FixpEstablishRejectedException` subtype on Establish rejects.

## Verification
```
dotnet restore SbeB3EntryPointClient.slnx
dotnet build   SbeB3EntryPointClient.slnx --no-restore -c Release    # 0 errors, 0 warnings
dotnet test    SbeB3EntryPointClient.slnx --no-build   -c Release    # 182 passed, 20 conformance skipped (no peer env)
dotnet format  SbeB3EntryPointClient.slnx --verify-no-changes --no-restore --severity warn   # clean
```

## Out of scope
- `B3MatchingPlatform` server-side support (tracked separately).
- `B3TradingPlatform` consumer migration (tracked separately).
