### PR TITLE
fix(wire): enforce §4.7 Retransmission.Count bound on inbound replay window

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -68,6 +68,31 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     private readonly SortedSet<ulong> _pendingInboundSeqs = new();
     private bool _gapRequestInFlight;
 
+    // ---- In-retransmission-window tracking (#175) ---------------------------
+    // FIXP §4.7: an inbound Retransmission(NextSeqNo, Count) frame promises the
+    // peer will deliver exactly Count app frames with seqs
+    // [NextSeqNo, NextSeqNo+Count). _activeRetransmission tracks the bounded
+    // reply burst so the client can detect protocol violations:
+    //   * peer over- or under-delivers vs declared Count,
+    //   * peer interleaves a new bounded reply before completing the previous,
+    //   * peer sends a non-retransmitted (live) seq while the reply is open.
+    // None of these conditions is fatal — they're logged at Warning and the
+    // contiguity tracker above keeps doing the right thing — but they're
+    // observable regressions a wire-puro client should not silently absorb.
+    private RetransmissionWindow? _activeRetransmission;
+
+    private readonly record struct RetransmissionWindow(
+        ulong NextSeqNo,
+        uint Count,
+        uint Received,
+        ulong ExpectedSeq,
+        bool Completed,
+        ulong RequestNanos)
+    {
+        public ulong LastSeqInWindow => NextSeqNo + Count - 1UL;
+        public bool Contains(ulong seq) => seq >= NextSeqNo && seq <= LastSeqInWindow;
+    }
+
     /// <summary>
     /// Persistence operation enqueued from the inbound loop and drained by a
     /// single dedicated worker per session lifetime. Replaces the legacy
@@ -278,7 +303,37 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             // The retransmitted frames themselves flow through the inbound
             // loop and OnInboundEventForPersistence advances the contiguous
             // tail accordingly. (#138)
-            lock (_inboundGapGate) { _gapRequestInFlight = false; }
+            lock (_inboundGapGate)
+            {
+                _gapRequestInFlight = false;
+                // #175: install / replace the bounded-reply window so the
+                // contiguity tracker can count frames against the declared
+                // Count and surface peer protocol violations.
+                if (count > 0)
+                {
+                    if (_activeRetransmission is { } prior && !prior.Completed)
+                    {
+                        _options.Logger.RetransmissionWindowUnderDelivered(
+                            prior.NextSeqNo, prior.Count, prior.Received);
+                        _options.Logger.RetransmissionWindowOverlapped(
+                            prior.NextSeqNo, prior.Count, prior.Received,
+                            nextSeq, count);
+                    }
+                    _activeRetransmission = new RetransmissionWindow(
+                        NextSeqNo: nextSeq,
+                        Count: count,
+                        Received: 0u,
+                        ExpectedSeq: nextSeq,
+                        Completed: false,
+                        RequestNanos: reqNanos);
+                }
+                else
+                {
+                    // count==0 is a no-op completion; clear any stale window
+                    // so we don't keep accounting against a phantom reply.
+                    _activeRetransmission = null;
+                }
+            }
             _retransmit!.RaiseRetransmissionReceived(nextSeq, count, NanosToOffset(reqNanos));
         };
         _session.OnInboundRetransmitReject = (code, reqNanos) =>
@@ -286,7 +341,14 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             _lastInboundUtc = DateTime.UtcNow;
             // Reject clears the in-flight flag — a later gap may need to
             // re-request after a transient peer-side condition lifts. (#138)
-            lock (_inboundGapGate) { _gapRequestInFlight = false; }
+            // It also tears down any in-progress retransmission window
+            // because the peer is no longer going to deliver the declared
+            // Count frames. (#175)
+            lock (_inboundGapGate)
+            {
+                _gapRequestInFlight = false;
+                _activeRetransmission = null;
+            }
             _retransmit!.RaiseRetransmitRejected((B3.EntryPoint.Client.Fixp.RetransmitRejectCode)(byte)code, NanosToOffset(reqNanos));
         };
         _session.OnInboundNotApplied = (from, count) =>
@@ -423,6 +485,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             _highestInboundSeqNum = snapshot.LastInboundSeqNum;
             _pendingInboundSeqs.Clear();
             _gapRequestInFlight = false;
+            _activeRetransmission = null;
         }
         _outstandingOrders.Clear();
         _outstandingQuoteFlowIds.Clear();
@@ -559,6 +622,71 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         {
             var seq = evt.SeqNum;
             if (seq > _highestInboundSeqNum) _highestInboundSeqNum = seq;
+
+            // #175: account this frame against any active retransmission
+            // window before contiguity bookkeeping. Per §4.7 the burst is
+            // strictly ordered: peer must send seqs NextSeqNo, NextSeqNo+1,
+            // ..., NextSeqNo+Count-1 — exactly Count frames, one per seq.
+            // Any deviation (duplicate inside burst, missing seq, seq out of
+            // range, more frames than declared) is a peer protocol violation
+            // we log but do not act on beyond that. The window stays open
+            // after reaching Count (Completed=true) so we can distinguish a
+            // legitimate next-live frame at NextSeqNo+Count from an extra
+            // in-range frame (genuine over-delivery).
+            if (_activeRetransmission is { } window)
+            {
+                if (!window.Completed && seq == window.ExpectedSeq)
+                {
+                    var nextExpected = window.ExpectedSeq + 1UL;
+                    var received = window.Received + 1u;
+                    var completed = received >= window.Count;
+                    if (completed)
+                    {
+                        _options.Logger.RetransmissionWindowCompleted(
+                            window.NextSeqNo, window.Count);
+                    }
+                    _activeRetransmission = window with
+                    {
+                        Received = received,
+                        ExpectedSeq = nextExpected,
+                        Completed = completed,
+                    };
+                }
+                else if (window.Contains(seq))
+                {
+                    // Seq is inside the declared range. Two flavors:
+                    //   * window not yet Completed → duplicate or
+                    //     out-of-order (logged as out-of-sequence).
+                    //   * window already Completed → genuine over-delivery
+                    //     (peer sent an extra frame in the bounded range
+                    //     after fulfilling the declared count).
+                    if (window.Completed)
+                    {
+                        _options.Logger.RetransmissionWindowOverDelivered(
+                            window.NextSeqNo, window.Count, seq);
+                    }
+                    else
+                    {
+                        _options.Logger.RetransmissionFrameOutOfSequence(
+                            window.NextSeqNo, window.Count, window.Received,
+                            window.ExpectedSeq, seq);
+                    }
+                }
+                else
+                {
+                    // Seq is outside [NextSeqNo, NextSeqNo+Count). Two cases:
+                    //   * window not Completed → peer terminated the burst
+                    //     early; under-delivery.
+                    //   * window Completed → this is normal next-live
+                    //     traffic; close silently.
+                    if (!window.Completed)
+                    {
+                        _options.Logger.RetransmissionWindowUnderDelivered(
+                            window.NextSeqNo, window.Count, window.Received);
+                    }
+                    _activeRetransmission = null;
+                }
+            }
 
             if (seq == _lastContiguousInboundSeqNum + 1UL)
             {
@@ -697,6 +825,34 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     {
         lock (_inboundGapGate)
             return (_lastContiguousInboundSeqNum, _highestInboundSeqNum, _pendingInboundSeqs.Count, _gapRequestInFlight);
+    }
+
+    // #175
+    internal void OpenRetransmissionWindowForTesting(ulong nextSeqNo, uint count, ulong requestNanos = 0UL)
+    {
+        lock (_inboundGapGate)
+        {
+            if (count == 0u)
+            {
+                _activeRetransmission = null;
+                return;
+            }
+            if (_activeRetransmission is { } prior && !prior.Completed)
+            {
+                _options.Logger.RetransmissionWindowUnderDelivered(
+                    prior.NextSeqNo, prior.Count, prior.Received);
+                _options.Logger.RetransmissionWindowOverlapped(
+                    prior.NextSeqNo, prior.Count, prior.Received,
+                    nextSeqNo, count);
+            }
+            _activeRetransmission = new RetransmissionWindow(nextSeqNo, count, 0u, nextSeqNo, false, requestNanos);
+        }
+    }
+
+    internal (ulong nextSeqNo, uint count, uint received, bool completed)? GetRetransmissionWindowForTesting()
+    {
+        lock (_inboundGapGate)
+            return _activeRetransmission is { } w ? (w.NextSeqNo, w.Count, w.Received, w.Completed) : null;
     }
     internal void RaiseInboundGapAtReconnectForTesting(ulong fromSeqNo, uint count, ulong priorSessionVerId)
         => InboundGapAtReconnect?.Invoke(this, new InboundGapAtReconnectEventArgs(fromSeqNo, count, priorSessionVerId));
@@ -1236,6 +1392,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             _highestInboundSeqNum = 0UL;
             _pendingInboundSeqs.Clear();
             _gapRequestInFlight = false;
+            _activeRetransmission = null;
         }
 
         _options.SessionVerId = next;

--- a/src/B3.EntryPoint.Client/Logging/LogMessages.cs
+++ b/src/B3.EntryPoint.Client/Logging/LogMessages.cs
@@ -151,6 +151,26 @@ internal static partial class LogMessages
         Message = "Inbound frame with unknown SBE templateId={TemplateId} ({FrameLength} bytes) — frame dropped, session continues")]
     public static partial void UnknownInboundTemplateId(this ILogger logger, int templateId, int frameLength);
 
+    [LoggerMessage(EventId = 4016, Level = LogLevel.Information,
+        Message = "Retransmission window completed: nextSeqNo={NextSeqNo} count={Count}")]
+    public static partial void RetransmissionWindowCompleted(this ILogger logger, ulong nextSeqNo, uint count);
+
+    [LoggerMessage(EventId = 4017, Level = LogLevel.Warning,
+        Message = "Retransmission window overlapped by new bounded reply: prior nextSeqNo={PriorNextSeqNo} count={PriorCount} received={PriorReceived}; new nextSeqNo={NewNextSeqNo} count={NewCount}")]
+    public static partial void RetransmissionWindowOverlapped(this ILogger logger, ulong priorNextSeqNo, uint priorCount, uint priorReceived, ulong newNextSeqNo, uint newCount);
+
+    [LoggerMessage(EventId = 4018, Level = LogLevel.Warning,
+        Message = "Retransmission frame out of sequence: window nextSeqNo={NextSeqNo} count={Count} received={Received} expected seq={ExpectedSeq}, got seq={Seq}")]
+    public static partial void RetransmissionFrameOutOfSequence(this ILogger logger, ulong nextSeqNo, uint count, uint received, ulong expectedSeq, ulong seq);
+
+    [LoggerMessage(EventId = 4019, Level = LogLevel.Warning,
+        Message = "Retransmission window under-delivered: nextSeqNo={NextSeqNo} declared count={Count}, received={Received} — peer promised more frames than it sent")]
+    public static partial void RetransmissionWindowUnderDelivered(this ILogger logger, ulong nextSeqNo, uint count, uint received);
+
+    [LoggerMessage(EventId = 4020, Level = LogLevel.Warning,
+        Message = "Retransmission window over-delivered: nextSeqNo={NextSeqNo} declared count={Count}, extra seq={Seq} arrived after completion")]
+    public static partial void RetransmissionWindowOverDelivered(this ILogger logger, ulong nextSeqNo, uint count, ulong seq);
+
     // ---------------- Error (5000–5999) ----------------
 
     [LoggerMessage(EventId = 5000, Level = LogLevel.Error,

--- a/tests/B3.EntryPoint.Client.Tests/RetransmissionWindowUnitTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/RetransmissionWindowUnitTests.cs
@@ -1,0 +1,192 @@
+using System.Linq;
+using System.Net;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace B3.EntryPoint.Client.Tests;
+
+/// <summary>
+/// Unit tests for the bounded retransmission window introduced in #175.
+/// FIXP §4.7: an inbound <c>Retransmission(NextSeqNo, Count)</c> envelope
+/// promises the peer will deliver exactly <c>Count</c> ordered app frames
+/// with seqs <c>NextSeqNo, NextSeqNo+1, ..., NextSeqNo+Count-1</c>. The
+/// client tracks the bounded reply so it can detect protocol violations
+/// (under-/over-delivery, overlapping replies, out-of-sequence seqs)
+/// without silently absorbing them.
+/// </summary>
+public class RetransmissionWindowUnitTests
+{
+    private static EntryPointClientOptions BaseOptions(ILogger? logger = null)
+    {
+        var opts = new EntryPointClientOptions
+        {
+            Endpoint = new IPEndPoint(IPAddress.Loopback, 1),
+            SessionId = 42u,
+            SessionVerId = 1u,
+            EnteringFirm = 7u,
+            Credentials = Credentials.FromUtf8("k"),
+        };
+        if (logger is not null)
+            opts.Logger = logger;
+        return opts;
+    }
+
+    private static bool HasEvent(FakeLogger fake, int id) =>
+        fake.Collector.GetSnapshot().Any(e => e.Id.Id == id);
+
+    private static EntryPointEvent FakeAck(ulong seq) => new OrderAccepted
+    {
+        SeqNum = seq,
+        SendingTime = DateTimeOffset.UnixEpoch,
+        ClOrdID = new ClOrdID(seq),
+        OrderId = seq,
+        OrderStatus = OrderStatus.New,
+        SecurityId = 1UL,
+        Side = Side.Buy,
+    };
+
+    [Fact]
+    public void Window_OpensOnNonZeroCount_ClosesAfterExactlyCountOrderedFrames()
+    {
+        var fake = new FakeLogger();
+        var client = new EntryPointClient(BaseOptions(fake));
+        client.SetInboundGapStateForTesting(contiguous: 2UL, highest: 5UL);
+        client.OpenRetransmissionWindowForTesting(nextSeqNo: 3UL, count: 3u);
+
+        Assert.Equal((3UL, 3u, 0u, false), client.GetRetransmissionWindowForTesting());
+        client.HandleInboundEventForTesting(FakeAck(3));
+        Assert.Equal((3UL, 3u, 1u, false), client.GetRetransmissionWindowForTesting());
+        client.HandleInboundEventForTesting(FakeAck(4));
+        Assert.Equal((3UL, 3u, 2u, false), client.GetRetransmissionWindowForTesting());
+        // Reaching Count flips Completed=true but the window stays installed
+        // so an extra in-range frame can be classified as over-delivery.
+        client.HandleInboundEventForTesting(FakeAck(5));
+        Assert.Equal((3UL, 3u, 3u, true), client.GetRetransmissionWindowForTesting());
+        // 4016 = RetransmissionWindowCompleted (Information)
+        Assert.True(HasEvent(fake, 4016));
+        // First out-of-range frame after completion is normal live traffic
+        // and closes the window silently.
+        client.HandleInboundEventForTesting(FakeAck(6));
+        Assert.Null(client.GetRetransmissionWindowForTesting());
+        // No under-/over-delivery on a clean completion + live continuation.
+        Assert.False(HasEvent(fake, 4019));
+        Assert.False(HasEvent(fake, 4020));
+    }
+
+    [Fact]
+    public void Window_NotOpenedWhenCountIsZero()
+    {
+        var client = new EntryPointClient(BaseOptions());
+        client.OpenRetransmissionWindowForTesting(nextSeqNo: 10UL, count: 0u);
+        Assert.Null(client.GetRetransmissionWindowForTesting());
+    }
+
+    [Fact]
+    public void Window_DuplicateSeqInsideRange_DoesNotAdvanceCounter()
+    {
+        var fake = new FakeLogger();
+        var client = new EntryPointClient(BaseOptions(fake));
+        client.SetInboundGapStateForTesting(contiguous: 2UL, highest: 5UL);
+        client.OpenRetransmissionWindowForTesting(nextSeqNo: 3UL, count: 3u);
+
+        client.HandleInboundEventForTesting(FakeAck(3));
+        Assert.Equal((3UL, 3u, 1u, false), client.GetRetransmissionWindowForTesting());
+
+        // Duplicate of last delivered seq → out-of-sequence, no advance.
+        client.HandleInboundEventForTesting(FakeAck(3));
+        Assert.Equal((3UL, 3u, 1u, false), client.GetRetransmissionWindowForTesting());
+
+        // Skip-ahead inside range (expected 4, got 5) → out-of-sequence.
+        client.HandleInboundEventForTesting(FakeAck(5));
+        Assert.Equal((3UL, 3u, 1u, false), client.GetRetransmissionWindowForTesting());
+        // 4018 = RetransmissionFrameOutOfSequence
+        Assert.True(HasEvent(fake, 4018));
+    }
+
+    [Fact]
+    public void Window_OutOfWindowSeqBeforeCompletion_TerminatesAsUnderDelivered()
+    {
+        var fake = new FakeLogger();
+        var client = new EntryPointClient(BaseOptions(fake));
+        client.SetInboundGapStateForTesting(contiguous: 2UL, highest: 5UL);
+        client.OpenRetransmissionWindowForTesting(nextSeqNo: 3UL, count: 3u);
+
+        client.HandleInboundEventForTesting(FakeAck(3));
+        client.HandleInboundEventForTesting(FakeAck(4));
+        Assert.Equal((3UL, 3u, 2u, false), client.GetRetransmissionWindowForTesting());
+
+        // Peer skips seq 5 and jumps to live seq 99 — burst terminated
+        // early (Count-1 frames). Window closes with under-delivery.
+        client.HandleInboundEventForTesting(FakeAck(99));
+        Assert.Null(client.GetRetransmissionWindowForTesting());
+        // 4019 = RetransmissionWindowUnderDelivered
+        Assert.True(HasEvent(fake, 4019));
+    }
+
+    [Fact]
+    public void Window_OverDelivery_DetectedWhenExtraInRangeFrameArrivesAfterCompletion()
+    {
+        var fake = new FakeLogger();
+        var client = new EntryPointClient(BaseOptions(fake));
+        client.SetInboundGapStateForTesting(contiguous: 2UL, highest: 5UL);
+        client.OpenRetransmissionWindowForTesting(nextSeqNo: 3UL, count: 2u);
+
+        client.HandleInboundEventForTesting(FakeAck(3));
+        client.HandleInboundEventForTesting(FakeAck(4));
+        // Count reached but window stays installed in Completed state.
+        Assert.Equal((3UL, 2u, 2u, true), client.GetRetransmissionWindowForTesting());
+
+        // Peer re-sends a seq still inside [3,4] — genuine over-delivery
+        // (extra Retransmission frame beyond declared Count). Window stays
+        // open until the next out-of-range frame closes it.
+        client.HandleInboundEventForTesting(FakeAck(3));
+        Assert.Equal((3UL, 2u, 2u, true), client.GetRetransmissionWindowForTesting());
+        // 4020 = RetransmissionWindowOverDelivered
+        Assert.True(HasEvent(fake, 4020));
+
+        // Next-live frame at NextSeqNo+Count closes the window cleanly.
+        client.HandleInboundEventForTesting(FakeAck(5));
+        Assert.Null(client.GetRetransmissionWindowForTesting());
+    }
+
+    [Fact]
+    public void Window_OverlappedByNewReply_ReplacesAndResetsReceived()
+    {
+        var fake = new FakeLogger();
+        var client = new EntryPointClient(BaseOptions(fake));
+        client.SetInboundGapStateForTesting(contiguous: 2UL, highest: 5UL);
+
+        client.OpenRetransmissionWindowForTesting(nextSeqNo: 3UL, count: 5u);
+        client.HandleInboundEventForTesting(FakeAck(3));
+        Assert.Equal((3UL, 5u, 1u, false), client.GetRetransmissionWindowForTesting());
+
+        // Peer opens a NEW bounded reply before the previous one completes
+        // (protocol violation). Previous window is replaced; counters reset.
+        // Production-path mirrored: logs BOTH 4019 (under-delivery of prior)
+        // AND 4017 (overlap).
+        client.OpenRetransmissionWindowForTesting(nextSeqNo: 10UL, count: 2u);
+        Assert.Equal((10UL, 2u, 0u, false), client.GetRetransmissionWindowForTesting());
+        Assert.True(HasEvent(fake, 4019));
+        Assert.True(HasEvent(fake, 4017));
+
+        client.HandleInboundEventForTesting(FakeAck(10));
+        client.HandleInboundEventForTesting(FakeAck(11));
+        Assert.Equal((10UL, 2u, 2u, true), client.GetRetransmissionWindowForTesting());
+    }
+
+    [Fact]
+    public void Window_PartialDelivery_StaysOpenUntilOutOfRangeFrame()
+    {
+        var client = new EntryPointClient(BaseOptions());
+        client.SetInboundGapStateForTesting(contiguous: 2UL, highest: 5UL);
+        client.OpenRetransmissionWindowForTesting(nextSeqNo: 3UL, count: 3u);
+
+        client.HandleInboundEventForTesting(FakeAck(3));
+        client.HandleInboundEventForTesting(FakeAck(4));
+        Assert.Equal((3UL, 3u, 2u, false), client.GetRetransmissionWindowForTesting());
+        // No out-of-range frame yet — window still open, awaiting seq 5.
+        Assert.NotNull(client.GetRetransmissionWindowForTesting());
+    }
+}


### PR DESCRIPTION
Closes #175.

Per FIXP §4.7, an inbound `Retransmission(NextSeqNo, Count)` frame promises the peer will deliver exactly `Count` ordered application frames with seqs `NextSeqNo..NextSeqNo+Count-1`. Before this change the client just let those frames flow through the contiguity tracker; protocol violations were silently absorbed.

## Behavior

The new `RetransmissionWindow` tracks the bounded reply and classifies every inbound app frame:

| Condition | Action | Event |
|---|---|---|
| `!Completed && seq == ExpectedSeq` | advance; at `Received==Count` flip `Completed=true` | 4016 `RetransmissionWindowCompleted` (Info) |
| `!Completed && Contains(seq) && seq != ExpectedSeq` | no advance | 4018 `RetransmissionFrameOutOfSequence` (Warn) |
| `!Completed && !Contains(seq)` | close window | 4019 `RetransmissionWindowUnderDelivered` (Warn) |
| `Completed && Contains(seq)` | keep open; allow further classification | 4020 `RetransmissionWindowOverDelivered` (Warn) |
| `Completed && !Contains(seq)` | close silently — normal live continuation | — |
| new `Retransmission` while previous `!Completed` | replace; report violation of prior | 4019 + 4017 `RetransmissionWindowOverlapped` |
| `RetransmitReject` | clear in-flight + window | — |
| snapshot rehydrate / renegotiate | clear window | — |

The window also stays open after `Received == Count` so genuine over-delivery (Count+1 in-range frames) is detectable; the very next out-of-window seq closes it cleanly as normal live traffic.

## Tests

`RetransmissionWindowUnitTests` (7 new tests) covers: exact-Count completion + clean live continuation, duplicate/out-of-order in range, early termination as under-delivery, genuine over-delivery via Count+1 in-range frame, overlapping new reply, partial delivery staying open, count==0 no-op. Each test asserts on the documented event IDs via `FakeLogger` where applicable.

Reviewed three rounds with GPT-5.5 (strict-sequencing semantics, dead-branch reachability, log-path test coverage).