### PR TITLE
fix(encoder): remove bogus AccountType write at NewOrderSingle offset 100 (#179)

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
@@ -220,7 +220,9 @@ internal static class OrderEntryEncoder
             BinaryPrimitives.WriteUInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 84, 8), request.MinQty.Value);
         if (request.MaxFloor.HasValue)
             BinaryPrimitives.WriteUInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 92, 8), request.MaxFloor.Value);
-        MemoryMarshalAsBytes(ref msg, 100, 1)[0] = (byte)request.AccountType;
+        // NOTE: B3 schema 8.4.2 has no accountType field in NewOrderSingle (only in
+        // OrderCancelReplaceRequest, tag 581, v2). Offset 100 is the start of
+        // ExecutingTrader (TraderOptional, 5 bytes). See issue #179.
         if (request.ExpireDate.HasValue)
             BinaryPrimitives.WriteUInt16LittleEndian(MemoryMarshalAsBytes(ref msg, 105, 2),
                 (ushort)((request.ExpireDate.Value - DateTimeOffset.UnixEpoch).Days));

--- a/src/B3.EntryPoint.Client/Models/OrderModels.cs
+++ b/src/B3.EntryPoint.Client/Models/OrderModels.cs
@@ -71,7 +71,6 @@ public sealed record NewOrderRequest
     public decimal? StopPrice { get; init; }
     public required ulong OrderQty { get; init; }
     public TimeInForce TimeInForce { get; init; } = TimeInForce.Day;
-    public AccountType AccountType { get; init; } = AccountType.RegularAccount;
     public ulong? Account { get; init; }
     public DateTimeOffset? ExpireDate { get; init; }
     public ulong? MinQty { get; init; }

--- a/src/B3.EntryPoint.Client/PublicAPI.Shipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Shipped.txt
@@ -451,8 +451,6 @@ B3.EntryPoint.Client.Models.NewOrderRequest
 B3.EntryPoint.Client.Models.NewOrderRequest.<Clone>$() -> B3.EntryPoint.Client.Models.NewOrderRequest!
 B3.EntryPoint.Client.Models.NewOrderRequest.Account.get -> ulong?
 B3.EntryPoint.Client.Models.NewOrderRequest.Account.init -> void
-B3.EntryPoint.Client.Models.NewOrderRequest.AccountType.get -> B3.EntryPoint.Client.Models.AccountType
-B3.EntryPoint.Client.Models.NewOrderRequest.AccountType.init -> void
 B3.EntryPoint.Client.Models.NewOrderRequest.ClOrdID.get -> B3.EntryPoint.Client.Models.ClOrdID
 B3.EntryPoint.Client.Models.NewOrderRequest.ClOrdID.init -> void
 B3.EntryPoint.Client.Models.NewOrderRequest.Equals(B3.EntryPoint.Client.Models.NewOrderRequest? other) -> bool

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+*REMOVED*B3.EntryPoint.Client.Models.NewOrderRequest.AccountType.get -> B3.EntryPoint.Client.Models.AccountType
+*REMOVED*B3.EntryPoint.Client.Models.NewOrderRequest.AccountType.init -> void
 B3.EntryPoint.Client.EntryPointClient.ReconnectAsync(B3.EntryPoint.Client.ReconnectMode mode, System.Func<uint, uint>? nextSessionVerIdSelector, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<B3.EntryPoint.Client.ReconnectOutcome>!
 B3.EntryPoint.Client.Fixp.FixpEstablishRejectedException
 B3.EntryPoint.Client.Fixp.FixpEstablishRejectedException.Code.get -> B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
@@ -101,6 +101,37 @@ public class OrderEntryEncoderTests
         Assert.Equal((ushort)102, tid);
     }
 
+    // Regression test for issue #179: the encoder used to write
+    // `(byte)request.AccountType` at offset 100 of NewOrderSingleData. Schema
+    // 8.4.2 has no accountType field in NewOrderSingle (only in
+    // OrderCancelReplaceRequest); offset 100 is the start of ExecutingTrader
+    // (TraderOptional, 5 bytes), so the write silently corrupted the first
+    // byte of ExecutingTrader with ASCII 38/39.
+    [Fact]
+    public void EncodeNewOrderSingle_DoesNotCorruptExecutingTrader_Issue179()
+    {
+        var req = new NewOrderRequest
+        {
+            ClOrdID = new ClOrdID(99UL),
+            SecurityId = 1,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            OrderQty = 10,
+            Price = 0.05m,
+        };
+        var buffer = new byte[512];
+        var len = OrderEntryEncoder.EncodeNewOrderSingle(buffer, req, Opts(), msgSeqNum: 3);
+
+        // Frame layout: SOFH (4) + MessageHeader (8) + payload.
+        var payload = buffer.AsSpan(4 + 8, len - 4 - 8);
+        Assert.True(B3.Entrypoint.Fixp.Sbe.V6.NewOrderSingleData.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        // ExecutingTrader is at offset 100. With the bug it would have decoded
+        // as "&\0\0\0\0" (38) since AccountType defaults to RegularAccount (39).
+        Assert.Equal(0, data.ExecutingTrader.AsTrimmedSpan().Length);
+    }
+
     [Fact]
     public void EncodeOrderCancelReplace_WritesTemplateId_104()
     {

--- a/tests/B3.EntryPoint.Client.Tests/Models/OrderModelsTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Models/OrderModelsTests.cs
@@ -39,7 +39,6 @@ public class OrderModelsTests
         };
         Assert.Equal(3UL, req.ClOrdID.Value);
         Assert.Equal(TimeInForce.Day, req.TimeInForce);
-        Assert.Equal(AccountType.RegularAccount, req.AccountType);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #179.

## What was wrong

`OrderEntryEncoder.EncodeNewOrderSingle` wrote `(byte)request.AccountType` at offset 100 of `NewOrderSingleData`. Schema 8.4.2 has **no** `accountType` field on `NewOrderSingle` (it only exists on `OrderCancelReplaceRequest`, FIX tag 581, sinceVersion=2). The generated binding lays out `ExecutingTrader` (`TraderOptional`, 5-byte inline array) at offset 100, so the write silently corrupted the first byte of `ExecutingTrader` with ASCII 38 (`RemoveAccountInformation`) or 39 (`RegularAccount`, the default). The venue saw a spurious `&\0\0\0\0` or `'\0\0\0\0` instead of an absent field.

## What changed

- **Encoder:** drop the offset-100 write in `EncodeNewOrderSingle`. Replace it with a comment pointing to this issue. (The Replace encoder uses `msg.SetAccountType(...)` against the legitimate `OrderCancelReplaceRequestData` field — unchanged.)
- **Model:** remove `NewOrderRequest.AccountType` (it was never on the wire for this template). Breaking API change tracked in `PublicAPI.Unshipped.txt` via `*REMOVED*` entries. `ReplaceOrderRequest.AccountType` stays.
- **Tests:** new `EncodeNewOrderSingle_DoesNotCorruptExecutingTrader_Issue179` decodes the encoded NewOrderSingle and asserts `ExecutingTrader` is empty.

## Validation

- `dotnet build -c Release` — 0 warnings, 0 errors.
- `dotnet test -c Release` — 196 unit tests pass.
- `dotnet format --verify-no-changes` — clean.

## Notes for reviewers

- This is a **wire-level severity/high fix**: pre-fix, every NewOrderSingle sent had a corrupted `ExecutingTrader` field even when the caller didn't set anything. Whether the venue rejected on this depends on per-firm validation rules.
- ABI break: any caller that set `NewOrderRequest.AccountType` now fails to compile. The property was a no-op on the wire anyway (the bogus byte landed in a different field), so removing it surfaces the issue clearly instead of silently dropping the value into another spot.