### PR TITLE
feat(models): expose missing wire fields on NewOrderRequest/ReplaceOrderRequest (#177)

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
@@ -17,6 +17,9 @@ using SbeSettlType = B3.Entrypoint.Fixp.Sbe.V6.SettlType;
 using SbeExecuteUnderlyingTrade = B3.Entrypoint.Fixp.Sbe.V6.ExecuteUnderlyingTrade;
 using SbeCrossType = B3.Entrypoint.Fixp.Sbe.V6.CrossType;
 using SbeCrossPrioritization = B3.Entrypoint.Fixp.Sbe.V6.CrossPrioritization;
+using SbeSelfTradePreventionInstruction = B3.Entrypoint.Fixp.Sbe.V6.SelfTradePreventionInstruction;
+using SbeRoutingInstruction = B3.Entrypoint.Fixp.Sbe.V6.RoutingInstruction;
+using SbeBoolean = B3.Entrypoint.Fixp.Sbe.V6.Boolean;
 
 namespace B3.EntryPoint.Client.Fixp;
 
@@ -198,15 +201,20 @@ internal static class OrderEntryEncoder
 
         var msg = default(NewOrderSingleData);
         msg.BusinessHeader = BuildBusinessHeader(options, msgSeqNum);
-        msg.MmProtectionReset = global::B3.Entrypoint.Fixp.Sbe.V6.Boolean.FALSE_VALUE;
+        msg.SetOrdTagID(request.OrdTagId);
+        msg.MmProtectionReset = request.MmProtectionReset ? SbeBoolean.TRUE_VALUE : SbeBoolean.FALSE_VALUE;
         msg.ClOrdID = new SbeClOrdID(request.ClOrdID.Value);
         msg.SetAccount(request.Account is null ? null : checked((uint)request.Account.Value));
         WriteFixedString(MemoryMarshalAsBytes(ref msg, 32, 10), options.SenderLocation);
         WriteFixedString(MemoryMarshalAsBytes(ref msg, 42, 5), options.EnteringTrader);
+        msg.SelfTradePreventionInstruction = (SbeSelfTradePreventionInstruction)(byte)request.SelfTradePreventionInstruction;
         msg.SecurityID = new SecurityID(request.SecurityId);
         msg.Side = (SbeSide)(byte)request.Side;
         msg.OrdType = (SbeOrdType)(byte)request.OrderType;
         msg.TimeInForce = (SbeTimeInForce)(byte)request.TimeInForce;
+        msg.SetRoutingInstruction(request.RoutingInstruction is null
+            ? null
+            : (SbeRoutingInstruction)(byte)request.RoutingInstruction.Value);
         msg.OrderQty = new Quantity(request.OrderQty);
         if (request.Price.HasValue)
             BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref msg, 68, 8), PriceMantissa(request.Price.Value));
@@ -226,6 +234,13 @@ internal static class OrderEntryEncoder
         if (request.ExpireDate.HasValue)
             BinaryPrimitives.WriteUInt16LittleEndian(MemoryMarshalAsBytes(ref msg, 105, 2),
                 (ushort)((request.ExpireDate.Value - DateTimeOffset.UnixEpoch).Days));
+        if (request.InvestorId is { } iid)
+        {
+            // InvestorID composite @ offset 119: ushort prefix + uint document, sequential pack=1.
+            BinaryPrimitives.WriteUInt16LittleEndian(MemoryMarshalAsBytes(ref msg, 119, 2), iid.Prefix);
+            BinaryPrimitives.WriteUInt32LittleEndian(MemoryMarshalAsBytes(ref msg, 121, 4), iid.Document);
+        }
+        msg.SetTradingSubAccount(request.TradingSubAccount);
 
         if (!NewOrderSingleData.TryEncode(msg, buffer.Slice(SofhSize + SbeHeaderSize),
                 ReadOnlySpan<byte>.Empty, memoBytes, out _))
@@ -247,15 +262,20 @@ internal static class OrderEntryEncoder
 
         var msg = default(OrderCancelReplaceRequestData);
         msg.BusinessHeader = BuildBusinessHeader(options, msgSeqNum);
-        msg.MmProtectionReset = global::B3.Entrypoint.Fixp.Sbe.V6.Boolean.FALSE_VALUE;
+        msg.SetOrdTagID(request.OrdTagId);
+        msg.MmProtectionReset = request.MmProtectionReset ? SbeBoolean.TRUE_VALUE : SbeBoolean.FALSE_VALUE;
         msg.ClOrdID = new SbeClOrdID(request.ClOrdID.Value);
         msg.SetAccount(request.Account is null ? null : checked((uint)request.Account.Value));
         WriteFixedString(MemoryMarshalAsBytes(ref msg, 32, 10), options.SenderLocation);
         WriteFixedString(MemoryMarshalAsBytes(ref msg, 42, 5), options.EnteringTrader);
+        msg.SelfTradePreventionInstruction = (SbeSelfTradePreventionInstruction)(byte)request.SelfTradePreventionInstruction;
         msg.SecurityID = new SecurityID(request.SecurityId);
         msg.Side = (SbeSide)(byte)request.Side;
         msg.OrdType = (SbeOrdType)(byte)request.OrderType;
         msg.SetTimeInForce((SbeTimeInForce)(byte)request.TimeInForce);
+        msg.SetRoutingInstruction(request.RoutingInstruction is null
+            ? null
+            : (SbeRoutingInstruction)(byte)request.RoutingInstruction.Value);
         msg.OrderQty = new Quantity(request.OrderQty);
         // Price@68 is PriceOptional (composite): no public setter, write mantissa directly.
         if (request.Price.HasValue)
@@ -274,6 +294,13 @@ internal static class OrderEntryEncoder
         msg.SetAccountType((SbeAccountType)(byte)request.AccountType);
         if (request.ExpireDate.HasValue)
             msg.SetExpireDate((ushort)((request.ExpireDate.Value - DateTimeOffset.UnixEpoch).Days));
+        if (request.InvestorId is { } iid)
+        {
+            // InvestorID composite @ offset 136: ushort prefix + uint document, sequential pack=1.
+            BinaryPrimitives.WriteUInt16LittleEndian(MemoryMarshalAsBytes(ref msg, 136, 2), iid.Prefix);
+            BinaryPrimitives.WriteUInt32LittleEndian(MemoryMarshalAsBytes(ref msg, 138, 4), iid.Document);
+        }
+        msg.SetTradingSubAccount(request.TradingSubAccount);
 
         if (!OrderCancelReplaceRequestData.TryEncode(msg, buffer.Slice(SofhSize + SbeHeaderSize),
                 ReadOnlySpan<byte>.Empty, memoBytes, out _))

--- a/src/B3.EntryPoint.Client/Models/OrderModels.cs
+++ b/src/B3.EntryPoint.Client/Models/OrderModels.cs
@@ -56,6 +56,37 @@ public enum AccountType : byte
 }
 
 /// <summary>
+/// Self-trade prevention instruction (schema enum
+/// <c>SelfTradePreventionInstruction</c>, FIX tag 35539). Indicates which
+/// order should be canceled when a self-trade is detected.
+/// </summary>
+public enum SelfTradePreventionInstruction : byte
+{
+    None = 0,
+    CancelAggressorOrder = 1,
+    CancelRestingOrder = 2,
+    CancelBothOrders = 3,
+}
+
+/// <summary>
+/// Additional order routing instruction (schema enum <c>RoutingInstruction</c>,
+/// FIX tag 35487, optional, <c>sinceVersion=2</c>).
+/// </summary>
+public enum RoutingInstruction : byte
+{
+    RetailLiquidityTaker = 1,
+    WaivedPriority = 2,
+    BrokerOnly = 3,
+    BrokerOnlyRemoval = 4,
+}
+
+/// <summary>
+/// Self-trade prevention / mass-cancel-on-behalf investor identification
+/// (schema composite <c>InvestorID</c>, FIX tag 35508).
+/// </summary>
+public readonly record struct InvestorId(ushort Prefix, uint Document);
+
+/// <summary>
 /// Logical request shape for <c>NewOrderSingle</c> (schema §6). The client
 /// converts user-friendly fields (decimal <see cref="Price"/>) to the wire
 /// encoding (fixed-point mantissa with exponent -4, i.e. <c>price × 10_000</c>)
@@ -76,6 +107,18 @@ public sealed record NewOrderRequest
     public ulong? MinQty { get; init; }
     public ulong? MaxFloor { get; init; }
     public string? MemoText { get; init; }
+    /// <summary>FIX tag 35505 — order tag identifier. Optional; default = absent (wire null = 0).</summary>
+    public byte? OrdTagId { get; init; }
+    /// <summary>FIX tag 9773 — when <see langword="true"/>, resets Market Maker Protection.</summary>
+    public bool MmProtectionReset { get; init; }
+    /// <summary>FIX tag 35539 — self-trade prevention instruction. Defaults to <see cref="SelfTradePreventionInstruction.None"/>.</summary>
+    public SelfTradePreventionInstruction SelfTradePreventionInstruction { get; init; } = SelfTradePreventionInstruction.None;
+    /// <summary>FIX tag 35487 — additional routing instruction (optional, <c>sinceVersion=2</c>).</summary>
+    public RoutingInstruction? RoutingInstruction { get; init; }
+    /// <summary>FIX tag 35508 — investor id for self-trade prevention / mass-cancel-on-behalf (<c>sinceVersion=1</c>).</summary>
+    public InvestorId? InvestorId { get; init; }
+    /// <summary>FIX tag 35121 — trading sub-account for associating risk limits (optional, <c>sinceVersion=5</c>).</summary>
+    public uint? TradingSubAccount { get; init; }
 }
 
 /// <summary>

--- a/src/B3.EntryPoint.Client/Models/ReplaceOrderRequest.cs
+++ b/src/B3.EntryPoint.Client/Models/ReplaceOrderRequest.cs
@@ -22,6 +22,18 @@ public sealed record ReplaceOrderRequest
     public ulong? MinQty { get; init; }
     public ulong? MaxFloor { get; init; }
     public string? MemoText { get; init; }
+    /// <summary>FIX tag 35505 — order tag identifier. Optional; default = absent (wire null = 0).</summary>
+    public byte? OrdTagId { get; init; }
+    /// <summary>FIX tag 9773 — when <see langword="true"/>, resets Market Maker Protection.</summary>
+    public bool MmProtectionReset { get; init; }
+    /// <summary>FIX tag 35539 — self-trade prevention instruction. Defaults to <see cref="SelfTradePreventionInstruction.None"/>.</summary>
+    public SelfTradePreventionInstruction SelfTradePreventionInstruction { get; init; } = SelfTradePreventionInstruction.None;
+    /// <summary>FIX tag 35487 — additional routing instruction (optional, <c>sinceVersion=2</c>).</summary>
+    public RoutingInstruction? RoutingInstruction { get; init; }
+    /// <summary>FIX tag 35508 — investor id for self-trade prevention / mass-cancel-on-behalf (<c>sinceVersion=1</c>).</summary>
+    public InvestorId? InvestorId { get; init; }
+    /// <summary>FIX tag 35121 — trading sub-account for associating risk limits (optional, <c>sinceVersion=5</c>).</summary>
+    public uint? TradingSubAccount { get; init; }
 }
 
 /// <summary>

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -1,6 +1,54 @@
 #nullable enable
 *REMOVED*B3.EntryPoint.Client.Models.NewOrderRequest.AccountType.get -> B3.EntryPoint.Client.Models.AccountType
 *REMOVED*B3.EntryPoint.Client.Models.NewOrderRequest.AccountType.init -> void
+B3.EntryPoint.Client.Models.SelfTradePreventionInstruction
+B3.EntryPoint.Client.Models.SelfTradePreventionInstruction.None = 0 -> B3.EntryPoint.Client.Models.SelfTradePreventionInstruction
+B3.EntryPoint.Client.Models.SelfTradePreventionInstruction.CancelAggressorOrder = 1 -> B3.EntryPoint.Client.Models.SelfTradePreventionInstruction
+B3.EntryPoint.Client.Models.SelfTradePreventionInstruction.CancelRestingOrder = 2 -> B3.EntryPoint.Client.Models.SelfTradePreventionInstruction
+B3.EntryPoint.Client.Models.SelfTradePreventionInstruction.CancelBothOrders = 3 -> B3.EntryPoint.Client.Models.SelfTradePreventionInstruction
+B3.EntryPoint.Client.Models.RoutingInstruction
+B3.EntryPoint.Client.Models.RoutingInstruction.RetailLiquidityTaker = 1 -> B3.EntryPoint.Client.Models.RoutingInstruction
+B3.EntryPoint.Client.Models.RoutingInstruction.WaivedPriority = 2 -> B3.EntryPoint.Client.Models.RoutingInstruction
+B3.EntryPoint.Client.Models.RoutingInstruction.BrokerOnly = 3 -> B3.EntryPoint.Client.Models.RoutingInstruction
+B3.EntryPoint.Client.Models.RoutingInstruction.BrokerOnlyRemoval = 4 -> B3.EntryPoint.Client.Models.RoutingInstruction
+B3.EntryPoint.Client.Models.InvestorId
+B3.EntryPoint.Client.Models.InvestorId.InvestorId() -> void
+B3.EntryPoint.Client.Models.InvestorId.InvestorId(ushort Prefix, uint Document) -> void
+B3.EntryPoint.Client.Models.InvestorId.Prefix.get -> ushort
+B3.EntryPoint.Client.Models.InvestorId.Prefix.init -> void
+B3.EntryPoint.Client.Models.InvestorId.Document.get -> uint
+B3.EntryPoint.Client.Models.InvestorId.Document.init -> void
+B3.EntryPoint.Client.Models.InvestorId.Deconstruct(out ushort Prefix, out uint Document) -> void
+B3.EntryPoint.Client.Models.InvestorId.Equals(B3.EntryPoint.Client.Models.InvestorId other) -> bool
+override B3.EntryPoint.Client.Models.InvestorId.GetHashCode() -> int
+~override B3.EntryPoint.Client.Models.InvestorId.ToString() -> string
+static B3.EntryPoint.Client.Models.InvestorId.operator !=(B3.EntryPoint.Client.Models.InvestorId left, B3.EntryPoint.Client.Models.InvestorId right) -> bool
+static B3.EntryPoint.Client.Models.InvestorId.operator ==(B3.EntryPoint.Client.Models.InvestorId left, B3.EntryPoint.Client.Models.InvestorId right) -> bool
+~override B3.EntryPoint.Client.Models.InvestorId.Equals(object obj) -> bool
+B3.EntryPoint.Client.Models.NewOrderRequest.OrdTagId.get -> byte?
+B3.EntryPoint.Client.Models.NewOrderRequest.OrdTagId.init -> void
+B3.EntryPoint.Client.Models.NewOrderRequest.MmProtectionReset.get -> bool
+B3.EntryPoint.Client.Models.NewOrderRequest.MmProtectionReset.init -> void
+B3.EntryPoint.Client.Models.NewOrderRequest.SelfTradePreventionInstruction.get -> B3.EntryPoint.Client.Models.SelfTradePreventionInstruction
+B3.EntryPoint.Client.Models.NewOrderRequest.SelfTradePreventionInstruction.init -> void
+B3.EntryPoint.Client.Models.NewOrderRequest.RoutingInstruction.get -> B3.EntryPoint.Client.Models.RoutingInstruction?
+B3.EntryPoint.Client.Models.NewOrderRequest.RoutingInstruction.init -> void
+B3.EntryPoint.Client.Models.NewOrderRequest.InvestorId.get -> B3.EntryPoint.Client.Models.InvestorId?
+B3.EntryPoint.Client.Models.NewOrderRequest.InvestorId.init -> void
+B3.EntryPoint.Client.Models.NewOrderRequest.TradingSubAccount.get -> uint?
+B3.EntryPoint.Client.Models.NewOrderRequest.TradingSubAccount.init -> void
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.OrdTagId.get -> byte?
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.OrdTagId.init -> void
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.MmProtectionReset.get -> bool
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.MmProtectionReset.init -> void
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.SelfTradePreventionInstruction.get -> B3.EntryPoint.Client.Models.SelfTradePreventionInstruction
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.SelfTradePreventionInstruction.init -> void
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.RoutingInstruction.get -> B3.EntryPoint.Client.Models.RoutingInstruction?
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.RoutingInstruction.init -> void
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.InvestorId.get -> B3.EntryPoint.Client.Models.InvestorId?
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.InvestorId.init -> void
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.TradingSubAccount.get -> uint?
+B3.EntryPoint.Client.Models.ReplaceOrderRequest.TradingSubAccount.init -> void
 B3.EntryPoint.Client.EntryPointClient.ReconnectAsync(B3.EntryPoint.Client.ReconnectMode mode, System.Func<uint, uint>? nextSessionVerIdSelector, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<B3.EntryPoint.Client.ReconnectOutcome>!
 B3.EntryPoint.Client.Fixp.FixpEstablishRejectedException
 B3.EntryPoint.Client.Fixp.FixpEstablishRejectedException.Code.get -> B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
@@ -9,6 +9,7 @@ using B3.EntryPoint.Client.Models;
 using SbeOcrr = B3.Entrypoint.Fixp.Sbe.V6.OrderCancelReplaceRequestData;
 using SbeAccountType = B3.Entrypoint.Fixp.Sbe.V6.AccountType;
 using SbeNewOrderCross = B3.Entrypoint.Fixp.Sbe.V6.NewOrderCrossData;
+using SbeNewOrderSingle = B3.Entrypoint.Fixp.Sbe.V6.NewOrderSingleData;
 using SbeQuoteRequest = B3.Entrypoint.Fixp.Sbe.V6.QuoteRequestData;
 using SbeQuote = B3.Entrypoint.Fixp.Sbe.V6.QuoteData;
 using SbeSide = B3.Entrypoint.Fixp.Sbe.V6.Side;
@@ -18,6 +19,9 @@ using SbeCrossPrioritization = B3.Entrypoint.Fixp.Sbe.V6.CrossPrioritization;
 using SbeExecuteUnderlyingTrade = B3.Entrypoint.Fixp.Sbe.V6.ExecuteUnderlyingTrade;
 using SbeSenderLocation = B3.Entrypoint.Fixp.Sbe.V6.SenderLocation;
 using SbeTrader = B3.Entrypoint.Fixp.Sbe.V6.Trader;
+using SbeBoolean = B3.Entrypoint.Fixp.Sbe.V6.Boolean;
+using SbeSelfTradePreventionInstruction = B3.Entrypoint.Fixp.Sbe.V6.SelfTradePreventionInstruction;
+using SbeRoutingInstruction = B3.Entrypoint.Fixp.Sbe.V6.RoutingInstruction;
 
 namespace B3.EntryPoint.Client.Tests.Fixp;
 
@@ -200,6 +204,78 @@ public class OrderEntryEncoderTests
         Assert.Equal(7UL, data.SecurityID.Value);
         Assert.Equal(50UL, data.OrderQty.Value);
         Assert.Equal(123_400L, data.Price.Mantissa);
+    }
+
+    // Issue #177: NewOrderSingle round-trips the wire fields that were
+    // previously inaccessible from the SDK (OrdTagID, MmProtectionReset,
+    // SelfTradePreventionInstruction, RoutingInstruction, InvestorID,
+    // TradingSubAccount).
+    [Fact]
+    public void EncodeNewOrderSingle_RoundTrips_NewWireFields_Issue177()
+    {
+        var req = new NewOrderRequest
+        {
+            ClOrdID = new ClOrdID(99UL),
+            SecurityId = 1,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            OrderQty = 10,
+            Price = 0.05m,
+            OrdTagId = 7,
+            MmProtectionReset = true,
+            SelfTradePreventionInstruction = SelfTradePreventionInstruction.CancelAggressorOrder,
+            RoutingInstruction = RoutingInstruction.BrokerOnly,
+            InvestorId = new InvestorId(Prefix: 1234, Document: 0xCAFEBABE),
+            TradingSubAccount = 555_000U,
+        };
+        var buffer = new byte[512];
+        var len = OrderEntryEncoder.EncodeNewOrderSingle(buffer, req, Opts(), msgSeqNum: 3);
+        var payload = buffer.AsSpan(4 + 8, len - 4 - 8);
+        Assert.True(SbeNewOrderSingle.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Equal((byte?)7, data.OrdTagID);
+        Assert.Equal(SbeBoolean.TRUE_VALUE, data.MmProtectionReset);
+        Assert.Equal(SbeSelfTradePreventionInstruction.CANCEL_AGGRESSOR_ORDER, data.SelfTradePreventionInstruction);
+        Assert.Equal(SbeRoutingInstruction.BROKER_ONLY, data.RoutingInstruction);
+        Assert.Equal((ushort?)1234, data.InvestorID.Prefix);
+        Assert.Equal((uint?)0xCAFEBABE, data.InvestorID.Document);
+        Assert.Equal((uint?)555_000U, data.TradingSubAccount);
+    }
+
+    // Issue #177: OCRR round-trips the same set of wire fields.
+    [Fact]
+    public void EncodeOrderCancelReplace_RoundTrips_NewWireFields_Issue177()
+    {
+        var req = new ReplaceOrderRequest
+        {
+            ClOrdID = new ClOrdID(2UL),
+            OrigClOrdID = new ClOrdID(1UL),
+            SecurityId = 1,
+            Side = Side.Buy,
+            OrderType = OrderType.Limit,
+            OrderQty = 20,
+            Price = 0.10m,
+            OrdTagId = 3,
+            MmProtectionReset = true,
+            SelfTradePreventionInstruction = SelfTradePreventionInstruction.CancelRestingOrder,
+            RoutingInstruction = RoutingInstruction.WaivedPriority,
+            InvestorId = new InvestorId(Prefix: 4321, Document: 0xDEADBEEF),
+            TradingSubAccount = 999_000U,
+        };
+        var buffer = new byte[512];
+        var len = OrderEntryEncoder.EncodeOrderCancelReplace(buffer, req, Opts(), msgSeqNum: 4);
+        var payload = buffer.AsSpan(4 + 8, len - 4 - 8);
+        Assert.True(SbeOcrr.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Equal((byte?)3, data.OrdTagID);
+        Assert.Equal(SbeBoolean.TRUE_VALUE, data.MmProtectionReset);
+        Assert.Equal(SbeSelfTradePreventionInstruction.CANCEL_RESTING_ORDER, data.SelfTradePreventionInstruction);
+        Assert.Equal(SbeRoutingInstruction.WAIVED_PRIORITY, data.RoutingInstruction);
+        Assert.Equal((ushort?)4321, data.InvestorID.Prefix);
+        Assert.Equal((uint?)0xDEADBEEF, data.InvestorID.Document);
+        Assert.Equal((uint?)999_000U, data.TradingSubAccount);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #177. Unblocks downstream pedrosakuma/B3TradingPlatform#459.

## What

Adds six previously-inaccessible wire fields to both `NewOrderRequest` and `ReplaceOrderRequest`:

| Property | Wire | Notes |
|---|---|---|
| `OrdTagId` (`byte?`) | NewOrderSingle@18 / OCRR@18 | optional, null sentinel 0 |
| `MmProtectionReset` (`bool`) | NewOrderSingle@19 / OCRR@19 | mandatory `Boolean` enum |
| `SelfTradePreventionInstruction` (new enum, schema id 293) | @47 / @47 | mandatory; `None=0` default |
| `RoutingInstruction` (new enum, schema id 457) | @59 / @59 | optional, null sentinel 255 |
| `InvestorId` (new `readonly record struct`) | NewOrderSingle@119 / OCRR@136 | composite (`ushort Prefix`, `uint Document`), written as raw LE bytes (composite has no public setter) |
| `TradingSubAccount` (`uint?`) | NewOrderSingle@129 / OCRR@146 | tag 35121, v5; null sentinel 0 |

Encoder writes all six on both messages at schema-correct offsets. Round-trip tests assert each field decodes via the generated `*Data.TryParse`.

## Intentionally excluded

- **`SecurityExchange` (tag 207)**: the SBE generator emits this as a 0-byte `const string Value = "BVMF"` — there is no wire byte to set and no model exposure is required.
- **`ExecInst` (FIX tag 18)**: does not exist in schema 8.4.2. The semantic equivalents are factored into the new fields above (`SelfTradePreventionInstruction`, `RoutingInstruction`, `MmProtectionReset`, `InvestorId`).
- **`DisplayResetPolicy`**: does not exist in schema 8.4.2. Iceberg refresh policy is hardwired in B3's matching engine.

## Checks

- Build clean (`-c Release`, `TreatWarningsAsErrors=true`)
- 198 unit tests pass (was 196, +2 round-trip tests for new fields)
- `dotnet format --verify-no-changes` clean
- `PublicAPI.Unshipped.txt` updated for every new public symbol (RS0016 satisfied)

## Architecture note

Wire-puro: nothing in this change references downstream-specific concepts. Field names mirror schema names; semantics follow the schema only.