### PR TITLE
feat(models): expose missing wire fields on CancelOrderRequest (#178)

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
@@ -160,7 +160,7 @@ internal static class OrderEntryEncoder
         return totalSize;
     }
 
-    /// <summary>Encodes an OrderCancelRequest (template id 104). Returns total bytes written.</summary>
+    /// <summary>Encodes an OrderCancelRequest (template id 105). Returns total bytes written.</summary>
     public static int EncodeOrderCancel(
         Span<byte> buffer,
         CancelOrderRequest request,
@@ -168,7 +168,12 @@ internal static class OrderEntryEncoder
         ulong msgSeqNum)
     {
         var memoBytes = MemoBytes(request.MemoText);
-        var payloadSize = OrderCancelRequestData.MESSAGE_SIZE + 1 + 0 + 1 + memoBytes.Length;
+        var deskIdBytes = request.DeskId is null
+            ? ReadOnlySpan<byte>.Empty
+            : Encoding.ASCII.GetBytes(request.DeskId);
+        if (deskIdBytes.Length > 255)
+            throw new ArgumentException("DeskId is too long (max 255 bytes).", nameof(request));
+        var payloadSize = OrderCancelRequestData.MESSAGE_SIZE + 1 + deskIdBytes.Length + 1 + memoBytes.Length;
         var totalSize = SofhSize + SbeHeaderSize + payloadSize;
         WriteHeaders(buffer.Slice(0, totalSize), totalSize, p => OrderCancelRequestData.WriteHeader(p));
 
@@ -176,13 +181,19 @@ internal static class OrderEntryEncoder
         msg.BusinessHeader = BuildBusinessHeader(options, msgSeqNum);
         msg.ClOrdID = new SbeClOrdID(request.ClOrdID.Value);
         msg.SecurityID = new SecurityID(request.SecurityId);
+        msg.SetOrderID(request.OrderId);
         msg.SetOrigClOrdID(request.OrigClOrdID.Value);
         msg.Side = (SbeSide)(byte)request.Side;
+        msg.SetExecRestatementReason(request.ExecRestatementReason is null
+            ? null
+            : (global::B3.Entrypoint.Fixp.Sbe.V6.ExecRestatementReasonValidForSingleCancel)(byte)request.ExecRestatementReason.Value);
         WriteFixedString(MemoryMarshalAsBytes(ref msg, 56, 10), options.SenderLocation);
         WriteFixedString(MemoryMarshalAsBytes(ref msg, 66, 5), options.EnteringTrader);
+        if (request.ExecutingTrader is not null)
+            WriteFixedString(MemoryMarshalAsBytes(ref msg, 71, 5), request.ExecutingTrader);
 
         if (!OrderCancelRequestData.TryEncode(msg, buffer.Slice(SofhSize + SbeHeaderSize),
-                ReadOnlySpan<byte>.Empty, memoBytes, out _))
+                deskIdBytes, memoBytes, out _))
             throw new InvalidOperationException("Failed to encode OrderCancelRequestData.");
         return totalSize;
     }

--- a/src/B3.EntryPoint.Client/Models/CancelOrderRequest.cs
+++ b/src/B3.EntryPoint.Client/Models/CancelOrderRequest.cs
@@ -30,6 +30,16 @@ public enum MassActionRejectReason : byte
 }
 
 /// <summary>
+/// Reason supplied with a solicited <c>OrderCancelRequest</c> (schema enum
+/// <c>ExecRestatementReasonValidForSingleCancel</c>, FIX tag 378).
+/// </summary>
+public enum CancelExecRestatementReason : byte
+{
+    /// <summary>Cancel was sent because of an operational error.</summary>
+    CancelOrderDueToOperationalError = 203,
+}
+
+/// <summary>
 /// Logical request shape for <c>OrderCancelRequest</c> (schema §6).
 /// </summary>
 public sealed record CancelOrderRequest
@@ -39,6 +49,14 @@ public sealed record CancelOrderRequest
     public required ulong SecurityId { get; init; }
     public required Side Side { get; init; }
     public ulong? Account { get; init; }
+    /// <summary>Venue-assigned order id (FIX tag 37). Alternative to <see cref="OrigClOrdID"/> for cancelling by venue id.</summary>
+    public ulong? OrderId { get; init; }
+    /// <summary>Reason supplied with a solicited cancel (FIX tag 378). When null no reason is sent.</summary>
+    public CancelExecRestatementReason? ExecRestatementReason { get; init; }
+    /// <summary>5-char executing trader id (FIX tag 35506). When null the field is left as the wire null sentinel.</summary>
+    public string? ExecutingTrader { get; init; }
+    /// <summary>Trading desk id (FIX tag 35510, varData). Encoded as ASCII; max 255 bytes.</summary>
+    public string? DeskId { get; init; }
     public string? MemoText { get; init; }
 }
 

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -49,6 +49,16 @@ B3.EntryPoint.Client.Models.ReplaceOrderRequest.InvestorId.get -> B3.EntryPoint.
 B3.EntryPoint.Client.Models.ReplaceOrderRequest.InvestorId.init -> void
 B3.EntryPoint.Client.Models.ReplaceOrderRequest.TradingSubAccount.get -> uint?
 B3.EntryPoint.Client.Models.ReplaceOrderRequest.TradingSubAccount.init -> void
+B3.EntryPoint.Client.Models.CancelExecRestatementReason
+B3.EntryPoint.Client.Models.CancelExecRestatementReason.CancelOrderDueToOperationalError = 203 -> B3.EntryPoint.Client.Models.CancelExecRestatementReason
+B3.EntryPoint.Client.Models.CancelOrderRequest.OrderId.get -> ulong?
+B3.EntryPoint.Client.Models.CancelOrderRequest.OrderId.init -> void
+B3.EntryPoint.Client.Models.CancelOrderRequest.ExecRestatementReason.get -> B3.EntryPoint.Client.Models.CancelExecRestatementReason?
+B3.EntryPoint.Client.Models.CancelOrderRequest.ExecRestatementReason.init -> void
+B3.EntryPoint.Client.Models.CancelOrderRequest.ExecutingTrader.get -> string?
+B3.EntryPoint.Client.Models.CancelOrderRequest.ExecutingTrader.init -> void
+B3.EntryPoint.Client.Models.CancelOrderRequest.DeskId.get -> string?
+B3.EntryPoint.Client.Models.CancelOrderRequest.DeskId.init -> void
 B3.EntryPoint.Client.EntryPointClient.ReconnectAsync(B3.EntryPoint.Client.ReconnectMode mode, System.Func<uint, uint>? nextSessionVerIdSelector, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<B3.EntryPoint.Client.ReconnectOutcome>!
 B3.EntryPoint.Client.Fixp.FixpEstablishRejectedException
 B3.EntryPoint.Client.Fixp.FixpEstablishRejectedException.Code.get -> B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/OrderEntryEncoderTests.cs
@@ -6,6 +6,8 @@ using B3.EntryPoint.Client;
 using B3.EntryPoint.Client.Auth;
 using B3.EntryPoint.Client.Fixp;
 using B3.EntryPoint.Client.Models;
+using SbeOcr = B3.Entrypoint.Fixp.Sbe.V6.OrderCancelRequestData;
+using SbeExecRestate = B3.Entrypoint.Fixp.Sbe.V6.ExecRestatementReasonValidForSingleCancel;
 using SbeOcrr = B3.Entrypoint.Fixp.Sbe.V6.OrderCancelReplaceRequestData;
 using SbeAccountType = B3.Entrypoint.Fixp.Sbe.V6.AccountType;
 using SbeNewOrderCross = B3.Entrypoint.Fixp.Sbe.V6.NewOrderCrossData;
@@ -83,6 +85,38 @@ public class OrderEntryEncoderTests
         var (_, tid) = ReadFrameHeader(buffer);
         Assert.True(len > 0);
         Assert.Equal((ushort)105, tid);
+    }
+
+    // Issue #178: OrderCancelRequest round-trips wire fields that were
+    // previously inaccessible from the SDK (OrderID, ExecRestatementReason,
+    // ExecutingTrader, DeskID varData).
+    [Fact]
+    public void EncodeOrderCancel_RoundTrips_NewWireFields_Issue178()
+    {
+        var req = new CancelOrderRequest
+        {
+            ClOrdID = new ClOrdID(2UL),
+            OrigClOrdID = new ClOrdID(1UL),
+            SecurityId = 7,
+            Side = Side.Sell,
+            OrderId = 0xCAFEBABEDEADBEEFUL,
+            ExecRestatementReason = CancelExecRestatementReason.CancelOrderDueToOperationalError,
+            ExecutingTrader = "X9999",
+            DeskId = "DESK1",
+        };
+        var buffer = new byte[256];
+        var len = OrderEntryEncoder.EncodeOrderCancel(buffer, req, Opts(), msgSeqNum: 2);
+        var payload = buffer.AsSpan(4 + 8, len - 4 - 8);
+        Assert.True(SbeOcr.TryParse(payload, out var reader));
+        ref readonly var data = ref reader.Data;
+
+        Assert.Equal((ulong?)0xCAFEBABEDEADBEEFUL, data.OrderID);
+        Assert.Equal(SbeExecRestate.CANCEL_ORDER_DUE_TO_OPERATIONAL_ERROR, data.ExecRestatementReason);
+        Assert.Equal("X9999", Encoding.ASCII.GetString(data.ExecutingTrader.AsTrimmedSpan()));
+
+        var deskIdBytes = new byte[reader.DeskID.Length];
+        reader.DeskID.VarData.CopyTo(deskIdBytes);
+        Assert.Equal("DESK1", Encoding.ASCII.GetString(deskIdBytes));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #178.

## What

Adds four previously-hidden wire fields to `CancelOrderRequest` (template 105):

| Property | Wire | Notes |
|---|---|---|
| `OrderId` (`ulong?`) | tag 37, OrderIDOptional @36 | venue-assigned id; alternative to `OrigClOrdID` for cancel-by-venue-id |
| `ExecRestatementReason` (new enum `CancelExecRestatementReason`) | tag 378 @53 | optional, null sentinel 255; only value is `CancelOrderDueToOperationalError = 203` |
| `ExecutingTrader` (`string?`) | tag 35506 @71 | 5-char fixed string; written only when non-null |
| `DeskId` (`string?`) | tag 35510 varData | ASCII; threaded through `OrderCancelRequestData.TryEncode`'s deskID arg with correct payload sizing |

Drive-by: fixed the `EncodeOrderCancel` doc-comment that wrongly said 'template id 104' (cancel is 105).

## Intentionally excluded

- **`SecurityExchange` (tag 207)**: the SBE generator emits this as a 0-byte `const string Value = "BVMF"`. Same exclusion rationale as PR #181.

## Checks

- Build clean (`-c Release`, `TreatWarningsAsErrors=true`)
- 199 unit tests pass (was 198, +1 round-trip test asserting all four new fields decode via `OrderCancelRequestData.TryParse`)
- `dotnet format --verify-no-changes` clean
- `PublicAPI.Unshipped.txt` updated for every new public symbol