### PR TITLE
fix(encoder): populate SendingTime on outbound business messages

### DIFF
--- a/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
+++ b/src/B3.EntryPoint.Client/Fixp/OrderEntryEncoder.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
 using System.Text;
 using B3.Entrypoint.Fixp.Sbe.V6;
 using B3.EntryPoint.Client.Framing;
@@ -38,12 +39,21 @@ internal static class OrderEntryEncoder
     private static long PriceMantissa(decimal price) =>
         (long)(price * 10_000m);
 
+    private static ulong NowUnixNanos() =>
+        (ulong)((DateTimeOffset.UtcNow - DateTimeOffset.UnixEpoch).Ticks * 100L);
+
+    private static UTCTimestampNanosOptional CreateSendingTime()
+    {
+        var nanos = NowUnixNanos();
+        return Unsafe.As<ulong, UTCTimestampNanosOptional>(ref nanos);
+    }
+
     private static InboundBusinessHeader BuildBusinessHeader(EntryPointClientOptions options, ulong msgSeqNum)
     {
         var header = default(InboundBusinessHeader);
         header.SessionID = new SessionID(options.SessionId);
         header.MsgSeqNum = SeqNumGuard.ToWireSeqNum(msgSeqNum);
-        header.SendingTime = default;
+        header.SendingTime = CreateSendingTime();
         header.MarketSegmentID = new MarketSegmentID(options.DefaultMarketSegmentId);
         return header;
     }
@@ -53,7 +63,7 @@ internal static class OrderEntryEncoder
         var header = default(BidirectionalBusinessHeader);
         header.SessionID = new SessionID(options.SessionId);
         header.MsgSeqNum = SeqNumGuard.ToWireSeqNum(msgSeqNum);
-        header.SendingTime = default;
+        header.SendingTime = CreateSendingTime();
         // MarketSegmentID is optional on bidirectional messages; left at NullValue (0) to mean "not set".
         if (options.DefaultMarketSegmentId != 0)
             MemoryMarshalAsBytes(ref header, 17, 1)[0] = options.DefaultMarketSegmentId;


### PR DESCRIPTION
## Problem

OrderEntryEncoder was setting `SendingTime = default` (zero) on all outbound `InboundBusinessHeader` and `BidirectionalBusinessHeader` structs.

This caused gateways with clock-skew validation (like B3MatchingPlatform after PR #423) to reject every business message with:

```
rejected business message: sendingTime 0 differs from server clock ... by ...ns (tolerance=5000000000ns)
```

## Solution

Populate `SendingTime` with the current UTC timestamp in nanoseconds using the same pattern as `FixpClientSession` (`Ticks * 100`).

Uses `Unsafe.As` to construct the `UTCTimestampNanosOptional` struct since the `Time` property is read-only.

## Testing

- Verified orders are accepted by matching-platform with clock-skew validation enabled
- No sendingTime rejection errors in logs