### PR TITLE
Detect peer TCP close and transition session out of Established (#187)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -365,6 +365,21 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
                 new KeyValuePair<string, object?>("code", code.ToString()));
             RaiseTerminated((TerminationCode)code, reason: null, initiatedByClient: false);
         };
+        _session.OnTransportClosed = ex =>
+        {
+            // Peer closed the TCP transport without a Terminate exchange
+            // (e.g. matching-platform restart). Surface as a Terminated event
+            // so the State property and EnsureEstablished() reflect the dead
+            // wire instead of leaving consumers stuck in a stale Established
+            // state until the next send fails. (#187)
+            EntryPointTelemetry.Terminations.Add(1,
+                new KeyValuePair<string, object?>("direction", "inbound"),
+                new KeyValuePair<string, object?>("code", "transport-closed"));
+            RaiseTerminated(
+                TerminationCode.Unspecified,
+                reason: ex?.Message ?? "TCP transport closed by peer.",
+                initiatedByClient: false);
+        };
         _lastInboundUtc = DateTime.UtcNow;
     }
 

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -204,6 +204,14 @@ internal sealed class FixpClientSession : IAsyncDisposable
     private Task? _inboundLoop;
     private CancellationTokenSource? _inboundCts;
     private ChannelWriter<EntryPointEvent>? _eventWriter;
+    // Set by DisposeAsync before cancelling the inbound loop so the loop can
+    // distinguish a user-driven graceful shutdown (silent) from a peer-side
+    // TCP close (must surface as a transport-loss notification). (#187)
+    private int _userShutdown;
+    // Latches the one-shot transport-closed notification so concurrent
+    // observers (inbound loop end + an outbound write that races with the
+    // peer close) cannot raise the hook twice. (#187)
+    private int _transportClosedRaised;
 
     /// <summary>
     /// Resumes the outbound counter from a persisted snapshot. Must be called
@@ -319,20 +327,69 @@ internal sealed class FixpClientSession : IAsyncDisposable
                 }
             }
         }
-        catch (OperationCanceledException) { /* shutdown */ }
-        catch (EndOfStreamException) { /* peer closed */ }
-        catch (IOException) { /* peer closed */ }
+        catch (OperationCanceledException)
+        {
+            // Cancelled by DisposeAsync (graceful shutdown) — no transport-loss
+            // signal needed. If the cancellation happened concurrently with a
+            // peer-side close, the user-shutdown flag distinguishes the two:
+            // a peer close that arrived before our cancel still surfaces below.
+            if (System.Threading.Volatile.Read(ref _userShutdown) != 0)
+                return;
+            RaiseTransportClosed(reason: null);
+            return;
+        }
+        catch (EndOfStreamException)
+        {
+            // Peer half-closed the TCP connection (FIN). Surface as a
+            // transport-loss signal so the outer client transitions out of
+            // Established and consumers stop issuing app frames. (#187)
+            RaiseTransportClosed(reason: null);
+            return;
+        }
+        catch (IOException ex)
+        {
+            // Peer closed / RST / socket error. Surface as a transport-loss
+            // signal so callers see an accurate session state instead of a
+            // stale Established. (#187)
+            RaiseTransportClosed(ex);
+            return;
+        }
         catch (Exception ex)
         {
             // Surface telemetry but do NOT poison the shared event channel:
             // the writer is owned by the outer EntryPointClient and must
             // remain usable across session swaps (e.g. ReconnectAsync). #144
             _options.Logger.InboundLoopFaulted(ex);
+            RaiseTransportClosed(ex);
             return;
         }
         // Loop exiting normally (cancellation, peer closed). The shared event
         // channel writer is intentionally NOT completed here — only
         // EntryPointClient.DisposeAsync may complete it. #144
+        if (System.Threading.Volatile.Read(ref _userShutdown) == 0)
+            RaiseTransportClosed(reason: null);
+    }
+
+    /// <summary>
+    /// Latched, idempotent notification that the underlying TCP transport
+    /// is gone (peer-initiated close, RST, or IO error). Drives the state
+    /// machine to <see cref="FixpClientState.Terminated"/> when still
+    /// transition-eligible and invokes <see cref="OnTransportClosed"/> so
+    /// the outer <see cref="EntryPointClient"/> can raise a
+    /// <c>Terminated</c> event and refuse further app sends. (#187)
+    /// </summary>
+    private void RaiseTransportClosed(Exception? reason)
+    {
+        if (System.Threading.Interlocked.Exchange(ref _transportClosedRaised, 1) != 0)
+            return;
+        try
+        {
+            if (_machine.CanFire(FixpClientTrigger.TransportClosed))
+                Fire(FixpClientTrigger.TransportClosed);
+        }
+        catch (InvalidFixpTransitionException) { /* already at a terminal state */ }
+        try { OnTransportClosed?.Invoke(reason); }
+        catch { /* swallow — telemetry must not break shutdown */ }
     }
 
     /// <summary>
@@ -488,8 +545,21 @@ internal sealed class FixpClientSession : IAsyncDisposable
     /// <summary>Optional hook: invoked when a Terminate frame arrives. Arg: terminationCode (byte).</summary>
     internal Action<byte>? OnInboundTerminate { get; set; }
 
+    /// <summary>
+    /// Optional hook: invoked exactly once when the underlying TCP transport
+    /// is closed by the peer (FIN, RST, IO error) without a preceding
+    /// <c>Terminate</c> exchange. Arg is the IO exception that triggered the
+    /// detection, or <see langword="null"/> for a clean FIN / cancellation
+    /// that the user did not initiate. Drives <see cref="EntryPointClient"/>
+    /// to raise its <c>Terminated</c> event and refuse further app sends so
+    /// callers see an accurate session state instead of a stale
+    /// <see cref="FixpClientState.Established"/>. (#187)
+    /// </summary>
+    internal Action<Exception?>? OnTransportClosed { get; set; }
+
     public async ValueTask DisposeAsync()
     {
+        System.Threading.Volatile.Write(ref _userShutdown, 1);
         try { _inboundCts?.Cancel(); } catch { /* ignore */ }
         if (_inboundLoop is not null)
         {

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/FixpClientSessionTransportClosedTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/FixpClientSessionTransportClosedTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using System.Threading.Channels;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Models;
+
+namespace B3.EntryPoint.Client.Tests.Fixp;
+
+/// <summary>
+/// Regression coverage for issue #187 — when the underlying TCP transport is
+/// closed by the peer (e.g. matching-platform restart) without a preceding
+/// <c>Terminate</c> exchange, the session must transition out of
+/// <see cref="FixpClientState.Established"/> so consumer code does not keep
+/// issuing app frames against a dead wire.
+/// </summary>
+public class FixpClientSessionTransportClosedTests
+{
+    private static EntryPointClientOptions Options() => new()
+    {
+        Endpoint = new IPEndPoint(IPAddress.Loopback, 1),
+        SessionId = 1,
+        SessionVerId = 1,
+        EnteringFirm = 1,
+        Credentials = Credentials.FromUtf8("k"),
+    };
+
+    /// <summary>
+    /// Read returns 0 (EOF) immediately, mirroring a peer-side TCP FIN.
+    /// Writes succeed silently so the session can be driven to Established
+    /// via the test-only hook.
+    /// </summary>
+    private sealed class ClosedReadStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => 0;
+        public override long Position { get => 0; set { } }
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override int Read(byte[] buffer, int offset, int count) => 0;
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(0);
+        public override long Seek(long offset, SeekOrigin origin) => 0;
+        public override void SetLength(long value) { }
+        public override void Write(byte[] buffer, int offset, int count) { }
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => Task.CompletedTask;
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public async Task InboundLoop_PeerClose_TransitionsToTerminated_AndRaisesHook()
+    {
+        var stream = new ClosedReadStream();
+        var session = new FixpClientSession(stream, Options());
+        session.ForceEstablishedForTesting();
+        Assert.Equal(FixpClientState.Established, session.State);
+
+        var hookTcs = new TaskCompletionSource<Exception?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        session.OnTransportClosed = ex => hookTcs.TrySetResult(ex);
+
+        var channel = Channel.CreateUnbounded<EntryPointEvent>();
+        session.StartInboundLoop(channel.Writer);
+
+        var fired = await hookTcs.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Null(fired); // EndOfStream → no IOException carried
+
+        Assert.Equal(FixpClientState.Terminated, session.State);
+
+        // Channel writer must remain open — it is shared across reconnects
+        // and only EntryPointClient.DisposeAsync may complete it. (#144)
+        Assert.False(channel.Reader.Completion.IsCompleted);
+
+        await session.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task InboundLoop_UserDispose_DoesNotRaiseTransportClosed()
+    {
+        // Blocks until cancelled — simulates a healthy peer with no traffic.
+        var stream = new BlockingReadStream();
+        var session = new FixpClientSession(stream, Options());
+        session.ForceEstablishedForTesting();
+
+        var raised = 0;
+        session.OnTransportClosed = _ => Interlocked.Increment(ref raised);
+
+        var channel = Channel.CreateUnbounded<EntryPointEvent>();
+        session.StartInboundLoop(channel.Writer);
+
+        // Give the loop a moment to enter ReadAsync.
+        await Task.Delay(50);
+
+        await session.DisposeAsync();
+
+        Assert.Equal(0, raised);
+    }
+
+    private sealed class BlockingReadStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => 0;
+        public override long Position { get => 0; set { } }
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override int Read(byte[] buffer, int offset, int count) => 0;
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+            return 0;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => 0;
+        public override void SetLength(long value) { }
+        public override void Write(byte[] buffer, int offset, int count) { }
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => Task.CompletedTask;
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
When the matching platform restarts (or any peer-side TCP FIN/RST occurs)
the inbound loop in FixpClientSession used to swallow the EndOfStream /
IOException silently. The state machine stayed at `Established` and
subsequent app calls (CancelReplaceAsync, CancelAsync, …) crashed at the
socket write with a misleading error while `State` and health checks
still reported a live session.

Surface the disconnect explicitly:

* RunInboundLoopAsync now fires `TransportClosed` and invokes a new
  one-shot `OnTransportClosed` hook whenever the loop exits due to a
  peer close (EndOfStream/IOException), generic exception, or an
  end-of-stream without a preceding Terminate. A `_userShutdown` latch
  set by DisposeAsync distinguishes graceful teardown so the hook does
  not fire on user-driven cancellation.
* EntryPointClient subscribes the hook in FinishEstablishedAsync and
  raises `Terminated(TerminationCode.Unspecified, …, initiatedByClient:
  false)`, increments the inbound terminations counter, and lets
  EnsureEstablished() refuse further sends with an accurate state.

Two regression tests cover the peer-close transition and the graceful
DisposeAsync path.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
