### PR TITLE
Release v0.15.3: default CancelOnDisconnect to opt-in (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3] - 2026-06-02
+
+### Changed
+- **api (#189)**: `EntryPointClientOptions.CancelOnDisconnect` now defaults
+  to `DoNotCancelOnDisconnectOrTerminate (0)` instead of
+  `CancelOnDisconnectOrTerminate (3)`. The previous aggressive default,
+  combined with `CodTimeoutWindowMs = 0`, made the matching engine cancel
+  **all** of a session's working orders on any client TCP drop (e.g. an OMS
+  restart that reconnects via session resumption). Cancel-on-disconnect is
+  now strictly opt-in, matching the enum's natural zero value. Participants
+  that want the venue to flatten the book on disconnect must set the property
+  (and usually a non-zero `CodTimeoutWindowMs` grace window) explicitly.
+
 ## [0.15.2] - 2026-06-01
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- NuGet metadata shared by all packable projects. -->
-    <Version>0.15.2</Version>
+    <Version>0.15.3</Version>
     <Authors>pedrosakuma</Authors>
     <Company>pedrosakuma</Company>
     <Copyright>Copyright (c) pedrosakuma</Copyright>

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -50,9 +50,14 @@ public sealed class EntryPointClientOptions
     /// <summary>
     /// Cancel-on-disconnect behaviour requested at <c>Establish</c> (schema
     /// 8.4.2 §811, field <c>cancelOnDisconnectType</c>). Defaults to
-    /// <see cref="CancelOnDisconnectType.CancelOnDisconnectOrTerminate"/> —
-    /// the safest choice for a participant that must not leave open orders
-    /// after losing the session.
+    /// <see cref="CancelOnDisconnectType.DoNotCancelOnDisconnectOrTerminate"/> —
+    /// cancel-on-disconnect is strictly opt-in, matching the enum's natural
+    /// zero value. This avoids silently cancelling all of a session's working
+    /// orders on a routine client TCP drop (e.g. an OMS process restart that
+    /// reconnects via session resumption). Participants that genuinely want the
+    /// venue to flatten the book on disconnect must set this explicitly to
+    /// <see cref="CancelOnDisconnectType.CancelOnDisconnectOrTerminate"/> (and
+    /// usually a non-zero <see cref="CodTimeoutWindowMs"/> grace window).
     /// </summary>
     /// <remarks>
     /// The value is encoded into every outbound <c>Establish</c> (both the
@@ -63,7 +68,7 @@ public sealed class EntryPointClientOptions
     /// </remarks>
     [System.Diagnostics.CodeAnalysis.Experimental("B3EP_COD")]
     public CancelOnDisconnectType CancelOnDisconnect { get; set; } =
-        CancelOnDisconnectType.CancelOnDisconnectOrTerminate;
+        CancelOnDisconnectType.DoNotCancelOnDisconnectOrTerminate;
 
     /// <summary>
     /// Grace window (milliseconds) the gateway will wait before triggering

--- a/tests/B3.EntryPoint.Client.Tests/TerminateApiTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/TerminateApiTests.cs
@@ -51,7 +51,7 @@ public class TerminateApiTests
     }
 
     [Fact]
-    public void Options_DefaultCancelOnDisconnect_IsSafest()
+    public void Options_DefaultCancelOnDisconnect_IsOptIn()
     {
         var o = new EntryPointClientOptions
         {
@@ -61,7 +61,7 @@ public class TerminateApiTests
             EnteringFirm = 1,
             Credentials = Credentials.FromUtf8("k"),
         };
-        Assert.Equal(CancelOnDisconnectType.CancelOnDisconnectOrTerminate, o.CancelOnDisconnect);
+        Assert.Equal(CancelOnDisconnectType.DoNotCancelOnDisconnectOrTerminate, o.CancelOnDisconnect);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

`EntryPointClientOptions.CancelOnDisconnect` defaulted to `CancelOnDisconnectOrTerminate (3)` with `CodTimeoutWindowMs = 0`. Any client TCP drop (e.g. an OMS process restart that reconnects via session resumption) made the matching engine immediately cancel **all** of the session's working orders — effectively silent data-loss for a stateful OMS.

## Changes

- Change the default to `DoNotCancelOnDisconnectOrTerminate (0)` so cancel-on-disconnect is **strictly opt-in**, matching the enum's natural zero value.
- Rewrite the XML-doc to explain the risk and how to explicitly re-enable aggressive CoD (plus a non-zero grace window).
- Update the unit test to assert the new opt-in default.

## Validation

- `dotnet build` clean (0 warnings, `TreatWarningsAsErrors`).
- 201/201 unit tests pass.

Fixes #189