### PR TITLE
feat(#191): cold-start session resume + suspendable shutdown

### DIFF
--- a/src/B3.EntryPoint.Client/ConnectMode.cs
+++ b/src/B3.EntryPoint.Client/ConnectMode.cs
@@ -1,0 +1,36 @@
+namespace B3.EntryPoint.Client;
+
+/// <summary>
+/// Selects how <see cref="EntryPointClient.ConnectAsync(System.Threading.CancellationToken)"/>
+/// performs the initial (cold-start / process-restart) FIXP handshake. See
+/// issue #191 for the spec rationale.
+/// </summary>
+public enum ConnectMode
+{
+    /// <summary>
+    /// Legacy behaviour: always perform a fresh <c>Negotiate</c> followed by
+    /// <c>Establish</c>. A persisted snapshot (when configured via
+    /// <see cref="EntryPointClientOptions.SessionStateStore"/>) is still used
+    /// to resume the outbound/inbound sequence counters and outstanding-order
+    /// set after Establish, but the wire handshake always opens a brand-new
+    /// logical session under the configured <c>SessionVerID</c>.
+    /// </summary>
+    NegotiateThenEstablish = 0,
+
+    /// <summary>
+    /// Spec-canonical process-restart resume (B3 EntryPoint 5.3 §5.3, #191):
+    /// when a usable persisted snapshot exists, reconnect TCP and send
+    /// <c>Establish</c> reusing the persisted <c>SessionVerID</c> (no
+    /// <c>Negotiate</c>). If the peer answers <c>EstablishmentAck</c> the
+    /// session is reattached across the process restart — the venue's
+    /// order-ownership and retransmit buffer survive and the
+    /// <c>SessionVerID</c> is not bumped. Only when the peer rejects
+    /// <c>Establish</c> with a recoverable code, or when no usable snapshot is
+    /// available, does the SDK fall back to a fresh <c>Negotiate</c> (with a
+    /// strictly-greater <c>SessionVerID</c> from
+    /// <see cref="EntryPointClientOptions.NextSessionVerIdSelector"/> on the
+    /// recoverable-reject path). Requires
+    /// <see cref="EntryPointClientOptions.SessionStateStore"/> to be set.
+    /// </summary>
+    EstablishReuseThenNegotiate = 1,
+}

--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -169,6 +169,18 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         if (_session is not null)
             throw new InvalidOperationException("Client is already connected.");
 
+        // #191: cold-start (process-restart) session resume. Attempt Establish
+        // reusing the persisted SessionVerID before falling back to a fresh
+        // Negotiate, so venue-side order ownership survives an OMS restart.
+        // Attempted at most ONCE per ConnectAsync, before the Negotiate retry
+        // loop, so a transient Negotiate failure never re-loads the snapshot
+        // and rewinds the SessionVerID (#191 review).
+        if (_options.ConnectMode == ConnectMode.EstablishReuseThenNegotiate &&
+            await TryColdResumeAsync(ct).ConfigureAwait(false))
+        {
+            return;
+        }
+
         var attempts = Math.Max(1, _options.ConnectMaxAttempts);
         Exception? lastError = null;
         for (var attempt = 1; attempt <= attempts; attempt++)
@@ -278,8 +290,6 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
 
         _session!.OnInboundEvent = OnInboundEventForPersistence;
 
-        _session.StartInboundLoop(_events.Writer);
-
         _keepAlive = new KeepAliveScheduler(
             _options.KeepAliveInterval,
             sendSequence: (seq, token) => _session.SendSequenceAsync(seq, token),
@@ -380,6 +390,16 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
                 reason: ex?.Message ?? "TCP transport closed by peer.",
                 initiatedByClient: false);
         };
+
+        // Start the inbound loop LAST — only after every On* callback
+        // (including `_retransmit` and the retransmission handlers above) is
+        // wired. Otherwise a gap frame arriving in the setup window could hit
+        // OnInboundEventForPersistence while `_retransmit` is still null, latch
+        // `_gapRequestInFlight = true` without issuing a request, and
+        // permanently suppress both the live and the cold-resume proactive
+        // retransmit (#191 review).
+        _session.StartInboundLoop(_events.Writer);
+
         _lastInboundUtc = DateTime.UtcNow;
     }
 
@@ -1234,15 +1254,28 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             }
         }
 
-        // Best-effort graceful Terminate before tearing the active session down.
-        try
+        // Best-effort graceful Terminate before tearing the active session
+        // down — ONLY when deliberately rotating to a new logical session
+        // (AlwaysNegotiate). For EstablishReuseThenNegotiate we intend to
+        // reattach the SAME session, so a Terminate(Finished) here would tell
+        // the venue the session is done-for-good and evict order ownership
+        // before the reattach (#191). The old transport is torn down by
+        // StopActiveSessionAsync below in either case.
+        if (mode == ReconnectMode.AlwaysNegotiate)
         {
-            if (_session is not null)
-                await _session.TerminateAsync(B3.Entrypoint.Fixp.Sbe.V6.TerminationCode.FINISHED, ct).ConfigureAwait(false);
+            try
+            {
+                if (_session is not null)
+                    await _session.TerminateAsync(B3.Entrypoint.Fixp.Sbe.V6.TerminationCode.FINISHED, ct).ConfigureAwait(false);
+            }
+            catch { /* best-effort */ }
         }
-        catch { /* best-effort */ }
 
-        await StopActiveSessionAsync(ct).ConfigureAwait(false);
+        // The transport teardown below must not itself emit a
+        // Terminate(Finished) via session dispose: for AlwaysNegotiate we just
+        // sent one explicitly above; for EstablishReuseThenNegotiate we intend
+        // to reattach the same session and must NOT evict ownership (#191).
+        await StopActiveSessionAsync(ct, suppressTerminate: true).ConfigureAwait(false);
 
         ReconnectOutcome outcome;
         if (mode == ReconnectMode.EstablishReuseThenNegotiate)
@@ -1373,14 +1406,15 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             // The current _session is the freshly-built reuse session whose
             // counters are still at 0; do NOT persist a snapshot from it
             // because that would clobber the good snapshot saved when the
-            // prior live session was torn down before reattach.
-            await StopActiveSessionAsync(CancellationToken.None, persistSnapshot: false).ConfigureAwait(false);
+            // prior live session was torn down before reattach. Suppress the
+            // dispose-time Terminate — this is an internal reattach teardown.
+            await StopActiveSessionAsync(CancellationToken.None, persistSnapshot: false, suppressTerminate: true).ConfigureAwait(false);
             throw;
         }
 
         // Reuse rejected — tear down without persisting (same reason as above)
         // and decide on the fallback path.
-        await StopActiveSessionAsync(CancellationToken.None, persistSnapshot: false).ConfigureAwait(false);
+        await StopActiveSessionAsync(CancellationToken.None, persistSnapshot: false, suppressTerminate: true).ConfigureAwait(false);
 
         var code = reuse.RejectCode!.Value;
         if (!IsRecoverableEstablishReject(code))
@@ -1422,6 +1456,183 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     }
 
     /// <summary>
+    /// #191 cold-start (process-restart) session resume. Attempts to reattach
+    /// the previously-negotiated session — TCP reconnect + Establish reusing
+    /// the persisted SessionVerID (no Negotiate) — so the venue keeps order
+    /// ownership across an OMS restart. Mirrors
+    /// <see cref="TryReattachOrRenegotiateAsync"/> but is seeded from the
+    /// persisted snapshot instead of a live in-process session.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when the session was reattached and the client is
+    /// fully connected (the caller must return without Negotiating);
+    /// <see langword="false"/> when there is no usable snapshot, or the peer
+    /// rejected Establish for a recoverable reason and the caller should fall
+    /// through to a fresh Negotiate (the SessionVerID has been bumped in that
+    /// case).
+    /// </returns>
+    private async Task<bool> TryColdResumeAsync(CancellationToken ct)
+    {
+        var store = _options.SessionStateStore;
+        if (store is null)
+            return false;
+
+        var snapshot = await store.ReplayAsync(ct).ConfigureAwait(false);
+        if (snapshot is null)
+            return false;
+
+        // A snapshot from a different SessionId, or one that never reached a
+        // negotiated SessionVerID, cannot be reattached — fall through to the
+        // normal Negotiate path under the configured SessionVerID.
+        if (snapshot.SessionId != _options.SessionId || snapshot.SessionVerId == 0u)
+            return false;
+
+        // Establish.NextSeqNo (the client's next outbound app MsgSeqNum) is a
+        // uint on the wire; refuse to resume rather than wrap.
+        if (snapshot.LastOutboundSeqNum + 1UL > uint.MaxValue)
+            return false;
+
+        var nextOutbound = (uint)(snapshot.LastOutboundSeqNum + 1UL);
+
+        // Resume the SAME logical session: reuse the persisted SessionVerID,
+        // do NOT bump it. The selector is only consulted on the recoverable
+        // reject path below.
+        _options.SessionVerId = snapshot.SessionVerId;
+
+        var tcp = new TcpClient();
+        try
+        {
+            using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            connectCts.CancelAfter(_options.ConnectTimeout);
+            await tcp.ConnectAsync(_options.Endpoint.Address, _options.Endpoint.Port, connectCts.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            tcp.Dispose();
+            throw;
+        }
+
+        _tcp = tcp;
+        Fixp.EstablishReuseResult reuse;
+        try
+        {
+            var transportStream = await EstablishTransportStreamAsync(tcp, ct).ConfigureAwait(false);
+            _session = new FixpClientSession(transportStream, _options);
+
+            using (var establish = EntryPointTelemetry.ActivitySource.StartActivity("entrypoint.establish.coldresume", ActivityKind.Client))
+            {
+                reuse = await _session.EstablishReuseAsync(nextOutbound, ct).ConfigureAwait(false);
+            }
+
+            if (reuse.Accepted)
+            {
+                var ack = reuse.Ack!.Value;
+                _options.Logger.Established(_options.Endpoint);
+
+                // FinishEstablishedAsync -> HydrateFromSnapshotAsync re-reads
+                // this same snapshot and resumes the outbound counter to
+                // LastOutboundSeqNum+1 and the inbound contiguity tail to
+                // LastInboundSeqNum, so the cross-restart application sequence
+                // is continuous. Resume explicitly first to mirror the live
+                // reattach path and stay correct even if hydration is skipped.
+                _session!.ResumeOutboundSeqNum(snapshot.LastOutboundSeqNum + 1UL);
+
+                await FinishEstablishedAsync(ct).ConfigureAwait(false);
+                StartIdleWatchdog();
+
+                _options.Logger.ColdResumeReattached(_options.SessionId, _options.SessionVerId, nextOutbound);
+
+                // If the peer advertises an inbound gap (it will deliver seq
+                // numbers beyond our persisted contiguous tail), proactively
+                // request retransmission. The live inbound-gap detector only
+                // fires when a post-gap frame arrives; on a fresh reattach the
+                // venue may report the gap in the Ack and then send nothing
+                // until we ask.
+                MaybeRequestColdResumeInboundGap(ack.NextSeqNo, snapshot.LastInboundSeqNum);
+
+                return true;
+            }
+        }
+        catch
+        {
+            // Reuse blew up (transport / decode). The current _session is the
+            // freshly-built reuse session whose counters are at 0; do NOT
+            // persist a snapshot from it — that would clobber the good
+            // persisted snapshot we just loaded. Rethrow so the host retries
+            // ConnectAsync; the SessionVerID stays at the persisted value.
+            // Suppress the dispose-time Terminate (internal teardown).
+            await StopActiveSessionAsync(CancellationToken.None, persistSnapshot: false, suppressTerminate: true).ConfigureAwait(false);
+            throw;
+        }
+
+        // Reuse rejected — tear down without persisting and decide. Suppress
+        // the dispose-time Terminate (internal teardown).
+        await StopActiveSessionAsync(CancellationToken.None, persistSnapshot: false, suppressTerminate: true).ConfigureAwait(false);
+
+        var code = reuse.RejectCode!.Value;
+        if (!IsRecoverableEstablishReject(code))
+            throw new Fixp.FixpEstablishRejectedException(code);
+
+        // Recoverable: bump the SessionVerID via the validated selector and let
+        // the caller fall through to a fresh Negotiate.
+        var selector = _options.NextSessionVerIdSelector ?? (static prev => prev + 1u);
+        var prevVerId = _options.SessionVerId;
+        var nextVerId = selector(prevVerId);
+        if (nextVerId <= prevVerId)
+            throw new InvalidOperationException(
+                $"NextSessionVerIdSelector returned {nextVerId} which is not strictly greater than the persisted SessionVerId {prevVerId}.");
+
+        _options.Logger.ColdResumeFallbackToNegotiate(code, prevVerId);
+        _options.SessionVerId = nextVerId;
+        return false;
+    }
+
+    /// <summary>
+    /// On a successful cold reattach, issue a single §4.7 RetransmitRequest when
+    /// the peer's Ack advertises inbound frames past our persisted contiguous
+    /// tail. Reuses the fire-and-forget pattern of the live inbound-gap
+    /// detector (<see cref="OnInboundEventForPersistence"/>).
+    /// </summary>
+    private void MaybeRequestColdResumeInboundGap(ulong ackNextSeqNo, ulong lastContiguousInbound)
+    {
+        if (ackNextSeqNo <= lastContiguousInbound + 1UL)
+            return;
+
+        ulong gapFrom;
+        uint gapCount;
+        lock (_inboundGapGate)
+        {
+            if (_gapRequestInFlight)
+                return;
+            gapFrom = lastContiguousInbound + 1UL;
+            var missing = ackNextSeqNo - gapFrom;
+            gapCount = (uint)Math.Min(missing, RetransmitRequestHandler.MaxCountPerRequest);
+            _gapRequestInFlight = true;
+        }
+
+        _options.Logger.InboundGapDetected(gapFrom, ackNextSeqNo, gapFrom, gapCount);
+        var handler = _retransmit;
+        if (handler is null)
+        {
+            lock (_inboundGapGate) { _gapRequestInFlight = false; }
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await handler.RequestRetransmitAsync(gapFrom, gapCount).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                lock (_inboundGapGate) { _gapRequestInFlight = false; }
+                _options.Logger.InboundGapRequestFailed(ex, gapFrom, gapCount);
+            }
+        });
+    }
+
+    /// <summary>
     /// Async stream of unsolicited events from the peer
     /// (<see cref="OrderAccepted"/>, <see cref="OrderRejected"/>,
     /// <see cref="OrderTrade"/>, <see cref="OrderCancelled"/>,
@@ -1457,7 +1668,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     /// <see cref="ReconnectAsync(uint, System.Threading.CancellationToken)"/> and <see cref="DisposeAsync"/> so the
     /// same ordering applies in both paths (#124).
     /// </summary>
-    private async Task StopActiveSessionAsync(CancellationToken ct, bool persistSnapshot = true)
+    private async Task StopActiveSessionAsync(CancellationToken ct, bool persistSnapshot = true, bool suppressTerminate = false)
     {
         var timeout = _options.SessionTeardownTimeout;
         if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromSeconds(5);
@@ -1497,6 +1708,13 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         try { _keepAlive?.Dispose(); } catch { }
         if (_session is not null)
         {
+            // Internal teardowns (within-process reconnect / cold-resume
+            // fallback) must not emit a Terminate(Finished) — we are about to
+            // re-open the session, and a Terminate would evict venue-side order
+            // ownership (#191). Graceful client dispose leaves this false so
+            // EntryPointClientOptions.TerminateOnDispose governs as usual.
+            if (suppressTerminate)
+                _session.SuppressTerminateOnDispose = true;
             try { await _session.DisposeAsync().ConfigureAwait(false); } catch { }
         }
         try { _tcp?.Dispose(); } catch { }

--- a/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClientOptions.cs
@@ -161,6 +161,52 @@ public sealed class EntryPointClientOptions
     public TlsOptions Tls { get; set; } = new();
 
     /// <summary>
+    /// Selects how <see cref="EntryPointClient.ConnectAsync(CancellationToken)"/>
+    /// performs the initial (cold-start / process-restart) handshake. Defaults
+    /// to <see cref="ConnectMode.NegotiateThenEstablish"/> (legacy behaviour).
+    /// Set to <see cref="ConnectMode.EstablishReuseThenNegotiate"/> to make a
+    /// process restart RESUME the previously-negotiated session by sending
+    /// <c>Establish</c> reusing the persisted <c>SessionVerID</c> before
+    /// falling back to a fresh <c>Negotiate</c> — so venue-side order
+    /// ownership survives an OMS restart (#191). Requires
+    /// <see cref="SessionStateStore"/> to be configured; without a usable
+    /// persisted snapshot the client behaves as
+    /// <see cref="ConnectMode.NegotiateThenEstablish"/>.
+    /// </summary>
+    public ConnectMode ConnectMode { get; set; } = ConnectMode.NegotiateThenEstablish;
+
+    /// <summary>
+    /// Selector invoked <em>only</em> when a cold-start Establish-reuse
+    /// (<see cref="ConnectMode.EstablishReuseThenNegotiate"/>) is rejected for
+    /// a recoverable reason and a fresh <c>Negotiate</c> with a
+    /// strictly-greater <c>SessionVerID</c> is therefore required. Receives the
+    /// persisted (rejected) <c>SessionVerID</c> and must return a
+    /// strictly-greater value (e.g. the spec's recommended
+    /// microseconds-since-epoch). When <see langword="null"/>, defaults to
+    /// <c>prev =&gt; prev + 1</c>.
+    /// </summary>
+    public Func<uint, uint>? NextSessionVerIdSelector { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/> (the default), the client sends a FIXP
+    /// <c>Terminate(Finished)</c> to the peer when the session is disposed.
+    /// This tells the venue the session is deliberately done-for-good (spec
+    /// §5.1) and the venue evicts the session's order-ownership state.
+    /// <para>
+    /// Set to <see langword="false"/> when the host intends to restart and
+    /// resume: dispose then closes the transport WITHOUT a Terminate, leaving
+    /// the venue session resumable (Suspended) so a subsequent
+    /// <see cref="ConnectMode.EstablishReuseThenNegotiate"/> cold start can
+    /// reattach it and keep working orders addressable (#191). The final
+    /// snapshot is still persisted on dispose. Operator/end-of-day logout that
+    /// genuinely wants the venue to drop the session should call
+    /// <see cref="EntryPointClient.TerminateAsync(TerminationCode, CancellationToken)"/>
+    /// explicitly.
+    /// </para>
+    /// </summary>
+    public bool TerminateOnDispose { get; set; } = true;
+
+    /// <summary>
     /// When <see langword="true"/> (the default), <see cref="EntryPointClient"/>
     /// invokes <see cref="Stream.FlushAsync(CancellationToken)"/> on the
     /// underlying transport after every outbound application frame. This is the

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -557,6 +557,18 @@ internal sealed class FixpClientSession : IAsyncDisposable
     /// </summary>
     internal Action<Exception?>? OnTransportClosed { get; set; }
 
+    /// <summary>
+    /// When set, suppresses the dispose-time <c>Terminate(Finished)</c> for
+    /// this session instance regardless of
+    /// <see cref="EntryPointClientOptions.TerminateOnDispose"/>. Used by the
+    /// client for INTERNAL teardowns (within-process reconnect / cold-start
+    /// reattach fallback) where the transport is being closed only to
+    /// immediately re-open under the same or a fresh SessionVerID — sending a
+    /// Terminate(Finished) there would tell the venue the session is
+    /// done-for-good and evict order ownership (#191).
+    /// </summary>
+    internal bool SuppressTerminateOnDispose { get; set; }
+
     public async ValueTask DisposeAsync()
     {
         System.Threading.Volatile.Write(ref _userShutdown, 1);
@@ -566,8 +578,17 @@ internal sealed class FixpClientSession : IAsyncDisposable
             try { await _inboundLoop.ConfigureAwait(false); } catch { /* ignore */ }
         }
         _inboundCts?.Dispose();
-        try { await TerminateAsync(SbeTerminationCode.FINISHED, CancellationToken.None).ConfigureAwait(false); }
-        catch { /* best-effort */ }
+        if (_options.TerminateOnDispose && !SuppressTerminateOnDispose)
+        {
+            // #191: gated so a host that intends to restart and resume can
+            // dispose WITHOUT telling the venue the session is done-for-good
+            // (Terminate=Finished evicts venue-side order ownership). When
+            // false (or suppressed for an internal reattach teardown), the
+            // transport is closed cleanly below and the venue keeps the
+            // session resumable (Suspended).
+            try { await TerminateAsync(SbeTerminationCode.FINISHED, CancellationToken.None).ConfigureAwait(false); }
+            catch { /* best-effort */ }
+        }
         await _stream.DisposeAsync().ConfigureAwait(false);
     }
 

--- a/src/B3.EntryPoint.Client/Logging/LogMessages.cs
+++ b/src/B3.EntryPoint.Client/Logging/LogMessages.cs
@@ -85,6 +85,14 @@ internal static partial class LogMessages
         Message = "Graceful Terminate sent to {Endpoint} (code={Code})")]
     public static partial void GracefulTerminate(this ILogger logger, EndPoint endpoint, int code);
 
+    [LoggerMessage(EventId = 3007, Level = LogLevel.Information,
+        Message = "Cold-start resume reattached: SessionID={SessionId} SessionVerID={SessionVerId} nextOutboundSeqNo={NextOutboundSeqNo}")]
+    public static partial void ColdResumeReattached(this ILogger logger, uint sessionId, uint sessionVerId, uint nextOutboundSeqNo);
+
+    [LoggerMessage(EventId = 3008, Level = LogLevel.Information,
+        Message = "Cold-start resume rejected (code={Code}); falling back to Negotiate from SessionVerID={SessionVerId}")]
+    public static partial void ColdResumeFallbackToNegotiate(this ILogger logger, B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode code, uint sessionVerId);
+
     // ---------------- Warning (4000–4999) ----------------
 
     [LoggerMessage(EventId = 4000, Level = LogLevel.Warning,

--- a/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
+++ b/src/B3.EntryPoint.Client/PublicAPI.Unshipped.txt
@@ -1,1 +1,10 @@
 #nullable enable
+B3.EntryPoint.Client.ConnectMode
+B3.EntryPoint.Client.ConnectMode.EstablishReuseThenNegotiate = 1 -> B3.EntryPoint.Client.ConnectMode
+B3.EntryPoint.Client.ConnectMode.NegotiateThenEstablish = 0 -> B3.EntryPoint.Client.ConnectMode
+B3.EntryPoint.Client.EntryPointClientOptions.ConnectMode.get -> B3.EntryPoint.Client.ConnectMode
+B3.EntryPoint.Client.EntryPointClientOptions.ConnectMode.set -> void
+B3.EntryPoint.Client.EntryPointClientOptions.NextSessionVerIdSelector.get -> System.Func<uint, uint>?
+B3.EntryPoint.Client.EntryPointClientOptions.NextSessionVerIdSelector.set -> void
+B3.EntryPoint.Client.EntryPointClientOptions.TerminateOnDispose.get -> bool
+B3.EntryPoint.Client.EntryPointClientOptions.TerminateOnDispose.set -> void

--- a/tests/B3.EntryPoint.Client.Tests/ColdStartResumeTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/ColdStartResumeTests.cs
@@ -1,0 +1,281 @@
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.State;
+using B3.EntryPoint.Client.TestPeer;
+
+namespace B3.EntryPoint.Client.Tests;
+
+/// <summary>
+/// Coverage for #191: cold-start (process-restart) session resume. With
+/// <see cref="ConnectMode.EstablishReuseThenNegotiate"/> a fresh process should
+/// reattach the previously-negotiated session via <c>Establish</c> reusing the
+/// persisted <c>SessionVerID</c> (no <c>Negotiate</c>) so venue-side order
+/// ownership survives the restart, falling back to <c>Negotiate</c> only when
+/// the peer rejects Establish or no usable snapshot exists. Also covers the
+/// <see cref="EntryPointClientOptions.TerminateOnDispose"/> suspendable-shutdown
+/// half.
+/// </summary>
+public class ColdStartResumeTests
+{
+    private const ushort NegotiateTemplateId = B3.Entrypoint.Fixp.Sbe.V6.NegotiateData.MESSAGE_ID;
+    private const ushort EstablishTemplateId = B3.Entrypoint.Fixp.Sbe.V6.EstablishData.MESSAGE_ID;
+    private const ushort TerminateTemplateId = B3.Entrypoint.Fixp.Sbe.V6.TerminateData.MESSAGE_ID;
+
+    private static EntryPointClientOptions Options(InProcessFixpTestPeer peer) => new()
+    {
+        Endpoint = peer.LocalEndpoint,
+        SessionId = 42u,
+        SessionVerId = 1u,
+        EnteringFirm = 7u,
+        Credentials = Credentials.FromUtf8("k"),
+        KeepAliveIntervalMs = 60_000u,
+    };
+
+    private static SessionSnapshot Snapshot(uint sessionId = 42u, uint sessionVerId = 7u,
+        ulong lastOut = 5u, ulong lastIn = 3u) => new()
+        {
+            SessionId = sessionId,
+            SessionVerId = sessionVerId,
+            LastOutboundSeqNum = lastOut,
+            LastInboundSeqNum = lastIn,
+            CapturedAt = DateTimeOffset.UtcNow,
+        };
+
+    [Fact]
+    public async Task ColdResume_WithUsableSnapshot_Reattaches_WithoutNegotiate_AndKeepsSessionVerId()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        var sawNegotiate = 0;
+        var sawEstablish = 0;
+        peer.MessageReceived += (_, e) =>
+        {
+            if (e.TemplateId == NegotiateTemplateId) Interlocked.Increment(ref sawNegotiate);
+            if (e.TemplateId == EstablishTemplateId) Interlocked.Increment(ref sawEstablish);
+        };
+        peer.Start();
+
+        var options = Options(peer);
+        options.ConnectMode = ConnectMode.EstablishReuseThenNegotiate;
+        options.SessionStateStore = new SnapshotStore(Snapshot(sessionVerId: 7u, lastOut: 5u));
+        await using var client = new EntryPointClient(options);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await client.ConnectAsync(cts.Token);
+
+        Assert.Equal(0, sawNegotiate);
+        Assert.Equal(1, sawEstablish);
+        // Reused, not bumped.
+        Assert.Equal(7u, options.SessionVerId);
+    }
+
+    [Fact]
+    public async Task ColdResume_EstablishRejectedUnnegotiated_FallsBackToNegotiate_WithBumpedVerId()
+    {
+        await using var peer = new InProcessFixpTestPeer(new TestPeerOptions
+        {
+            RejectEstablishWithoutPriorNegotiate = true,
+        });
+        var sawNegotiate = 0;
+        peer.MessageReceived += (_, e) =>
+        {
+            if (e.TemplateId == NegotiateTemplateId) Interlocked.Increment(ref sawNegotiate);
+        };
+        peer.Start();
+
+        var options = Options(peer);
+        options.ConnectMode = ConnectMode.EstablishReuseThenNegotiate;
+        options.SessionStateStore = new SnapshotStore(Snapshot(sessionVerId: 7u));
+        options.NextSessionVerIdSelector = prev => prev + 100u;
+        await using var client = new EntryPointClient(options);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await client.ConnectAsync(cts.Token);
+
+        // The recoverable reject forced a Negotiate, and the verId was bumped
+        // off the persisted (rejected) value via the selector.
+        Assert.True(sawNegotiate >= 1);
+        Assert.Equal(107u, options.SessionVerId);
+    }
+
+    [Fact]
+    public async Task ColdResume_NoSnapshot_PlainNegotiate_NoVerIdChange()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        var sawNegotiate = 0;
+        peer.MessageReceived += (_, e) =>
+        {
+            if (e.TemplateId == NegotiateTemplateId) Interlocked.Increment(ref sawNegotiate);
+        };
+        peer.Start();
+
+        var options = Options(peer);
+        options.ConnectMode = ConnectMode.EstablishReuseThenNegotiate;
+        options.SessionStateStore = new SnapshotStore(null);
+        await using var client = new EntryPointClient(options);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await client.ConnectAsync(cts.Token);
+
+        Assert.Equal(1, sawNegotiate);
+        Assert.Equal(1u, options.SessionVerId);
+    }
+
+    [Fact]
+    public async Task ColdResume_SessionIdMismatchSnapshot_PlainNegotiate()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        var sawNegotiate = 0;
+        peer.MessageReceived += (_, e) =>
+        {
+            if (e.TemplateId == NegotiateTemplateId) Interlocked.Increment(ref sawNegotiate);
+        };
+        peer.Start();
+
+        var options = Options(peer);
+        options.ConnectMode = ConnectMode.EstablishReuseThenNegotiate;
+        // Snapshot belongs to a different SessionId → not reattachable.
+        options.SessionStateStore = new SnapshotStore(Snapshot(sessionId: 999u, sessionVerId: 7u));
+        await using var client = new EntryPointClient(options);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await client.ConnectAsync(cts.Token);
+
+        Assert.Equal(1, sawNegotiate);
+        Assert.Equal(1u, options.SessionVerId);
+    }
+
+    [Fact]
+    public async Task ColdResume_SnapshotWithZeroVerId_PlainNegotiate()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        var sawNegotiate = 0;
+        peer.MessageReceived += (_, e) =>
+        {
+            if (e.TemplateId == NegotiateTemplateId) Interlocked.Increment(ref sawNegotiate);
+        };
+        peer.Start();
+
+        var options = Options(peer);
+        options.ConnectMode = ConnectMode.EstablishReuseThenNegotiate;
+        options.SessionStateStore = new SnapshotStore(Snapshot(sessionVerId: 0u));
+        await using var client = new EntryPointClient(options);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await client.ConnectAsync(cts.Token);
+
+        Assert.Equal(1, sawNegotiate);
+    }
+
+    [Fact]
+    public async Task DefaultConnectMode_AlwaysNegotiates_RegressionGuard()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        var sawNegotiate = 0;
+        peer.MessageReceived += (_, e) =>
+        {
+            if (e.TemplateId == NegotiateTemplateId) Interlocked.Increment(ref sawNegotiate);
+        };
+        peer.Start();
+
+        var options = Options(peer);
+        // Default ConnectMode + a perfectly usable snapshot must STILL Negotiate.
+        options.SessionStateStore = new SnapshotStore(Snapshot(sessionVerId: 7u));
+        Assert.Equal(ConnectMode.NegotiateThenEstablish, options.ConnectMode);
+        await using var client = new EntryPointClient(options);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await client.ConnectAsync(cts.Token);
+
+        Assert.Equal(1, sawNegotiate);
+    }
+
+    [Fact]
+    public async Task TerminateOnDispose_False_DoesNotSendTerminate()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        var sawTerminate = 0;
+        peer.MessageReceived += (_, e) =>
+        {
+            if (e.TemplateId == TerminateTemplateId) Interlocked.Increment(ref sawTerminate);
+        };
+        peer.Start();
+
+        var options = Options(peer);
+        options.TerminateOnDispose = false;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var client = new EntryPointClient(options);
+        await client.ConnectAsync(cts.Token);
+
+        await client.DisposeAsync();
+
+        // Give the peer a moment to observe any (unexpected) Terminate frame.
+        await Task.Delay(200, cts.Token);
+        Assert.Equal(0, sawTerminate);
+    }
+
+    [Fact]
+    public async Task TerminateOnDispose_DefaultTrue_SendsTerminate()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        var terminateSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        peer.MessageReceived += (_, e) =>
+        {
+            if (e.TemplateId == TerminateTemplateId) terminateSeen.TrySetResult();
+        };
+        peer.Start();
+
+        var options = Options(peer);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var client = new EntryPointClient(options);
+        await client.ConnectAsync(cts.Token);
+
+        await client.DisposeAsync();
+
+        var completed = await Task.WhenAny(terminateSeen.Task, Task.Delay(2000, cts.Token));
+        Assert.Same(terminateSeen.Task, completed);
+    }
+
+    [Fact]
+    public async Task Reconnect_EstablishReuse_DoesNotEmitTerminate_EvenWhenTerminateOnDisposeTrue()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        var terminatesDuringReconnect = 0;
+        var reconnecting = false;
+        peer.MessageReceived += (_, e) =>
+        {
+            if (reconnecting && e.TemplateId == TerminateTemplateId)
+                Interlocked.Increment(ref terminatesDuringReconnect);
+        };
+        peer.Start();
+
+        var options = Options(peer); // TerminateOnDispose defaults to true
+        await using var client = new EntryPointClient(options);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(cts.Token);
+
+        reconnecting = true;
+        var outcome = await client.ReconnectAsync(
+            ReconnectMode.EstablishReuseThenNegotiate, nextSessionVerIdSelector: null, cts.Token);
+        await Task.Delay(150, cts.Token);
+        reconnecting = false;
+
+        Assert.Equal(ReconnectKind.Reattached, outcome.Kind);
+        Assert.Equal(0, terminatesDuringReconnect);
+    }
+
+    private sealed class SnapshotStore : ISessionStateStore
+    {
+        private SessionSnapshot? _snapshot;
+        public SnapshotStore(SessionSnapshot? snapshot) => _snapshot = snapshot;
+
+        public ValueTask<SessionSnapshot?> LoadAsync(CancellationToken ct = default) => new(_snapshot);
+        public ValueTask SaveAsync(SessionSnapshot snapshot, CancellationToken ct = default)
+        {
+            _snapshot = snapshot;
+            return default;
+        }
+        public ValueTask AppendDeltaAsync(SessionDelta delta, CancellationToken ct = default) => default;
+        public ValueTask<SessionSnapshot?> ReplayAsync(CancellationToken ct = default) => new(_snapshot);
+        public ValueTask CompactAsync(CancellationToken ct = default) => default;
+    }
+}


### PR DESCRIPTION
Closes #191.

Makes an OMS process restart **resume** the negotiated FIXP session instead of evicting venue-side order ownership. Two opt-in halves, both default-off (back-compat).

## Half A — suspendable shutdown
- `EntryPointClientOptions.TerminateOnDispose` (default `true`). When `false`, `FixpClientSession.DisposeAsync` closes the transport **without** `Terminate(Finished)`, leaving the venue session resumable (Suspended). Final snapshot still persisted.
- Internal teardowns (within-process reconnect reattach + cold-resume fallback) now suppress the dispose-time `Terminate` unconditionally via `FixpClientSession.SuppressTerminateOnDispose`. Previously the reconnect path's `StopActiveSessionAsync` still emitted `Terminate` when `TerminateOnDispose=true`, which would evict ownership on a real venue **before** the reattach Establish — defeating #173 reattach. Now a reattach never Terminates.

## Half B — cold-start resume
- New `ConnectMode { NegotiateThenEstablish=0 (default), EstablishReuseThenNegotiate=1 }` + `NextSessionVerIdSelector`.
- `ConnectAsync` with `EstablishReuseThenNegotiate` runs `TryColdResumeAsync` **once** before the Negotiate retry loop: loads the persisted snapshot and, if usable (same `SessionId`, non-zero `SessionVerId`, no `uint` overflow), reconnects TCP and sends `Establish` reusing the persisted `SessionVerID` (`NextSeqNo = LastOutboundSeqNum+1`) — **no Negotiate**. On Ack → resume counters + `FinishEstablished` + proactive inbound `RetransmitRequest` when the Ack advertises a gap. On recoverable reject → teardown, bump `SessionVerID` via the validated selector, fall through to a fresh Negotiate. On non-recoverable reject → throw.

## Incidental fix
`StartInboundLoop` now runs only after every `On*` callback (incl. `_retransmit`) is wired, so a gap frame in the setup window can no longer latch `_gapRequestInFlight` without issuing a request (surfaced by the proactive cold-resume retransmit).

## Design notes
- **Outbound seq resumes across a verID bump on the Negotiate fallback**, consistent with the existing `Spec_4_7_Retransmit/ReconnectRetransmitTests` contract — `HydrateFromSnapshotAsync` deliberately left unchanged.
- New public API recorded in `PublicAPI.Unshipped.txt` (RS0016).

## Tests
`ColdStartResumeTests` (9): reuse-accepted (no Negotiate, verID unchanged), recoverable-reject fallback (Negotiate + bumped verID), no-snapshot / SessionId-mismatch / zero-verID → plain Negotiate, default-`ConnectMode` regression guard, `TerminateOnDispose` true/false dispose behavior, reattach-emits-no-Terminate. Full client suite green (210/210), `dotnet format` clean.

Reviewed with a gpt-5.5 code-review pass; both findings (reattach-still-Terminates; early-gap suppression) were addressed in this PR.

> Downstream: B3TradingPlatform#512 wires `TerminateOnDispose=false` + `ConnectMode=EstablishReuseThenNegotiate` and stops the unconditional verID bump, after this SDK ships.
