### PR TITLE
Release v0.16.1: fix stale-snapshot resume on SessionVerId bump (#208)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- NuGet metadata shared by all packable projects. -->
-    <Version>0.16.0</Version>
+    <Version>0.16.1</Version>
     <Authors>pedrosakuma</Authors>
     <Company>pedrosakuma</Company>
     <Copyright>Copyright (c) pedrosakuma</Copyright>


### PR DESCRIPTION
Bumps package version to 0.16.1 to release the #208 fix (#209): HydrateFromSnapshotAsync no longer resumes outbound/inbound state from a stale pre-bump snapshot after a cold-start EstablishReuse reject falls back to Negotiate.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>