### PR TITLE
Serialize outbound frame writes to fix Stream.WriteAsync race (#211)

### DIFF
--- a/src/B3.EntryPoint.Client/EntryPointClient.cs
+++ b/src/B3.EntryPoint.Client/EntryPointClient.cs
@@ -30,6 +30,15 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     private TcpClient? _tcp;
     private FixpClientSession? _session;
 
+    // #211: NextOutboundSeqNum() reserves a MsgSeqNum atomically, but the
+    // subsequent encode + SendApplicationFrameAsync steps are not otherwise
+    // serialized. Two concurrent callers (e.g. "Cancel All" firing several
+    // CancelAsync calls) could reserve seq N and N+1, then race to actually
+    // write to the wire, letting N+1 land before N. This lock spans
+    // reserve-seq -> encode -> write for every outbound application frame so
+    // wire order always matches seq-assignment order.
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
+
     // #208: set by TryColdResumeAsync immediately before it bumps SessionVerID
     // and falls through to a fresh Negotiate (recoverable EstablishReuse
     // reject). Consumed exactly once by the following HydrateFromSnapshotAsync
@@ -960,6 +969,32 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         catch (OperationCanceledException) { /* shutdown */ }
     }
 
+    /// <summary>
+    /// Reserves the next outbound MsgSeqNum, encodes the application frame via
+    /// <paramref name="encode"/>, and writes it to the session — all under
+    /// <see cref="_sendLock"/> (#211) so the reserve→encode→write critical
+    /// section for concurrent outbound calls (e.g. a burst of CancelAsync from
+    /// a "Cancel All" action) can never interleave. This guarantees the wire
+    /// order of application frames always matches the order in which their
+    /// MsgSeqNum was assigned.
+    /// </summary>
+    private async Task<ulong> SendOrderEntryFrameAsync(
+        Func<ulong, (byte[] Buffer, int Length)> encode, CancellationToken ct)
+    {
+        await _sendLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var seq = _session!.NextOutboundSeqNum();
+            var (buffer, len) = encode(seq);
+            await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+            return seq;
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+    }
+
     /// <inheritdoc />
     public async Task<ClOrdID> SubmitAsync(NewOrderRequest request, CancellationToken ct = default)
     {
@@ -969,10 +1004,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         await EvaluateRiskAsync(OutboundRequestKind.NewOrder, request, request.SecurityId, clordid, ct).ConfigureAwait(false);
         using var activity = StartOutbound("entrypoint.submit", OutboundRequestKind.NewOrder, request.SecurityId, clordid);
         var startTs = Stopwatch.GetTimestamp();
-        var seq = _session!.NextOutboundSeqNum();
-        var buffer = new byte[NewOrderSingleData.MESSAGE_SIZE + 256];
-        var len = OrderEntryEncoder.EncodeNewOrderSingle(buffer, request, _options, seq);
-        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        var seq = await SendOrderEntryFrameAsync(s =>
+        {
+            var buffer = new byte[NewOrderSingleData.MESSAGE_SIZE + 256];
+            var len = OrderEntryEncoder.EncodeNewOrderSingle(buffer, request, _options, s);
+            return (buffer, len);
+        }, ct).ConfigureAwait(false);
         await AppendOutboundOrderDeltaAsync(seq, request.ClOrdID, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "NewOrder"));
         RecordLatency(startTs, OutboundRequestKind.NewOrder);
@@ -988,10 +1025,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         await EvaluateRiskAsync(OutboundRequestKind.SimpleNewOrder, request, request.SecurityId, clordid, ct).ConfigureAwait(false);
         using var activity = StartOutbound("entrypoint.submit_simple", OutboundRequestKind.SimpleNewOrder, request.SecurityId, clordid);
         var startTs = Stopwatch.GetTimestamp();
-        var seq = _session!.NextOutboundSeqNum();
-        var buffer = new byte[SimpleNewOrderData.MESSAGE_SIZE + 64];
-        var len = OrderEntryEncoder.EncodeSimpleNewOrder(buffer, request, _options, seq);
-        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        var seq = await SendOrderEntryFrameAsync(s =>
+        {
+            var buffer = new byte[SimpleNewOrderData.MESSAGE_SIZE + 64];
+            var len = OrderEntryEncoder.EncodeSimpleNewOrder(buffer, request, _options, s);
+            return (buffer, len);
+        }, ct).ConfigureAwait(false);
         await AppendOutboundOrderDeltaAsync(seq, request.ClOrdID, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "SimpleNewOrder"));
         RecordLatency(startTs, OutboundRequestKind.SimpleNewOrder);
@@ -1007,10 +1046,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         await EvaluateRiskAsync(OutboundRequestKind.Replace, request, request.SecurityId, clordid, ct).ConfigureAwait(false);
         using var activity = StartOutbound("entrypoint.replace", OutboundRequestKind.Replace, request.SecurityId, clordid);
         var startTs = Stopwatch.GetTimestamp();
-        var seq = _session!.NextOutboundSeqNum();
-        var buffer = new byte[OrderCancelReplaceRequestData.MESSAGE_SIZE + 256];
-        var len = OrderEntryEncoder.EncodeOrderCancelReplace(buffer, request, _options, seq);
-        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        var seq = await SendOrderEntryFrameAsync(s =>
+        {
+            var buffer = new byte[OrderCancelReplaceRequestData.MESSAGE_SIZE + 256];
+            var len = OrderEntryEncoder.EncodeOrderCancelReplace(buffer, request, _options, s);
+            return (buffer, len);
+        }, ct).ConfigureAwait(false);
         await AppendOutboundOrderDeltaAsync(seq, request.ClOrdID, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersReplaced.Add(1, new KeyValuePair<string, object?>("kind", "Replace"));
         RecordLatency(startTs, OutboundRequestKind.Replace);
@@ -1026,10 +1067,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         await EvaluateRiskAsync(OutboundRequestKind.SimpleReplace, request, request.SecurityId, clordid, ct).ConfigureAwait(false);
         using var activity = StartOutbound("entrypoint.replace_simple", OutboundRequestKind.SimpleReplace, request.SecurityId, clordid);
         var startTs = Stopwatch.GetTimestamp();
-        var seq = _session!.NextOutboundSeqNum();
-        var buffer = new byte[SimpleModifyOrderData.MESSAGE_SIZE + 64];
-        var len = OrderEntryEncoder.EncodeSimpleModifyOrder(buffer, request, _options, seq);
-        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        var seq = await SendOrderEntryFrameAsync(s =>
+        {
+            var buffer = new byte[SimpleModifyOrderData.MESSAGE_SIZE + 64];
+            var len = OrderEntryEncoder.EncodeSimpleModifyOrder(buffer, request, _options, s);
+            return (buffer, len);
+        }, ct).ConfigureAwait(false);
         await AppendOutboundOrderDeltaAsync(seq, request.ClOrdID, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersReplaced.Add(1, new KeyValuePair<string, object?>("kind", "SimpleReplace"));
         RecordLatency(startTs, OutboundRequestKind.SimpleReplace);
@@ -1045,10 +1088,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         await EvaluateRiskAsync(OutboundRequestKind.Cancel, request, request.SecurityId, clordid, ct).ConfigureAwait(false);
         using var activity = StartOutbound("entrypoint.cancel", OutboundRequestKind.Cancel, request.SecurityId, clordid);
         var startTs = Stopwatch.GetTimestamp();
-        var seq = _session!.NextOutboundSeqNum();
-        var buffer = new byte[OrderCancelRequestData.MESSAGE_SIZE + 256];
-        var len = OrderEntryEncoder.EncodeOrderCancel(buffer, request, _options, seq);
-        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        var seq = await SendOrderEntryFrameAsync(s =>
+        {
+            var buffer = new byte[OrderCancelRequestData.MESSAGE_SIZE + 256];
+            var len = OrderEntryEncoder.EncodeOrderCancel(buffer, request, _options, s);
+            return (buffer, len);
+        }, ct).ConfigureAwait(false);
         await AppendOutboundOrderDeltaAsync(seq, request.ClOrdID, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersCancelled.Add(1);
         RecordLatency(startTs, OutboundRequestKind.Cancel);
@@ -1067,10 +1112,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
             await EvaluateRiskAsync(OutboundRequestKind.MassAction, req, req.SecurityId ?? 0UL, clordid, token).ConfigureAwait(false);
             using var activity = StartOutbound("entrypoint.mass_action", OutboundRequestKind.MassAction, req.SecurityId ?? 0UL, clordid);
             var startTs = Stopwatch.GetTimestamp();
-            var seq = _session!.NextOutboundSeqNum();
-            var buffer = new byte[OrderMassActionRequestData.MESSAGE_SIZE + 32];
-            var len = OrderEntryEncoder.EncodeOrderMassAction(buffer, req, _options, seq);
-            await _session.SendApplicationFrameAsync(buffer, len, token).ConfigureAwait(false);
+            var seq = await SendOrderEntryFrameAsync(s =>
+            {
+                var buffer = new byte[OrderMassActionRequestData.MESSAGE_SIZE + 32];
+                var len = OrderEntryEncoder.EncodeOrderMassAction(buffer, req, _options, s);
+                return (buffer, len);
+            }, token).ConfigureAwait(false);
             await AppendOutboundOrderDeltaAsync(seq, req.ClOrdID, clordid, req.SecurityId ?? 0UL, token).ConfigureAwait(false);
             EntryPointTelemetry.MassActions.Add(1);
             RecordLatency(startTs, OutboundRequestKind.MassAction);
@@ -1094,11 +1141,13 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         await EvaluateRiskAsync(OutboundRequestKind.NewOrder, request, request.SecurityId, clordid, ct).ConfigureAwait(false);
         using var activity = StartOutbound("entrypoint.submit_cross", OutboundRequestKind.NewOrder, request.SecurityId, clordid);
         var startTs = Stopwatch.GetTimestamp();
-        var seq = _session!.NextOutboundSeqNum();
-        var legBytes = (request.Legs?.Count ?? 0) * B3.Entrypoint.Fixp.Sbe.V6.NewOrderCrossData.NoSidesData.MESSAGE_SIZE;
-        var buffer = new byte[B3.Entrypoint.Fixp.Sbe.V6.NewOrderCrossData.MESSAGE_SIZE + legBytes + 256];
-        var len = OrderEntryEncoder.EncodeNewOrderCross(buffer, request, _options, seq);
-        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        var seq = await SendOrderEntryFrameAsync(s =>
+        {
+            var legBytes = (request.Legs?.Count ?? 0) * B3.Entrypoint.Fixp.Sbe.V6.NewOrderCrossData.NoSidesData.MESSAGE_SIZE;
+            var buffer = new byte[B3.Entrypoint.Fixp.Sbe.V6.NewOrderCrossData.MESSAGE_SIZE + legBytes + 256];
+            var len = OrderEntryEncoder.EncodeNewOrderCross(buffer, request, _options, s);
+            return (buffer, len);
+        }, ct).ConfigureAwait(false);
         await AppendOutboundDeltaAsync(seq, clordid, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "NewOrderCross"));
         RecordLatency(startTs, OutboundRequestKind.NewOrder);
@@ -1113,10 +1162,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         await EvaluateRiskAsync(OutboundRequestKind.NewOrder, request, request.SecurityId, request.QuoteReqId, ct).ConfigureAwait(false);
         using var activity = StartOutbound("entrypoint.quote_request", OutboundRequestKind.NewOrder, request.SecurityId, request.QuoteReqId);
         var startTs = Stopwatch.GetTimestamp();
-        var seq = _session!.NextOutboundSeqNum();
-        var buffer = new byte[QuoteRequestData.MESSAGE_SIZE + 32];
-        var len = OrderEntryEncoder.EncodeQuoteRequest(buffer, request, _options, seq);
-        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        var seq = await SendOrderEntryFrameAsync(s =>
+        {
+            var buffer = new byte[QuoteRequestData.MESSAGE_SIZE + 32];
+            var len = OrderEntryEncoder.EncodeQuoteRequest(buffer, request, _options, s);
+            return (buffer, len);
+        }, ct).ConfigureAwait(false);
         await AppendOutboundDeltaAsync(seq, request.QuoteReqId, request.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "QuoteRequest"));
         RecordLatency(startTs, OutboundRequestKind.NewOrder);
@@ -1130,10 +1181,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         await EvaluateRiskAsync(OutboundRequestKind.NewOrder, quote, quote.SecurityId, quote.QuoteId, ct).ConfigureAwait(false);
         using var activity = StartOutbound("entrypoint.quote", OutboundRequestKind.NewOrder, quote.SecurityId, quote.QuoteId);
         var startTs = Stopwatch.GetTimestamp();
-        var seq = _session!.NextOutboundSeqNum();
-        var buffer = new byte[QuoteData.MESSAGE_SIZE + 32];
-        var len = OrderEntryEncoder.EncodeQuote(buffer, quote, _options, seq);
-        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        var seq = await SendOrderEntryFrameAsync(s =>
+        {
+            var buffer = new byte[QuoteData.MESSAGE_SIZE + 32];
+            var len = OrderEntryEncoder.EncodeQuote(buffer, quote, _options, s);
+            return (buffer, len);
+        }, ct).ConfigureAwait(false);
         await AppendOutboundDeltaAsync(seq, quote.QuoteId, quote.SecurityId, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersSubmitted.Add(1, new KeyValuePair<string, object?>("kind", "Quote"));
         RecordLatency(startTs, OutboundRequestKind.NewOrder);
@@ -1147,10 +1200,12 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
         await EvaluateRiskAsync(OutboundRequestKind.Cancel, quoteId, 0UL, quoteId, ct).ConfigureAwait(false);
         using var activity = StartOutbound("entrypoint.quote_cancel", OutboundRequestKind.Cancel, 0UL, quoteId);
         var startTs = Stopwatch.GetTimestamp();
-        var seq = _session!.NextOutboundSeqNum();
-        var buffer = new byte[QuoteCancelData.MESSAGE_SIZE + 32];
-        var len = OrderEntryEncoder.EncodeQuoteCancel(buffer, quoteId, 0UL, _options, seq);
-        await _session.SendApplicationFrameAsync(buffer, len, ct).ConfigureAwait(false);
+        var seq = await SendOrderEntryFrameAsync(s =>
+        {
+            var buffer = new byte[QuoteCancelData.MESSAGE_SIZE + 32];
+            var len = OrderEntryEncoder.EncodeQuoteCancel(buffer, quoteId, 0UL, _options, s);
+            return (buffer, len);
+        }, ct).ConfigureAwait(false);
         await AppendOutboundDeltaAsync(seq, quoteId, 0UL, ct).ConfigureAwait(false);
         EntryPointTelemetry.OrdersCancelled.Add(1, new KeyValuePair<string, object?>("kind", "QuoteCancel"));
         RecordLatency(startTs, OutboundRequestKind.Cancel);
@@ -1680,6 +1735,7 @@ public sealed class EntryPointClient : IEntryPointClient, ISubmitOrder, IReplace
     {
         await StopActiveSessionAsync(CancellationToken.None).ConfigureAwait(false);
         _events.Writer.TryComplete();
+        _sendLock.Dispose();
     }
 
     /// <summary>

--- a/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
+++ b/src/B3.EntryPoint.Client/Fixp/FixpClientSession.cs
@@ -27,6 +27,15 @@ internal sealed class FixpClientSession : IAsyncDisposable
     private readonly EntryPointClientOptions _options;
     private readonly FixpClientStateMachine _machine = new();
 
+    // #211: every outbound frame (Negotiate/Establish/Terminate/Sequence/
+    // RetransmitRequest/application frames) ultimately writes to this single
+    // shared _stream. Stream/SslStream implementations do not support
+    // concurrent WriteAsync calls, so all writers must serialize through this
+    // lock to guarantee both (a) no two callers interleave bytes on the wire,
+    // and (b) frames land on the wire in the same order their callers
+    // acquired the lock.
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
     public FixpClientSession(Stream stream, EntryPointClientOptions options)
     {
         ArgumentNullException.ThrowIfNull(stream);
@@ -414,9 +423,17 @@ internal sealed class FixpClientSession : IAsyncDisposable
             throw new InvalidOperationException($"Cannot send application frame from state {_machine.State}.");
         if (_options.Logger.IsEnabled(LogLevel.Trace) && length >= SofhSize + SbeHeaderSize)
             _options.Logger.OutboundFrame(BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(SofhSize, 2)), length);
-        await _stream.WriteAsync(buffer.AsMemory(0, length), ct).ConfigureAwait(false);
-        if (_options.AutoFlushOutboundFrames)
-            await _stream.FlushAsync(ct).ConfigureAwait(false);
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _stream.WriteAsync(buffer.AsMemory(0, length), ct).ConfigureAwait(false);
+            if (_options.AutoFlushOutboundFrames)
+                await _stream.FlushAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
     }
 
     /// <summary>
@@ -426,7 +443,18 @@ internal sealed class FixpClientSession : IAsyncDisposable
     /// <see cref="EntryPointClientOptions.AutoFlushOutboundFrames"/> is
     /// <see langword="false"/>. Issue #123.
     /// </summary>
-    public Task FlushOutboundAsync(CancellationToken ct) => _stream.FlushAsync(ct);
+    public async Task FlushOutboundAsync(CancellationToken ct)
+    {
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _stream.FlushAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
 
     /// <summary>Returns the next outbound MsgSeqNum and increments the counter.</summary>
     /// <remarks>
@@ -501,8 +529,16 @@ internal sealed class FixpClientSession : IAsyncDisposable
         if (!payload.TryEncode(buffer.AsSpan(SofhSize + SbeHeaderSize), out _))
             throw new InvalidOperationException("Failed to encode Sequence payload.");
 
-        await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
-        await _stream.FlushAsync(ct).ConfigureAwait(false);
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
+            await _stream.FlushAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
     }
 
     /// <summary>Sends a §4.7 RetransmitRequest covering [fromSeqNo, fromSeqNo+count).</summary>
@@ -521,8 +557,16 @@ internal sealed class FixpClientSession : IAsyncDisposable
         };
         if (!payload.TryEncode(buffer.AsSpan(SofhSize + SbeHeaderSize), out _))
             throw new InvalidOperationException("Failed to encode RetransmitRequest payload.");
-        await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
-        await _stream.FlushAsync(ct).ConfigureAwait(false);
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
+            await _stream.FlushAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
     }
 
     /// <summary>Optional hook: invoked by the inbound loop when a peer Sequence frame arrives.</summary>
@@ -590,6 +634,7 @@ internal sealed class FixpClientSession : IAsyncDisposable
             catch { /* best-effort */ }
         }
         await _stream.DisposeAsync().ConfigureAwait(false);
+        _writeLock.Dispose();
     }
 
     // -- Wire encoding -------------------------------------------------------
@@ -623,8 +668,16 @@ internal sealed class FixpClientSession : IAsyncDisposable
             throw new InvalidOperationException("Failed to encode Negotiate payload.");
         }
 
-        await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
-        await _stream.FlushAsync(ct).ConfigureAwait(false);
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
+            await _stream.FlushAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
     }
 
     private async Task SendEstablishAsync(uint nextSeqNo, CancellationToken ct)
@@ -654,8 +707,16 @@ internal sealed class FixpClientSession : IAsyncDisposable
         if (!EstablishData.TryEncode(payload, buffer.AsSpan(SofhSize + SbeHeaderSize), creds, out _))
             throw new InvalidOperationException("Failed to encode Establish payload.");
 
-        await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
-        await _stream.FlushAsync(ct).ConfigureAwait(false);
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
+            await _stream.FlushAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
     }
 
     private async Task SendTerminateAsync(SbeTerminationCode code, CancellationToken ct)
@@ -676,8 +737,16 @@ internal sealed class FixpClientSession : IAsyncDisposable
         if (!payload.TryEncode(buffer.AsSpan(SofhSize + SbeHeaderSize), out _))
             throw new InvalidOperationException("Failed to encode Terminate payload.");
 
-        await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
-        await _stream.FlushAsync(ct).ConfigureAwait(false);
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _stream.WriteAsync(buffer, ct).ConfigureAwait(false);
+            await _stream.FlushAsync(ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
     }
 
     private static ushort ReadTemplateId(byte[] frame)

--- a/tests/B3.EntryPoint.Client.Tests/Fixp/ConcurrentSendOrderingTests.cs
+++ b/tests/B3.EntryPoint.Client.Tests/Fixp/ConcurrentSendOrderingTests.cs
@@ -1,0 +1,159 @@
+using System.Collections.Concurrent;
+using System.Net;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using B3.EntryPoint.Client.Auth;
+using B3.EntryPoint.Client.Fixp;
+using B3.EntryPoint.Client.Models;
+using B3.EntryPoint.Client.TestPeer;
+
+namespace B3.EntryPoint.Client.Tests.Fixp;
+
+/// <summary>
+/// Regression coverage for #211 — concurrent outbound application-frame sends
+/// must not race on the underlying transport <c>Stream</c>.
+/// </summary>
+public class ConcurrentSendOrderingTests
+{
+    /// <summary>
+    /// A <see cref="MemoryStream"/> whose <see cref="WriteAsync(ReadOnlyMemory{byte}, CancellationToken)"/>
+    /// artificially stalls before completing whenever the buffer's first byte
+    /// is <see cref="SlowMarker"/>. This lets a test start a "slow" write
+    /// first and a "fast" write second, and observe whether the underlying
+    /// stream still receives them in call order (correct, serialized) or in
+    /// completion order (buggy, racy) — exactly the class of bug in #211.
+    /// </summary>
+    private sealed class DelayableStream : MemoryStream
+    {
+        public const byte SlowMarker = 0xAA;
+        public TimeSpan Delay = TimeSpan.FromMilliseconds(200);
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (count > 0 && buffer[offset] == SlowMarker)
+                await Task.Delay(Delay, cancellationToken).ConfigureAwait(false);
+            await base.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (buffer.Length > 0 && buffer.Span[0] == SlowMarker)
+                await Task.Delay(Delay, cancellationToken).ConfigureAwait(false);
+            await base.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static EntryPointClientOptions SessionOptions() => new()
+    {
+        Endpoint = new IPEndPoint(IPAddress.Loopback, 1),
+        SessionId = 1,
+        SessionVerId = 1,
+        EnteringFirm = 1,
+        Credentials = Credentials.FromUtf8("k"),
+    };
+
+    /// <summary>
+    /// Without write-side serialization, a "slow" frame started first can
+    /// lose the race to a "fast" frame started second and land on the wire
+    /// out of call order (or interleaved with it). #211's fix wraps every
+    /// <see cref="FixpClientSession"/> outbound write in a lock, so the slow
+    /// frame's bytes must always precede the fast frame's bytes in the
+    /// underlying stream regardless of which write completes first.
+    /// </summary>
+    [Fact]
+    public async Task SendApplicationFrameAsync_SerializesConcurrentWrites_PreservesCallOrder()
+    {
+        var stream = new DelayableStream();
+        var session = new FixpClientSession(stream, SessionOptions());
+        session.ForceEstablishedForTesting();
+
+        var slowFrame = Enumerable.Repeat(DelayableStream.SlowMarker, 32).ToArray();
+        var fastFrame = Enumerable.Repeat((byte)0xBB, 32).ToArray();
+
+        var slowTask = session.SendApplicationFrameAsync(slowFrame, slowFrame.Length, CancellationToken.None);
+        // Give the slow call a head start so it acquires the write lock (and
+        // enters its artificial delay) before the fast call is issued.
+        await Task.Delay(50);
+        var fastTask = session.SendApplicationFrameAsync(fastFrame, fastFrame.Length, CancellationToken.None);
+
+        await Task.WhenAll(slowTask, fastTask);
+
+        var written = stream.ToArray();
+        Assert.Equal(slowFrame.Length + fastFrame.Length, written.Length);
+        Assert.Equal(slowFrame, written[..slowFrame.Length]);
+        Assert.Equal(fastFrame, written[slowFrame.Length..]);
+    }
+
+    private static EntryPointClientOptions ClientOptions(InProcessFixpTestPeer peer) => new()
+    {
+        Endpoint = peer.LocalEndpoint,
+        SessionId = 42u,
+        SessionVerId = 1u,
+        EnteringFirm = 7u,
+        Credentials = Credentials.FromUtf8("test-key"),
+        KeepAliveIntervalMs = 60_000u,
+    };
+
+    /// <summary>
+    /// End-to-end coverage over a real TCP loopback connection (mirroring
+    /// B3TradingPlatform's "Cancel All" panic action): a burst of concurrent
+    /// <see cref="EntryPointClient.CancelAsync"/> calls must land on the wire
+    /// with strictly increasing, gap-free MsgSeqNum and no decode failures.
+    /// </summary>
+    [Fact]
+    public async Task ConcurrentCancelAsync_ArrivesInGapFreeSeqOrder()
+    {
+        await using var peer = new InProcessFixpTestPeer();
+        var received = new ConcurrentQueue<(uint MsgSeqNum, string ClOrdId)>();
+        var decodeFailures = 0;
+
+        peer.MessageReceived += (_, e) =>
+        {
+            if (e.TemplateId != OrderCancelRequestData.MESSAGE_ID)
+                return;
+            if (!OrderCancelRequestData.TryParse(e.Payload.Span, out var reader))
+            {
+                Interlocked.Increment(ref decodeFailures);
+                return;
+            }
+            ref readonly var req = ref reader.Data;
+            received.Enqueue((req.BusinessHeader.MsgSeqNum.Value, req.ClOrdID.Value.ToString()));
+        };
+        peer.Start();
+
+        await using var client = new EntryPointClient(ClientOptions(peer));
+        using var connectCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await client.ConnectAsync(connectCts.Token);
+
+        const int concurrency = 8;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var tasks = new Task[concurrency];
+        for (int i = 0; i < concurrency; i++)
+        {
+            var clOrdId = (1000UL + (ulong)i).ToString();
+            tasks[i] = client.CancelAsync(new CancelOrderRequest
+            {
+                ClOrdID = B3.EntryPoint.Client.Models.ClOrdID.Parse(clOrdId),
+                OrigClOrdID = B3.EntryPoint.Client.Models.ClOrdID.Parse(clOrdId),
+                SecurityId = 1,
+                Side = B3.EntryPoint.Client.Models.Side.Buy,
+            }, cts.Token);
+        }
+        await Task.WhenAll(tasks);
+
+        // Give the peer's inbound loop a moment to drain the last frames.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (received.Count < concurrency && DateTime.UtcNow < deadline)
+            await Task.Delay(25);
+
+        Assert.Equal(0, decodeFailures);
+        Assert.Equal(concurrency, received.Count);
+
+        var seqNums = received.Select(r => r.MsgSeqNum).ToArray();
+        var sorted = seqNums.OrderBy(s => s).ToArray();
+        // Gap-free and unique: every reserved seq number actually reached the
+        // peer exactly once, with no corrupted/duplicated frames.
+        for (int i = 1; i < sorted.Length; i++)
+            Assert.Equal(sorted[i - 1] + 1, sorted[i]);
+    }
+}
+


### PR DESCRIPTION
## Summary
Fixes #211 — concurrent outbound sends could race on the shared `Stream.WriteAsync`, letting frames land on the wire out of `MsgSeqNum` order or interleaved.

## Changes
- `FixpClientSession`: added a `_writeLock` (`SemaphoreSlim(1,1)`) wrapping every raw `_stream.WriteAsync`/`FlushAsync` call site — Negotiate, Establish, Terminate, Sequence, RetransmitRequest, and application frames — so no two callers ever write to the underlying `Stream`/`SslStream` concurrently.
- `EntryPointClient`: added a `_sendLock` spanning the full "reserve seq → encode → write" critical section for every outbound application frame (`SubmitAsync`, `SubmitSimpleAsync`, `ReplaceAsync`, `ReplaceSimpleAsync`, `CancelAsync`, `MassActionAsync`, `SubmitCrossAsync`, `SendQuoteRequestAsync`, `SendQuoteAsync`, `CancelQuoteAsync`), via a new private `SendOrderEntryFrameAsync` helper. This guarantees wire order always matches seq-assignment order, closing the gap between the already-atomic `NextOutboundSeqNum()` reservation and the actual write.
- Both locks are disposed alongside their owning session/client.

## Tests
- `ConcurrentSendOrderingTests.SendApplicationFrameAsync_SerializesConcurrentWrites_PreservesCallOrder` — deterministic test using a `DelayableStream` double that stalls a "slow" frame's write; verified it **fails without the fix** (fast frame wins the race and lands first) and **passes with the fix**.
- `ConcurrentSendOrderingTests.ConcurrentCancelAsync_ArrivesInGapFreeSeqOrder` — end-to-end test firing 8 concurrent `CancelAsync` calls (mirroring the "Cancel All" trigger) over a real TCP loopback `InProcessFixpTestPeer`, asserting gap-free, unique `MsgSeqNum` with zero decode failures.

## Validation
- `dotnet build SbeB3EntryPointClient.slnx -c Release` — 0 warnings/errors
- `dotnet test SbeB3EntryPointClient.slnx --no-build -c Release` — all unit tests pass (213), conformance tests correctly skipped (no peer env vars)
- `dotnet format SbeB3EntryPointClient.slnx --verify-no-changes --no-restore --severity warn` — clean

Closes #211.